### PR TITLE
GroundForcePainter for applying custom liveries to ground units and ships

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * **[Engine]** Support for DCS v2.8.0.32066.
 * **[Briefing]** Add tanker info to mission briefing
 * **[Campaign]** Add 3 new campaigns by Oscar Juliet from WRL
+* **[Campaign]** Add ability to define livery overrides also for ground/naval units
 * **[Data]** Added data to support C-47 Skytrain.
 * **[Data]** Added data to support KS-19 & SON-9, including support for "AAA Site" layout.
 * **[Mission Generation]** Add option to configure the maximum front-line length in settings

--- a/game/factions/faction.py
+++ b/game/factions/faction.py
@@ -116,6 +116,9 @@ class Faction:
     # List of default livery overrides
     liveries_overrides: Dict[AircraftType, List[str]] = field(default_factory=dict)
 
+    # List of default livery overrides for ground vehicles
+    liveries_overrides_ground_forces: Dict[str, List[str]] = field(default_factory=dict)
+
     #: Set to True if the faction should force the "Unrestricted satnav" option
     #: for the mission. This option enables GPS for capable aircraft regardless
     #: of the time period or operator. For example, the CJTF "countries" don't
@@ -283,6 +286,16 @@ class Faction:
         for name, livery in liveries_overrides.items():
             aircraft = AircraftType.named(name)
             faction.liveries_overrides[aircraft] = [s.lower() for s in livery]
+
+        # Load liveries override for ground forces
+        faction.liveries_overrides_ground_forces = {}
+        liveries_overrides_ground_forces = json.get(
+            "liveries_overrides_ground_forces", {}
+        )
+        for vehicle_type, livery in liveries_overrides_ground_forces.items():
+            faction.liveries_overrides_ground_forces[vehicle_type] = [
+                s.lower() for s in livery
+            ]
 
         faction.unrestricted_satnav = json.get("unrestricted_satnav", False)
 

--- a/game/game.py
+++ b/game/game.py
@@ -215,6 +215,11 @@ class Game:
             return self.blue
         return self.red
 
+    def coalition_for_country(self, country: str) -> Coalition:
+        if country == self.blue.country_name:
+            return self.blue
+        return self.red
+
     def adjust_budget(self, amount: float, player: bool) -> None:
         self.coalition_for(player).adjust_budget(amount)
 

--- a/game/game.py
+++ b/game/game.py
@@ -215,11 +215,6 @@ class Game:
             return self.blue
         return self.red
 
-    def coalition_for_country(self, country: str) -> Coalition:
-        if country == self.blue.country_name:
-            return self.blue
-        return self.red
-
     def adjust_budget(self, amount: float, player: bool) -> None:
         self.coalition_for(player).adjust_budget(amount)
 

--- a/game/missiongenerator/convoygenerator.py
+++ b/game/missiongenerator/convoygenerator.py
@@ -10,6 +10,7 @@ from dcs.unit import Vehicle
 from dcs.unitgroup import VehicleGroup
 
 from game.dcs.groundunittype import GroundUnitType
+from game.missiongenerator.groundforcepainter import GroundForcePainter
 from game.transfers import Convoy
 from game.unitmap import UnitMap
 from game.utils import kph
@@ -72,6 +73,7 @@ class ConvoyGenerator:
         for_player: bool,
     ) -> VehicleGroup:
         country = self.mission.country(self.game.coalition_for(for_player).country_name)
+        faction = self.game.faction_for(for_player)
 
         unit_types = list(units.items())
         main_unit_type, main_unit_count = unit_types[0]
@@ -97,6 +99,7 @@ class ConvoyGenerator:
                 v.position.x = position.x
                 v.position.y = next(y)
                 v.heading = 0
+                GroundForcePainter(faction, v).apply_livery()
                 group.add_unit(v)
 
         return group

--- a/game/missiongenerator/convoygenerator.py
+++ b/game/missiongenerator/convoygenerator.py
@@ -97,6 +97,7 @@ class ConvoyGenerator:
                 v.position.x = position.x
                 v.position.y = next(y)
                 v.heading = 0
+                GroundForcePainter(faction, v).apply_livery()
                 group.add_unit(v)
 
         return group

--- a/game/missiongenerator/groundforcepainter.py
+++ b/game/missiongenerator/groundforcepainter.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+import random
+from typing import Any, Optional
+
+from dcs.unit import Ship
+from dcs.unitgroup import Vehicle
+
+from game.factions.faction import Faction
+
+
+class GroundForcePainter:
+    def __init__(self, faction: Faction, vehicle: Vehicle) -> None:
+        self.faction = faction
+        self.vehicle = vehicle
+
+    def livery_from_faction(self) -> Optional[str]:
+        faction = self.faction
+        try:
+            if (
+                choices := faction.liveries_overrides_ground_forces.get(
+                    self.vehicle.type
+                )
+            ) is not None:
+                return random.choice(choices)
+        except AttributeError:
+            logging.warning(
+                f"Faction {self.faction.name} is missing livery for ground unit {self.vehicle.type}"
+            )
+            return None
+        logging.warning(
+            f"Faction {self.faction.name} is missing livery for ground unit {self.vehicle.type}"
+        )
+        return None
+
+    def determine_livery(self) -> Optional[str]:
+        if (livery := self.livery_from_faction()) is not None:
+            return livery
+        return None
+
+    def apply_livery(self) -> None:
+        livery = self.determine_livery()
+        if livery is None:
+            return
+        self.vehicle.livery_id = livery
+
+
+class NavalForcePainter:
+    def __init__(self, faction: Faction, vessel: Ship) -> None:
+        self.faction = faction
+        self.vessel = vessel
+
+    def livery_from_faction(self) -> Optional[str]:
+        faction = self.faction
+        try:
+            if (
+                choices := faction.liveries_overrides_ground_forces.get(
+                    self.vessel.type
+                )
+            ) is not None:
+                return random.choice(choices)
+        except AttributeError:
+            logging.warning(
+                f"Faction {self.faction.name} is missing livery for naval unit {self.vessel.type}"
+            )
+            return None
+        logging.warning(
+            f"Faction {self.faction.name} is missing livery for naval unit {self.vessel.type}"
+        )
+        return None
+
+    def determine_livery(self) -> Optional[str]:
+        if (livery := self.livery_from_faction()) is not None:
+            return livery
+        return None
+
+    def apply_livery(self) -> None:
+        livery = self.determine_livery()
+        if livery is None:
+            return
+        self.vessel.livery_id = livery

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -40,6 +40,10 @@ from dcs.unitgroup import MovingGroup, ShipGroup, StaticGroup, VehicleGroup
 from dcs.unittype import ShipType, VehicleType
 from dcs.vehicles import vehicle_map
 
