### PR TITLE
F-100 Super Sabre mod version 2.7.18.30765 patch 20.10.22 support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,7 @@ BAI/ANTISHIP/DEAD/STRIKE/BARCAP/CAS/OCA/AIR-ASSAULT (main) missions
 * **[Modding]** Support for Su-30 mod version 2.01B
 * **[Modding]** Support for A-6A Intruder version 2.7.5.01
 * **[Modding]** Support for F-4B Phantom II mod version v2.7.10.02, patch 2022.10.02
-* **[Modding]** Support for F-100 Super Sabre mod versions v2.7.18.01 & 2.7.18.30765 and patches 30.09.22 & 09.10.22
+* **[Modding]** Support for F-100 Super Sabre mod versions v2.7.18.01 & 2.7.18.30765 and patch 20.10.22
 * **[Modding]** Support for F-105 mod version 2.7.12.23x
 * **[Modding]** Support IDF Mod Project F-16I Sufa & F-16D v2.2 mod
 * **[Modding]** Support for F-84G mod version 2.5.7.01

--- a/game/ato/ai_flight_planner_db.py
+++ b/game/ato/ai_flight_planner_db.py
@@ -366,13 +366,14 @@ SEAD_ESCORT_CAPABLE = [
     Su_30SM,
     MiG_27K,
     Tornado_GR4,
+    VSN_F105G,
+    VSN_F100,
 ]
 
 
 SEAD_CAPABLE = SEAD_ESCORT_CAPABLE + [
     F_14B,
     F_14A_135_GR,
-    VSN_F105G,
 ]
 
 # Aircraft used for DEAD tasks. Must be capable of the CAS DCS task.

--- a/pydcs_extensions/f100/f100.py
+++ b/pydcs_extensions/f100/f100.py
@@ -297,6 +297,10 @@ class VSN_F100(PlaneType):
             7,
             Weapons.LAU_7_with_AIM_9P_Sidewinder_IR_AAM,
         )
+        LAU_118a_with_AGM_45B_Shrike_ARM__Imp_ = (
+            7,
+            Weapons.LAU_118a_with_AGM_45B_Shrike_ARM__Imp_,
+        )
         Fuel_tank_500_Liter = (7, WeaponsF100.Fuel_tank_500_Liter)
 
     # ERRR <CLEAN>

--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -713,7 +713,7 @@ class GeneratorOptions(QtWidgets.QWizardPage):
             ("F-16I Sufa & F-16D (v2.2 by IDF Mods Project)", f_16_idf),
             ("F-22A Raptor", f22_raptor),
             ("F-84G Thunderjet (v2.5.7.01)", f84g_thunderjet),
-            ("F-100 Super Sabre (v2.7.18.30765 patch 09.10.22)", f100_supersabre),
+            ("F-100 Super Sabre (v2.7.18.30765 patch 20.10.22)", f100_supersabre),
             ("F-104 Starfighter (v2.7.11.222.01)", f104_starfighter),
             ("F-105 Thunderchief (v2.7.12.23x)", f105_thunderchief),
             ("Frenchpack", frenchpack),

--- a/resources/customized_payloads/VSN_F100.lua
+++ b/resources/customized_payloads/VSN_F100.lua
@@ -166,6 +166,72 @@ local unitPayloads = {
 				[1] = 19,
 			},
 		},
+        [6] = {
+			["displayName"] = "SEAD",
+			["name"] = "SEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{3E6B632D-65EB-44D2-9501-1C2D04515405}",
+					["num"] = 7,
+				},
+				[2] = {
+					["CLSID"] = "{VSN_F1001000_ptb}",
+					["num"] = 8,
+				},
+				[3] = {
+					["CLSID"] = "{GAR-8}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{VSN_F1001000_ptb}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{GAR-8}",
+					["num"] = 9,
+				},
+				[6] = {
+					["CLSID"] = "{3E6B632D-65EB-44D2-9501-1C2D04515405}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 19,
+			},
+		},
+        [7] = {
+			["displayName"] = "Retribution SEAD Escort",
+			["name"] = "Retribution SEAD Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{3E6B632D-65EB-44D2-9501-1C2D04515405}",
+					["num"] = 7,
+				},
+				[2] = {
+					["CLSID"] = "{VSN_F1001000_ptb}",
+					["num"] = 8,
+				},
+				[3] = {
+					["CLSID"] = "{BRU33_2*LAU61}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{VSN_F1001000_ptb}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{BRU33_2*LAU61}",
+					["num"] = 9,
+				},
+				[6] = {
+					["CLSID"] = "{3E6B632D-65EB-44D2-9501-1C2D04515405}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 19,
+			},
+		},
 	},
 	["tasks"] = {
 	},


### PR DESCRIPTION
Updated the F-100 Super Sabre mod support to version 2.7.18.30765 patch 20.10.22. This patch allows the carry of two AGM-45 Shrike ARMs, so added loadouts for SEAD & SEAD Escort and enabled those mission types for the aircraft.