### PR TITLE
Add option to only generate night missions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 * **[Mission Generation]** Use Escort & SEAD tasks for Escort & SEAD Escort flights
 * **[Mission Generation]** Variable flight-size (2/3/4-ship) for 
 BAI/ANTISHIP/DEAD/STRIKE/BARCAP/CAS/OCA/AIR-ASSAULT (main) missions
+* **[Mission Generation]** Add option to only generate night missions
 * **[Modding]** Support for F-15D 'Baz' mod version 1.0
 * **[Modding]** Support for Su-30 mod version 2.01B
 * **[Modding]** Support for A-6A Intruder version 2.7.5.01

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -14,6 +14,7 @@ from .minutesoption import minutes_option
 from .optiondescription import OptionDescription, SETTING_DESCRIPTION_KEY
 from .skilloption import skill_option
 from ..ato.starttype import StartType
+from ..weather import NightMissions
 
 
 @unique
@@ -105,17 +106,16 @@ class Settings:
         section=MISSION_DIFFICULTY_SECTION,
         default=True,
     )
-    night_disabled: bool = boolean_option(
-        "No night missions",
+    night_day_missions: NightMissions = choices_option(
+        "Night/day mission options",
         page=DIFFICULTY_PAGE,
-        section=MISSION_DIFFICULTY_SECTION,
-        default=False,
-    )
-    night_missions_only: bool = boolean_option(
-        "Only night missions",
-        page=DIFFICULTY_PAGE,
-        section=MISSION_DIFFICULTY_SECTION,
-        default=False,
+        section=MISSION_RESTRICTIONS_SECTION,
+        choices={
+            "Generate night and day missions": NightMissions.DayAndNight,
+            "Only generate day missions": NightMissions.OnlyDay,
+            "Only generate night missions": NightMissions.OnlyNight,
+        },
+        default=NightMissions.DayAndNight,
     )
     # Mission Restrictions
     labels: str = choices_option(

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -111,6 +111,12 @@ class Settings:
         section=MISSION_DIFFICULTY_SECTION,
         default=False,
     )
+    night_missions_only: bool = boolean_option(
+        "Only night missions",
+        page=DIFFICULTY_PAGE,
+        section=MISSION_DIFFICULTY_SECTION,
+        default=False,
+    )
     # Mission Restrictions
     labels: str = choices_option(
         "In game labels",

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -109,7 +109,7 @@ class Settings:
     night_day_missions: NightMissions = choices_option(
         "Night/day mission options",
         page=DIFFICULTY_PAGE,
-        section=MISSION_RESTRICTIONS_SECTION,
+        section=MISSION_DIFFICULTY_SECTION,
         choices={
             "Generate night and day missions": NightMissions.DayAndNight,
             "Only generate day missions": NightMissions.OnlyDay,

--- a/game/weather.py
+++ b/game/weather.py
@@ -19,6 +19,12 @@ if TYPE_CHECKING:
     from game.theater.seasonalconditions import SeasonalConditions
 
 
+class NightMissions(Enum):
+    DayAndNight = "nightmissions_nightandday"
+    OnlyDay = "nightmissions_onlyday"
+    OnlyNight = "nightmissions_onlynight"
+
+
 class TimeOfDay(Enum):
     Dawn = "dawn"
     Day = "day"
@@ -303,8 +309,7 @@ class Conditions:
             theater,
             day,
             time_of_day,
-            settings.night_disabled,
-            settings.night_missions_only,
+            settings.night_day_missions,
         )
         return cls(
             time_of_day=time_of_day,
@@ -318,10 +323,9 @@ class Conditions:
         theater: ConflictTheater,
         day: datetime.date,
         time_of_day: TimeOfDay,
-        night_disabled: bool,
-        night_missions_only: bool,
+        night_day_missions: NightMissions,
     ) -> datetime.datetime:
-        if night_disabled:
+        if night_day_missions == NightMissions.OnlyDay:
             logging.info("Skip Night mission due to user settings")
             time_range = {
                 TimeOfDay.Dawn: (8, 9),
@@ -329,7 +333,7 @@ class Conditions:
                 TimeOfDay.Dusk: (12, 14),
                 TimeOfDay.Night: (14, 17),
             }[time_of_day]
-        elif night_missions_only:
+        elif night_day_missions == NightMissions.OnlyNight:
             logging.info("Skip Day mission due to user settings")
             time_range = {
                 TimeOfDay.Dawn: (0, 3),

--- a/game/weather.py
+++ b/game/weather.py
@@ -300,7 +300,11 @@ class Conditions:
         settings: Settings,
     ) -> Conditions:
         _start_time = cls.generate_start_time(
-            theater, day, time_of_day, settings.night_disabled
+            theater,
+            day,
+            time_of_day,
+            settings.night_disabled,
+            settings.night_missions_only,
         )
         return cls(
             time_of_day=time_of_day,
@@ -315,6 +319,7 @@ class Conditions:
         day: datetime.date,
         time_of_day: TimeOfDay,
         night_disabled: bool,
+        night_missions_only: bool,
     ) -> datetime.datetime:
         if night_disabled:
             logging.info("Skip Night mission due to user settings")
@@ -323,6 +328,14 @@ class Conditions:
                 TimeOfDay.Day: (10, 12),
                 TimeOfDay.Dusk: (12, 14),
                 TimeOfDay.Night: (14, 17),
+            }[time_of_day]
+        elif night_missions_only:
+            logging.info("Skip Day mission due to user settings")
+            time_range = {
+                TimeOfDay.Dawn: (0, 3),
+                TimeOfDay.Day: (3, 6),
+                TimeOfDay.Dusk: (21, 22),
+                TimeOfDay.Night: (22, 23),
             }[time_of_day]
         else:
             time_range = theater.daytime_map[time_of_day.value]


### PR DESCRIPTION
Restores the option of only generating night missions, originally introduced in Liberation 5.1.0.