+from game.missiongenerator.groundforcepainter import (
+    NavalForcePainter,
+    GroundForcePainter,
+)
 from game.missiongenerator.missiondata import CarrierInfo, MissionData
 from game.radio.radios import RadioFrequency, RadioRegistry
 from game.radio.tacan import TacanBand, TacanChannel, TacanRegistry, TacanUsage
@@ -122,6 +126,7 @@ class GroundObjectGenerator:
         vehicle_group: Optional[VehicleGroup] = None
         for unit in units:
             assert issubclass(unit.type, VehicleType)
+            faction = self.game.coalition_for_country(self.country.name).faction
             if vehicle_group is None:
                 vehicle_group = self.m.vehicle_group(
                     self.country,
@@ -134,11 +139,13 @@ class GroundObjectGenerator:
                 self.enable_eplrs(vehicle_group, unit.type)
                 vehicle_group.units[0].name = unit.unit_name
                 self.set_alarm_state(vehicle_group)
+                GroundForcePainter(faction, vehicle_group.units[0]).apply_livery()
             else:
                 vehicle_unit = self.m.vehicle(unit.unit_name, unit.type)
                 vehicle_unit.player_can_drive = True
                 vehicle_unit.position = unit.position
                 vehicle_unit.heading = unit.position.heading.degrees
+                GroundForcePainter(faction, vehicle_unit).apply_livery()
                 vehicle_group.add_unit(vehicle_unit)
             self._register_theater_unit(unit, vehicle_group.units[-1])
         if vehicle_group is None:
@@ -154,6 +161,7 @@ class GroundObjectGenerator:
         ship_group: Optional[ShipGroup] = None
         for unit in units:
             assert issubclass(unit.type, ShipType)
+            faction = self.game.coalition_for_country(self.country.name).faction
             if ship_group is None:
                 ship_group = self.m.ship_group(
                     self.country,
@@ -166,12 +174,14 @@ class GroundObjectGenerator:
                     ship_group.set_frequency(frequency.hertz)
                 ship_group.units[0].name = unit.unit_name
                 self.set_alarm_state(ship_group)
+                NavalForcePainter(faction, ship_group.units[0]).apply_livery()
             else:
                 ship_unit = self.m.ship(unit.unit_name, unit.type)
                 if frequency:
                     ship_unit.set_frequency(frequency.hertz)
                 ship_unit.position = unit.position
                 ship_unit.heading = unit.position.heading.degrees
+                NavalForcePainter(faction, ship_unit).apply_livery()
                 ship_group.add_unit(ship_unit)
             self._register_theater_unit(unit, ship_group.units[-1])
         if ship_group is None:

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -126,7 +126,7 @@ class GroundObjectGenerator:
         vehicle_group: Optional[VehicleGroup] = None
         for unit in units:
             assert issubclass(unit.type, VehicleType)
-            faction = self.game.coalition_for_country(self.country.name).faction
+            faction = unit.ground_object.control_point.coalition.faction
             if vehicle_group is None:
                 vehicle_group = self.m.vehicle_group(
                     self.country,
@@ -161,7 +161,7 @@ class GroundObjectGenerator:
         ship_group: Optional[ShipGroup] = None
         for unit in units:
             assert issubclass(unit.type, ShipType)
-            faction = self.game.coalition_for_country(self.country.name).faction
+            faction = unit.ground_object.control_point.coalition.faction
             if ship_group is None:
                 ship_group = self.m.ship_group(
                     self.country,


### PR DESCRIPTION
Implemented GroundForcePainter for applying custom liveries to ground units. The liveries can be applied to front line objects (including infantry), convoys, naval units and TGOs.

Livery overrides are defined in the faction file like this:
```
  "liveries_overrides_ground_forces": {
    "Soldier M249": [
      "summer",
      "DPM",
      "US-1",
      "US-2",
      "GOE III SPN m4"
    ],
    "Soldier M4": [
      "summer",
      "DPM",
      "US-1",
      "US-2",
      "GOE III SPN m4"
    ],
    "Soldier M4 GRG": [
      "BDU",
      "US Forest-1",
      "US Forest-2",
      "US Forest-3",
      "US Forest-4"
    ]
  }
```

Note: the DCS id of the unit should be used, instead of the unit name defined in the unit yaml.