### PR TITLE
Desired tanker on-station time will now only apply to TheaterRefuelingFlightPlan

### DIFF
--- a/game/ato/flightplans/flightplanbuildertypes.py
+++ b/game/ato/flightplans/flightplanbuildertypes.py
@@ -26,12 +26,13 @@ from .theaterrefueling import TheaterRefuelingFlightPlan
 
 if TYPE_CHECKING:
     from game.ato import Flight
-    from game.theater import FrontLine
 
 
 class FlightPlanBuilderTypes:
     @staticmethod
     def for_flight(flight: Flight) -> Type[IBuilder[Any, Any]]:
+        from game.theater import FrontLine
+
         if flight.flight_type is FlightType.REFUELING:
             if flight.package.target.is_friendly(flight.squadron.player) or isinstance(
                 flight.package.target, FrontLine

--- a/game/ato/flightplans/packagerefueling.py
+++ b/game/ato/flightplans/packagerefueling.py
@@ -23,17 +23,9 @@ class PackageRefuelingFlightPlan(RefuelingFlightPlan):
     def patrol_duration(self) -> timedelta:
         # TODO: Only consider aircraft that can refuel with this tanker type.
         refuel_time_minutes = 5
-        min_patrol_duration = refuel_time_minutes
-
         for self.flight in self.package.flights:
             flight_size = self.flight.roster.max_size
             refuel_time_minutes = refuel_time_minutes + 4 * flight_size + 1
-            min_patrol_duration = (
-                self.flight.coalition.game.settings.desired_tanker_on_station_time.seconds
-                // 60
-            )
-        if refuel_time_minutes < min_patrol_duration:
-            refuel_time_minutes = min_patrol_duration
 
         return timedelta(minutes=refuel_time_minutes)
 

--- a/game/ato/flightplans/theaterrefueling.py
+++ b/game/ato/flightplans/theaterrefueling.py
@@ -17,7 +17,7 @@ class TheaterRefuelingFlightPlan(RefuelingFlightPlan):
 
     @property
     def patrol_duration(self) -> timedelta:
-        return timedelta(hours=1)
+        return self.flight.coalition.game.settings.desired_tanker_on_station_time
 
 
 class Builder(IBuilder[TheaterRefuelingFlightPlan, PatrollingLayout]):


### PR DESCRIPTION
Restored the default patrol duration handling in PackageRefuelingFlightPlan. Desired tanker on-station time will now only apply to TheaterRefuelingFlightPlan.
Also fixed a FrontLine import bug in flightplanbuilder.py