### PR TITLE
Update uk_1990.json

### DIFF
--- a/resources/factions/uk_1990.json
+++ b/resources/factions/uk_1990.json
@@ -55,7 +55,7 @@
     "FFG Oliver Hazard Perry",
     "DDG Arleigh Burke IIa",
     "CG Ticonderoga",
-    "LHA-1 Tarawa",
+    "R05 Invincible"
     "CVN-74 John C. Stennis"
   ],
   "missiles": [],

--- a/resources/factions/uk_1990.json
+++ b/resources/factions/uk_1990.json
@@ -55,7 +55,7 @@
     "FFG Oliver Hazard Perry",
     "DDG Arleigh Burke IIa",
     "CG Ticonderoga",
-    "R05 Invincible"
+    "R05 Invincible",
     "CVN-74 John C. Stennis"
   ],
   "missiles": [],


### PR DESCRIPTION
Replaced USS Tarawa with HMS Invincible. 

Successfully tested replacing Tarawa w Invincible as valid control point on Pacific Repartee with four Harriers parked. 