### PR TITLE
F-104C is now correctly removed from the faction when the mod is not enabled

### DIFF
--- a/game/factions/faction.py
+++ b/game/factions/faction.py
@@ -356,6 +356,7 @@ class Faction:
         if not mod_settings.f100_supersabre:
             self.remove_aircraft("VSN_F100")
         if not mod_settings.f104_starfighter:
+            self.remove_aircraft("VSN_F104C")
             self.remove_aircraft("VSN_F104G")
             self.remove_aircraft("VSN_F104S")
             self.remove_aircraft("VSN_F104S_AG")


### PR DESCRIPTION
F-104C is now correctly removed from the faction when the mod is not enabled.