### PR TITLE
Improved the F-16I Sufa & F-16D mod v3.2 loadouts

### DIFF
--- a/resources/customized_payloads/F-16D_50.lua
+++ b/resources/customized_payloads/F-16D_50.lua
@@ -2,6 +2,62 @@ local unitPayloads = {
 	["name"] = "F-16D_50",
 	["payloads"] = {
 		[1] = {
+			["name"] = "Retribution OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[2] = {
 			["name"] = "Retribution SEAD",
 			["pylons"] = {
 				[1] = {
@@ -17,7 +73,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
 					["num"] = 4,
 				},
 				[5] = {
@@ -25,7 +81,7 @@ local unitPayloads = {
 					["num"] = 5,
 				},
 				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
 					["num"] = 6,
 				},
 				[7] = {
@@ -48,12 +104,20 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[12] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+				[13] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
 			},
 			["tasks"] = {
 				[1] = 29,
 			},
 		},
-		[2] = {
+		[3] = {
 			["name"] = "Retribution Ferry",
 			["pylons"] = {
 				[1] = {
@@ -73,11 +137,11 @@ local unitPayloads = {
 					["num"] = 2,
 				},
 				[5] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
 					["num"] = 4,
 				},
 				[7] = {
@@ -88,11 +152,245 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[9] = {
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 3,
+				},
+				[11] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
 			},
 			["tasks"] = {
 			},
 		},
-		[3] = {
+		[4] = {
+			["name"] = "Retribution Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{GBU-31V3B}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{GBU-31V3B}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+			},
+			["tasks"] = {
+				[1] = 33,
+			},
+		},
+		[5] = {
+			["name"] = "ANTISHIP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[3] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 7,
+				},
+				[4] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[7] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[11] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+				[12] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[6] = {
+			["name"] = "Retribution SEAD Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "LAU_88_AGM_65H_2_R",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
+				[13] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+			},
+			["tasks"] = {
+				[1] = 29,
+			},
+		},
+		[7] = {
+			["name"] = "CAP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[8] = {
 			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
@@ -147,110 +445,7 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
-		[4] = {
-			["name"] = "Retribution Strike",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 33,
-			},
-		},
-		[5] = {
-			["name"] = "CAP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[6] = {
+		[9] = {
 			["displayName"] = "Retribution DEAD",
 			["name"] = "Retribution DEAD",
 			["pylons"] = {
@@ -309,165 +504,6 @@ local unitPayloads = {
 			},
 			["tasks"] = {
 				[1] = 31,
-			},
-		},
-		[7] = {
-			["name"] = "Retribution OCA/Runway",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 11,
-			},
-		},
-		[8] = {
-			["name"] = "ANTISHIP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[3] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 7,
-				},
-				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
-					["num"] = 6,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[7] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
-					["num"] = 4,
-				},
-				[8] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[10] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[11] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
-				},
-				[12] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[9] = {
-			["name"] = "Retribution SEAD Escort",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_L",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_R",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 29,
 			},
 		},
 	},

--- a/resources/customized_payloads/F-16D_50_NS.lua
+++ b/resources/customized_payloads/F-16D_50_NS.lua
@@ -2,6 +2,58 @@ local unitPayloads = {
 	["name"] = "F-16D_50_NS",
 	["payloads"] = {
 		[1] = {
+			["name"] = "Retribution OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[2] = {
 			["name"] = "Retribution SEAD",
 			["pylons"] = {
 				[1] = {
@@ -17,7 +69,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[5] = {
@@ -25,7 +77,7 @@ local unitPayloads = {
 					["num"] = 5,
 				},
 				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[7] = {
@@ -48,12 +100,16 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[12] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
 			},
 			["tasks"] = {
 				[1] = 29,
 			},
 		},
-		[2] = {
+		[3] = {
 			["name"] = "Retribution Ferry",
 			["pylons"] = {
 				[1] = {
@@ -73,11 +129,11 @@ local unitPayloads = {
 					["num"] = 2,
 				},
 				[5] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[7] = {
@@ -87,61 +143,14 @@ local unitPayloads = {
 				[8] = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[3] = {
-			["name"] = "CAS",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{DAC53A2F-79CA-42FF-A77A-F5649B601308}",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "{DAC53A2F-79CA-42FF-A77A-F5649B601308}",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
 				},
 				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 7,
 				},
 				[10] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[11] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
-				},
-				[12] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 3,
 				},
 			},
 			["tasks"] = {
@@ -171,19 +180,19 @@ local unitPayloads = {
 					["num"] = 11,
 				},
 				[6] = {
-					["CLSID"] = "{GBU-24}",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[7] = {
-					["CLSID"] = "{GBU-24}",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[8] = {
-					["CLSID"] = "{GBU-24}",
+					["CLSID"] = "{GBU-31V3B}",
 					["num"] = 3,
 				},
 				[9] = {
-					["CLSID"] = "{GBU-24}",
+					["CLSID"] = "{GBU-31V3B}",
 					["num"] = 7,
 				},
 				[10] = {
@@ -200,6 +209,113 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
+			["name"] = "ANTISHIP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[3] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 7,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[7] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[6] = {
+			["name"] = "Retribution SEAD Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "LAU_88_AGM_65H_2_R",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
+			},
+			["tasks"] = {
+				[1] = 29,
+			},
+		},
+		[7] = {
 			["name"] = "CAP",
 			["pylons"] = {
 				[1] = {
@@ -215,7 +331,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[5] = {
@@ -223,7 +339,7 @@ local unitPayloads = {
 					["num"] = 5,
 				},
 				[6] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[7] = {
@@ -239,8 +355,55 @@ local unitPayloads = {
 					["num"] = 9,
 				},
 				[10] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[8] = {
+			["name"] = "CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{DAC53A2F-79CA-42FF-A77A-F5649B601308}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{DAC53A2F-79CA-42FF-A77A-F5649B601308}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
 				},
 				[11] = {
 					["CLSID"] = "ALQ_184_Long",
@@ -250,7 +413,7 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
-		[6] = {
+		[9] = {
 			["displayName"] = "Retribution DEAD",
 			["name"] = "Retribution DEAD",
 			["pylons"] = {
@@ -275,7 +438,7 @@ local unitPayloads = {
 					["num"] = 7,
 				},
 				[6] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[7] = {
@@ -283,7 +446,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[8] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[9] = {
@@ -299,175 +462,12 @@ local unitPayloads = {
 					["num"] = 10,
 				},
 				[12] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
-				},
-				[13] = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
 			},
 			["tasks"] = {
 				[1] = 31,
-			},
-		},
-		[7] = {
-			["name"] = "Retribution OCA/Runway",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 11,
-			},
-		},
-		[8] = {
-			["name"] = "ANTISHIP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[3] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 7,
-				},
-				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
-					["num"] = 6,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[7] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
-					["num"] = 4,
-				},
-				[8] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[10] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[11] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
-				},
-				[12] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[9] = {
-			["name"] = "Retribution SEAD Escort",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_L",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_R",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 29,
 			},
 		},
 	},

--- a/resources/customized_payloads/F-16D_52.lua
+++ b/resources/customized_payloads/F-16D_52.lua
@@ -2,6 +2,62 @@ local unitPayloads = {
 	["name"] = "F-16D_52",
 	["payloads"] = {
 		[1] = {
+			["name"] = "Retribution OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[2] = {
 			["name"] = "Retribution SEAD",
 			["pylons"] = {
 				[1] = {
@@ -17,7 +73,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
 					["num"] = 4,
 				},
 				[5] = {
@@ -25,7 +81,7 @@ local unitPayloads = {
 					["num"] = 5,
 				},
 				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
 					["num"] = 6,
 				},
 				[7] = {
@@ -48,12 +104,20 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[12] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+				[13] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
 			},
 			["tasks"] = {
 				[1] = 29,
 			},
 		},
-		[2] = {
+		[3] = {
 			["name"] = "Retribution Ferry",
 			["pylons"] = {
 				[1] = {
@@ -73,11 +137,11 @@ local unitPayloads = {
 					["num"] = 2,
 				},
 				[5] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
 					["num"] = 4,
 				},
 				[7] = {
@@ -88,11 +152,245 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[9] = {
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 3,
+				},
+				[11] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
 			},
 			["tasks"] = {
 			},
 		},
-		[3] = {
+		[4] = {
+			["name"] = "Retribution Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{GBU-31V3B}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{GBU-31V3B}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+			},
+			["tasks"] = {
+				[1] = 33,
+			},
+		},
+		[5] = {
+			["name"] = "ANTISHIP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[3] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 7,
+				},
+				[4] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[7] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[11] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+				[12] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[6] = {
+			["name"] = "Retribution SEAD Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "LAU_88_AGM_65H_2_R",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
+				[13] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+			},
+			["tasks"] = {
+				[1] = 29,
+			},
+		},
+		[7] = {
+			["name"] = "CAP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project F-16C CFT}",
+					["num"] = 16,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[8] = {
 			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
@@ -147,110 +445,7 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
-		[4] = {
-			["name"] = "Retribution Strike",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 33,
-			},
-		},
-		[5] = {
-			["name"] = "CAP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[6] = {
+		[9] = {
 			["displayName"] = "Retribution DEAD",
 			["name"] = "Retribution DEAD",
 			["pylons"] = {
@@ -311,166 +506,6 @@ local unitPayloads = {
 				[1] = 31,
 			},
 		},
-		[7] = {
-			["name"] = "Retribution OCA/Runway",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 11,
-			},
-		},
-		[8] = {
-			["name"] = "ANTISHIP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[3] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 7,
-				},
-				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
-					["num"] = 6,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[7] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
-					["num"] = 4,
-				},
-				[8] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[10] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[11] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
-				},
-				[12] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[9] = {
-			["name"] = "Retribution SEAD Escort",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_L",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_R",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 29,
-			},
-		},
-
 	},
 	["tasks"] = {
 	},

--- a/resources/customized_payloads/F-16D_52_NS.lua
+++ b/resources/customized_payloads/F-16D_52_NS.lua
@@ -2,6 +2,58 @@ local unitPayloads = {
 	["name"] = "F-16D_52_NS",
 	["payloads"] = {
 		[1] = {
+			["name"] = "Retribution OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[2] = {
 			["name"] = "Retribution SEAD",
 			["pylons"] = {
 				[1] = {
@@ -17,7 +69,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[5] = {
@@ -25,7 +77,7 @@ local unitPayloads = {
 					["num"] = 5,
 				},
 				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[7] = {
@@ -48,12 +100,16 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[12] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
 			},
 			["tasks"] = {
 				[1] = 29,
 			},
 		},
-		[2] = {
+		[3] = {
 			["name"] = "Retribution Ferry",
 			["pylons"] = {
 				[1] = {
@@ -73,11 +129,11 @@ local unitPayloads = {
 					["num"] = 2,
 				},
 				[5] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[7] = {
@@ -87,61 +143,14 @@ local unitPayloads = {
 				[8] = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[3] = {
-			["name"] = "CAS",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{DAC53A2F-79CA-42FF-A77A-F5649B601308}",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "{DAC53A2F-79CA-42FF-A77A-F5649B601308}",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
 				},
 				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 7,
 				},
 				[10] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[11] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
-				},
-				[12] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 3,
 				},
 			},
 			["tasks"] = {
@@ -171,19 +180,19 @@ local unitPayloads = {
 					["num"] = 11,
 				},
 				[6] = {
-					["CLSID"] = "{GBU-24}",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[7] = {
-					["CLSID"] = "{GBU-24}",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[8] = {
-					["CLSID"] = "{GBU-24}",
+					["CLSID"] = "{GBU-31V3B}",
 					["num"] = 3,
 				},
 				[9] = {
-					["CLSID"] = "{GBU-24}",
+					["CLSID"] = "{GBU-31V3B}",
 					["num"] = 7,
 				},
 				[10] = {
@@ -200,6 +209,113 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
+			["name"] = "ANTISHIP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[3] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 7,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[7] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[6] = {
+			["name"] = "Retribution SEAD Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "LAU_88_AGM_65H_2_R",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
+			},
+			["tasks"] = {
+				[1] = 29,
+			},
+		},
+		[7] = {
 			["name"] = "CAP",
 			["pylons"] = {
 				[1] = {
@@ -215,7 +331,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[5] = {
@@ -223,7 +339,7 @@ local unitPayloads = {
 					["num"] = 5,
 				},
 				[6] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[7] = {
@@ -239,8 +355,55 @@ local unitPayloads = {
 					["num"] = 9,
 				},
 				[10] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[8] = {
+			["name"] = "CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{DAC53A2F-79CA-42FF-A77A-F5649B601308}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{DAC53A2F-79CA-42FF-A77A-F5649B601308}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
 				},
 				[11] = {
 					["CLSID"] = "ALQ_184_Long",
@@ -250,7 +413,7 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
-		[6] = {
+		[9] = {
 			["displayName"] = "Retribution DEAD",
 			["name"] = "Retribution DEAD",
 			["pylons"] = {
@@ -275,7 +438,7 @@ local unitPayloads = {
 					["num"] = 7,
 				},
 				[6] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[7] = {
@@ -283,7 +446,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[8] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[9] = {
@@ -299,175 +462,12 @@ local unitPayloads = {
 					["num"] = 10,
 				},
 				[12] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
-				},
-				[13] = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
 			},
 			["tasks"] = {
 				[1] = 31,
-			},
-		},
-		[7] = {
-			["name"] = "Retribution OCA/Runway",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 11,
-			},
-		},
-		[8] = {
-			["name"] = "ANTISHIP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[3] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 7,
-				},
-				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
-					["num"] = 6,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[7] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
-					["num"] = 4,
-				},
-				[8] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[10] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[11] = {
-					["CLSID"] = "{IDF Mods Project F-16C CFT}",
-					["num"] = 16,
-				},
-				[12] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[9] = {
-			["name"] = "Retribution SEAD Escort",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_L",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_R",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 29,
 			},
 		},
 	},

--- a/resources/customized_payloads/F-16D_Barak_30.lua
+++ b/resources/customized_payloads/F-16D_Barak_30.lua
@@ -2,6 +2,58 @@ local unitPayloads = {
 	["name"] = "F-16D_Barak_30",
 	["payloads"] = {
 		[1] = {
+			["name"] = "Retribution OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[2] = {
 			["name"] = "Retribution SEAD",
 			["pylons"] = {
 				[1] = {
@@ -17,7 +69,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[5] = {
@@ -25,7 +77,7 @@ local unitPayloads = {
 					["num"] = 5,
 				},
 				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[7] = {
@@ -48,12 +100,16 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[12] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
 			},
 			["tasks"] = {
 				[1] = 29,
 			},
 		},
-		[2] = {
+		[3] = {
 			["name"] = "Retribution Ferry",
 			["pylons"] = {
 				[1] = {
@@ -73,11 +129,11 @@ local unitPayloads = {
 					["num"] = 2,
 				},
 				[5] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[7] = {
@@ -88,11 +144,225 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[9] = {
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 3,
+				},
 			},
 			["tasks"] = {
 			},
 		},
-		[3] = {
+		[4] = {
+			["name"] = "Retribution Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{GBU-31V3B}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{GBU-31V3B}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+				[1] = 33,
+			},
+		},
+		[5] = {
+			["name"] = "ANTISHIP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[3] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 7,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[7] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[6] = {
+			["name"] = "Retribution SEAD Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "LAU_88_AGM_65H_2_R",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
+			},
+			["tasks"] = {
+				[1] = 29,
+			},
+		},
+		[7] = {
+			["name"] = "CAP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[8] = {
 			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
@@ -143,106 +413,7 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
-		[4] = {
-			["name"] = "Retribution Strike",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 33,
-			},
-		},
-		[5] = {
-			["name"] = "CAP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{600gal}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{600gal}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[6] = {
+		[9] = {
 			["displayName"] = "Retribution DEAD",
 			["name"] = "Retribution DEAD",
 			["pylons"] = {
@@ -297,161 +468,6 @@ local unitPayloads = {
 			},
 			["tasks"] = {
 				[1] = 31,
-			},
-		},
-		[7] = {
-			["name"] = "Retribution OCA/Runway",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 11,
-			},
-		},
-		[8] = {
-			["name"] = "ANTISHIP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[3] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 7,
-				},
-				[4] = {
-					["CLSID"] = "{600gal}",
-					["num"] = 6,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[7] = {
-					["CLSID"] = "{600gal}",
-					["num"] = 4,
-				},
-				[8] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[10] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[9] = {
-			["name"] = "Retribution SEAD Escort",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_L",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_R",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 29,
 			},
 		},
 	},

--- a/resources/customized_payloads/F-16D_Barak_40.lua
+++ b/resources/customized_payloads/F-16D_Barak_40.lua
@@ -2,6 +2,58 @@ local unitPayloads = {
 	["name"] = "F-16D_Barak_40",
 	["payloads"] = {
 		[1] = {
+			["name"] = "Retribution OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[2] = {
 			["name"] = "Retribution SEAD",
 			["pylons"] = {
 				[1] = {
@@ -17,7 +69,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[5] = {
@@ -25,7 +77,7 @@ local unitPayloads = {
 					["num"] = 5,
 				},
 				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[7] = {
@@ -48,12 +100,16 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[12] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
 			},
 			["tasks"] = {
 				[1] = 29,
 			},
 		},
-		[2] = {
+		[3] = {
 			["name"] = "Retribution Ferry",
 			["pylons"] = {
 				[1] = {
@@ -73,11 +129,11 @@ local unitPayloads = {
 					["num"] = 2,
 				},
 				[5] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal}",
 					["num"] = 4,
 				},
 				[7] = {
@@ -88,11 +144,225 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[9] = {
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 3,
+				},
 			},
 			["tasks"] = {
 			},
 		},
-		[3] = {
+		[4] = {
+			["name"] = "Retribution Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{GBU-31V3B}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{GBU-31V3B}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+				[1] = 33,
+			},
+		},
+		[5] = {
+			["name"] = "ANTISHIP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[3] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 7,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[7] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[6] = {
+			["name"] = "Retribution SEAD Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "LAU_88_AGM_65H_2_R",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
+			},
+			["tasks"] = {
+				[1] = 29,
+			},
+		},
+		[7] = {
+			["name"] = "CAP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[8] = {
 			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
@@ -143,106 +413,7 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
-		[4] = {
-			["name"] = "Retribution Strike",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 33,
-			},
-		},
-		[5] = {
-			["name"] = "CAP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{600gal}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{600gal}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[6] = {
+		[9] = {
 			["displayName"] = "Retribution DEAD",
 			["name"] = "Retribution DEAD",
 			["pylons"] = {
@@ -297,161 +468,6 @@ local unitPayloads = {
 			},
 			["tasks"] = {
 				[1] = 31,
-			},
-		},
-		[7] = {
-			["name"] = "Retribution OCA/Runway",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 11,
-			},
-		},
-		[8] = {
-			["name"] = "ANTISHIP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[3] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 7,
-				},
-				[4] = {
-					["CLSID"] = "{600gal}",
-					["num"] = 6,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[7] = {
-					["CLSID"] = "{600gal}",
-					["num"] = 4,
-				},
-				[8] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[10] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[9] = {
-			["name"] = "Retribution SEAD Escort",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_L",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_R",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 29,
 			},
 		},
 	},

--- a/resources/customized_payloads/F-16I.lua
+++ b/resources/customized_payloads/F-16I.lua
@@ -2,6 +2,62 @@ local unitPayloads = {
 	["name"] = "F-16I",
 	["payloads"] = {
 		[1] = {
+			["name"] = "Retribution OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{IDF Mods Project F-16I CFT}",
+					["num"] = 16,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[2] = {
 			["name"] = "Retribution SEAD",
 			["pylons"] = {
 				[1] = {
@@ -17,7 +73,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
 					["num"] = 4,
 				},
 				[5] = {
@@ -25,7 +81,7 @@ local unitPayloads = {
 					["num"] = 5,
 				},
 				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
 					["num"] = 6,
 				},
 				[7] = {
@@ -48,12 +104,20 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[12] = {
+					["CLSID"] = "{IDF Mods Project F-16I CFT}",
+					["num"] = 16,
+				},
+				[13] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
 			},
 			["tasks"] = {
 				[1] = 29,
 			},
 		},
-		[2] = {
+		[3] = {
 			["name"] = "Retribution Ferry",
 			["pylons"] = {
 				[1] = {
@@ -73,11 +137,11 @@ local unitPayloads = {
 					["num"] = 2,
 				},
 				[5] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "MXU-648-TP",
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
 					["num"] = 4,
 				},
 				[7] = {
@@ -88,11 +152,245 @@ local unitPayloads = {
 					["CLSID"] = "ALQ_184_Long",
 					["num"] = 13,
 				},
+				[9] = {
+					["CLSID"] = "{IDF Mods Project F-16I CFT}",
+					["num"] = 16,
+				},
+				[10] = {
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 7,
+				},
+				[11] = {
+					["CLSID"] = "MXU-648-TP",
+					["num"] = 3,
+				},
 			},
 			["tasks"] = {
 			},
 		},
-		[3] = {
+		[4] = {
+			["name"] = "Retribution Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[8] = {
+					["CLSID"] = "{GBU-31V3B}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{GBU-31V3B}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{IDF Mods Project F-16I CFT}",
+					["num"] = 16,
+				},
+			},
+			["tasks"] = {
+				[1] = 33,
+			},
+		},
+		[5] = {
+			["name"] = "ANTISHIP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[3] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 7,
+				},
+				[4] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[5] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[7] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
+					["num"] = 3,
+				},
+				[9] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[10] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[11] = {
+					["CLSID"] = "{IDF Mods Project F-16I CFT}",
+					["num"] = 16,
+				},
+				[12] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[6] = {
+			["name"] = "Retribution SEAD Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{IDF Mods Project 300gal}",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "LAU_88_AGM_65H_2_R",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 11,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+				[12] = {
+					["CLSID"] = "{IDF Mods Project F-16I CFT}",
+					["num"] = 16,
+				},
+				[13] = {
+					["CLSID"] = "{AN_ASQ_213}",
+					["num"] = 10,
+				},
+			},
+			["tasks"] = {
+				[1] = 29,
+			},
+		},
+		[7] = {
+			["name"] = "CAP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 8,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 9,
+				},
+				[10] = {
+					["CLSID"] = "{IDF Mods Project F-16I CFT}",
+					["num"] = 16,
+				},
+				[11] = {
+					["CLSID"] = "ALQ_184_Long",
+					["num"] = 13,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[8] = {
 			["name"] = "CAS",
 			["pylons"] = {
 				[1] = {
@@ -147,110 +445,7 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
-		[4] = {
-			["name"] = "Retribution Strike",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{GBU-24}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 33,
-			},
-		},
-		[5] = {
-			["name"] = "CAP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project F-16I CFT}",
-					["num"] = 16,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[6] = {
+		[9] = {
 			["displayName"] = "Retribution DEAD",
 			["name"] = "Retribution DEAD",
 			["pylons"] = {
@@ -309,165 +504,6 @@ local unitPayloads = {
 			},
 			["tasks"] = {
 				[1] = 31,
-			},
-		},
-		[7] = {
-			["name"] = "Retribution OCA/Runway",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[4] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 4,
-				},
-				[7] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 6,
-				},
-				[8] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
-					["num"] = 7,
-				},
-				[10] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 11,
-			},
-		},
-		[8] = {
-			["name"] = "ANTISHIP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[3] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 7,
-				},
-				[4] = {
-					["CLSID"] = "{600gal+CFT Fuel Right 1500lb}",
-					["num"] = 6,
-				},
-				[5] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 5,
-				},
-				[7] = {
-					["CLSID"] = "{600gal+CFT Fuel Left 1500lb}",
-					["num"] = 4,
-				},
-				[8] = {
-					["CLSID"] = "{69DC8AE7-8F77-427B-B8AA-B19D3F478B66}",
-					["num"] = 3,
-				},
-				[9] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[10] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[11] = {
-					["CLSID"] = "{IDF Mods Project F-16I CFT}",
-					["num"] = 16,
-				},
-				[12] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[9] = {
-			["name"] = "Retribution SEAD Escort",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_L",
-					["num"] = 3,
-				},
-				[4] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 4,
-				},
-				[5] = {
-					["CLSID"] = "{IDF Mods Project 300gal}",
-					["num"] = 5,
-				},
-				[6] = {
-					["CLSID"] = "{B06DD79A-F21E-4EB9-BD9D-AB3844618C93}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "LAU_88_AGM_65H_2_R",
-					["num"] = 7,
-				},
-				[8] = {
-					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
-					["num"] = 8,
-				},
-				[9] = {
-					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
-					["num"] = 9,
-				},
-				[10] = {
-					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
-					["num"] = 11,
-				},
-				[11] = {
-					["CLSID"] = "ALQ_184_Long",
-					["num"] = 13,
-				},
-			},
-			["tasks"] = {
-				[1] = 29,
 			},
 		},
 	},


### PR DESCRIPTION
Improved the F-16I Sufa & F-16D mod v3.2 loadouts. Now uses CFTs on more loadouts on those variants which can carry them. Regular 600 gallon wing tanks for the others. Stations 4 and 6 are not used for weapons in these loadouts any more, for realism's sake.