### PR TITLE
New Squadrons for Vietnam Era

### DIFF
--- a/resources/squadrons/A-4E Skyhawk/VA-212 -Rampant Riders- (USS HANCOCK) 1972.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-212 -Rampant Riders- (USS HANCOCK) 1972.yaml
@@ -1,0 +1,25 @@
+---
+name: VA-212
+nickname: Rampant Riders
+country: USA
+role: Carrier-based Attack/Light Fighter
+aircraft: A-4E Skyhawk
+bases:
+  carrier: true
+  shore: true
+livery: USN VA-212 Rampant Raiders
+mission_types:
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP
+players:
+  - BlueCat

--- a/resources/squadrons/A-4E Skyhawk/VA-46 -Clansmen- (USS FORRESTAL) 1967.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-46 -Clansmen- (USS FORRESTAL) 1967.yaml
@@ -1,0 +1,25 @@
+---
+name: VA-46 Clansmen
+nickname: Clansmen
+country: USA
+role: Carrier-based Attack/Light Fighter
+aircraft: A-4E Skyhawk
+bases:
+  carrier: true
+  shore: true
+livery: USN VA-46 Clansmen
+mission_types:
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP
+players:
+  - Mad Max

--- a/resources/squadrons/A-4E Skyhawk/VA-55 -Warhorses- (USS HANCOCK) 1972.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VA-55 -Warhorses- (USS HANCOCK) 1972.yaml
@@ -1,0 +1,25 @@
+---
+name: VA-55 Warhorses
+nickname: Warhorses
+country: USA
+role: Carrier-based Attack/Light Fighter
+aircraft: A-4E Skyhawk
+bases:
+  carrier: true
+  shore: true
+livery: USN VA-55 -Warhorses- (USS HANCOCK 1973)
+mission_types:
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP
+players:
+  - Mad Max

--- a/resources/squadrons/A-4E Skyhawk/VMA-144 -Roadrunners- (USS BON HOMME RICHARD 1969).yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-144 -Roadrunners- (USS BON HOMME RICHARD 1969).yaml
@@ -1,0 +1,25 @@
+---
+name: VMA-144 Roadrunners
+nickname: Roadrunners
+country: USA
+role: Carrier-based Attack/Light Fighter
+aircraft: A-4E Skyhawk
+bases:
+  carrier: true
+  shore: true
+livery: USN VA-144 Roadrunners
+mission_types:
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP
+players:
+  - BlueCat

--- a/resources/squadrons/A-4E Skyhawk/VMA-311 -Tomcats- (Da Nang) 1971.yaml
+++ b/resources/squadrons/A-4E Skyhawk/VMA-311 -Tomcats- (Da Nang) 1971.yaml
@@ -1,0 +1,26 @@
+---
+name: VMA-311 Tomcats
+nickname: Tomcats
+country: USA
+role: Carrier-based Attack/Light Fighter
+aircraft: A-4E Skyhawk
+bases:
+  carrier: true
+  shore: true
+livery: USMC VMA-311 Tomcats
+mission_types:
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP
+players:
+  - Mad Max
+  - BlueCat

--- a/resources/squadrons/A-6A Intruder/VA-165 -Boomers - (USS CONSTELLATION) 1965.yaml
+++ b/resources/squadrons/A-6A Intruder/VA-165 -Boomers - (USS CONSTELLATION) 1965.yaml
@@ -1,0 +1,20 @@
+---
+name: VA-165 Boomers
+nickname: Boomers
+country: USA
+role: Carrier-based Attack
+aircraft: A-6A Intruder
+livery: VA-165 Boomers - HD 521 - HiVis
+mission_types:
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/A-6A Intruder/VA-176 -Thunderbolts - (USS FORRESTAL) 1986.yaml
+++ b/resources/squadrons/A-6A Intruder/VA-176 -Thunderbolts - (USS FORRESTAL) 1986.yaml
@@ -1,0 +1,20 @@
+---
+name: VA-176 Thunderbolts
+nickname: Thunderbolts
+country: USA
+role: Carrier-based Attack
+aircraft: A-6A Intruder
+livery: VA-176 AE 503
+mission_types:
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/A-6A Intruder/VA-196 -Main Battery - (USS CONSTELLATION) 1967.yaml
+++ b/resources/squadrons/A-6A Intruder/VA-196 -Main Battery - (USS CONSTELLATION) 1967.yaml
@@ -1,0 +1,20 @@
+---
+name: VA-196 Main Battery
+nickname: Main Battery
+country: USA
+role: Carrier-based Attack
+aircraft: A-6A Intruder
+livery: VA-196 Main Battery NK - HD 412 - HiVis
+mission_types:
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/A-6A Intruder/VA-304 -Firebirds - (USS NIMITZ) 1988.yaml
+++ b/resources/squadrons/A-6A Intruder/VA-304 -Firebirds - (USS NIMITZ) 1988.yaml
@@ -1,0 +1,20 @@
+---
+name: VA-304 Firebirds
+nickname: Firebirds
+country: USA
+role: Carrier-based Attack
+aircraft: A-6A Intruder
+livery: VA-304 Firebirds AA - HD 422 - HiVis
+mission_types:
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/A-6A Intruder/VA-34 -Blue Blasters - (JOHN F KENNEDY) 1970.yaml
+++ b/resources/squadrons/A-6A Intruder/VA-34 -Blue Blasters - (JOHN F KENNEDY) 1970.yaml
@@ -1,0 +1,20 @@
+---
+name: VA-34 Blue Blasters
+nickname: Blue Blasters
+country: USA
+role: Carrier-based Attack
+aircraft: A-6A Intruder
+livery: VA-34 Blue Blasters AB - HD 514
+mission_types:
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/A-6A Intruder/VA-52 -Knightriders - (USS CARL VINSON) 1983.yaml
+++ b/resources/squadrons/A-6A Intruder/VA-52 -Knightriders - (USS CARL VINSON) 1983.yaml
@@ -1,0 +1,20 @@
+---
+name: VA-52 Knightriders
+nickname: Knightriders
+country: USA
+role: Carrier-based Attack
+aircraft: A-6A Intruder
+livery: VA-52 Knightriders NL - HD 521 - HiVis
+mission_types:
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/B-52H/307th Strategic Wing - (U Tapao RTAFB Thailand).yaml
+++ b/resources/squadrons/B-52H/307th Strategic Wing - (U Tapao RTAFB Thailand).yaml
@@ -1,0 +1,15 @@
+---
+name: 307th Strategic Wing
+nickname: Big Stick
+country: USA
+role: Strategic Bomber
+aircraft: B-52H Stratofortress
+livery: USAF - 70s - South East Asia
+mission_types:
+  - Anti-ship
+  - BAI
+  - CAS
+  - DEAD
+  - OCA/Aircraft
+  - OCA/Runway
+  - Strike

--- a/resources/squadrons/B-52H/43d Strategic Wing - (Andersen AFB Guam).yaml
+++ b/resources/squadrons/B-52H/43d Strategic Wing - (Andersen AFB Guam).yaml
@@ -1,0 +1,15 @@
+---
+name: 43d Strategic Wing
+nickname: Willing, Able, Ready
+country: USA
+role: Strategic Bomber
+aircraft: B-52H Stratofortress
+livery: USAF - 70s - South East Asia
+mission_types:
+  - Anti-ship
+  - BAI
+  - CAS
+  - DEAD
+  - OCA/Aircraft
+  - OCA/Runway
+  - Strike

--- a/resources/squadrons/E-2 Hawkeye/VAW-122 -Steeljaws- (USS FORRESTAL 1987).yaml
+++ b/resources/squadrons/E-2 Hawkeye/VAW-122 -Steeljaws- (USS FORRESTAL 1987).yaml
@@ -1,0 +1,9 @@
+---
+name: VAW-122
+nickname: Steeljaws
+country: USA
+role: AEW&C
+aircraft: E-2C Hawkeye
+livery: US Navy - 90s - VAW-122 AE 600
+mission_types:
+  - AEW&C

--- a/resources/squadrons/E-2 Hawkeye/VAW-123 -Screwtops- (USS SARATOGA 1972).yaml
+++ b/resources/squadrons/E-2 Hawkeye/VAW-123 -Screwtops- (USS SARATOGA 1972).yaml
@@ -1,0 +1,9 @@
+---
+name: VAW-123
+nickname: Screwtops
+country: USA
+role: AEW&C
+aircraft: E-2C Hawkeye
+livery: US Navy - 70s - VAW-123
+mission_types:
+  - AEW&C

--- a/resources/squadrons/F-4B Phantom II/USAF 433th TFS -Blue Devils- (Ubon 1967).yaml
+++ b/resources/squadrons/F-4B Phantom II/USAF 433th TFS -Blue Devils- (Ubon 1967).yaml
@@ -1,0 +1,22 @@
+---
+name: USAF 433th TFS
+nickname: Blue Devils
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: USAF 433 TFS 63-7680 (SEA)
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/USAF 45th TFS -Hoosier Hogs- (Ubon 1965).yaml
+++ b/resources/squadrons/F-4B Phantom II/USAF 45th TFS -Hoosier Hogs- (Ubon 1965).yaml
@@ -1,0 +1,22 @@
+---
+name: USAF 45th TFS
+nickname: Hoosier Hogs
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: USAF 45th TFS 40693
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/USAF 555th TFS -Triple Nickel- (Udon 1966).yaml
+++ b/resources/squadrons/F-4B Phantom II/USAF 555th TFS -Triple Nickel- (Udon 1966).yaml
@@ -1,0 +1,22 @@
+---
+name: USAF 555th TFS
+nickname: Triple Nickel
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: USAF 555 TFS - 463 (SEA)
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-103 -Sluggers- 206 (USS SARATOGA 1972).yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-103 -Sluggers- 206 (USS SARATOGA 1972).yaml
@@ -1,0 +1,22 @@
+---
+name: VF-103
+nickname: Sluggers
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-103 Sluggers 206
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-111 -Sundowners- 201 (USS CORAL SEA 1971).yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-111 -Sundowners- 201 (USS CORAL SEA 1971).yaml
@@ -1,0 +1,22 @@
+---
+name: VF-111
+nickname: Sundowners
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-111 201 USS CORAL SEA
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-114 -Aardvarks- 210 (USS KITTY HAWK 1972 ).yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-114 -Aardvarks- 210 (USS KITTY HAWK 1972 ).yaml
@@ -1,0 +1,22 @@
+---
+name: VF-114
+nickname: Aardvarks
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-114 Aardvarks 210 (Kills)
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-121 -Pacemakers- 118  (Miramar 1960).yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-121 -Pacemakers- 118  (Miramar 1960).yaml
@@ -1,0 +1,22 @@
+---
+name: VF-121
+nickname: Pacemakers
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-121-118
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-14 -Tophatters- 101 (USS ROOSEVELT 1966) .yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-14 -Tophatters- 101 (USS ROOSEVELT 1966) .yaml
@@ -1,0 +1,22 @@
+---
+name: VF-14
+nickname: Tophatters
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-14 101
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-151 -Vigilantes- 213 (USS MIDWAY 1971).yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-151 -Vigilantes- 213 (USS MIDWAY 1971).yaml
@@ -1,0 +1,22 @@
+---
+name: VF-151
+nickname: Vigilantes
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-151 213 USS MIDWAY
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-161 -Chargers- 101 (USS MIDWAY 1971).yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-161 -Chargers- 101 (USS MIDWAY 1971).yaml
@@ -1,0 +1,22 @@
+---
+name: VF-161
+nickname: Chargers
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-161 101
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-21 -Freelancers- 102 (USS MIDWAY 1965).yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-21 -Freelancers- 102 (USS MIDWAY 1965).yaml
@@ -1,0 +1,22 @@
+---
+name: VF-21
+nickname: Freelancers
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-21 102 USS MIDWAY
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-31 -Tomcatters- 106 (USS SARATOGA 1972).yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-31 -Tomcatters- 106 (USS SARATOGA 1972).yaml
@@ -1,0 +1,22 @@
+---
+name: VF-31
+nickname: Tomcatters
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-31 Tomcatters 106
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-41 -Black Aces- 112 (USS ROOSEVELT 1970).yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-41 -Black Aces- 112 (USS ROOSEVELT 1970).yaml
@@ -1,0 +1,22 @@
+---
+name: VF-41
+nickname: Black Aces
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-41 112
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-51 -Screaming Eagles- 110 (USS CORAL SEA 1971).yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-51 -Screaming Eagles- 110 (USS CORAL SEA 1971).yaml
@@ -1,0 +1,22 @@
+---
+name: VF-51
+nickname: Screaming Eagles
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-51 110 USS CORAL SEA
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VF-84 -Jolly Rogers- 200 (USS INDEPENDENCE 1965).yaml
+++ b/resources/squadrons/F-4B Phantom II/VF-84 -Jolly Rogers- 200 (USS INDEPENDENCE 1965).yaml
@@ -1,0 +1,22 @@
+---
+name: VF-84
+nickname: Jolly Rogers
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VF-84 Jolly Rogers 200 15-5868
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VMFA-212 -Lancers- AC02 (Da Nang 1972).yaml
+++ b/resources/squadrons/F-4B Phantom II/VMFA-212 -Lancers- AC02 (Da Nang 1972).yaml
@@ -1,0 +1,22 @@
+---
+name: VMFA-212
+nickname: Lancers
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VMFA-212 AC02
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VMFA-314 -Black Knights- 5 (Da Nang 1966).yaml
+++ b/resources/squadrons/F-4B Phantom II/VMFA-314 -Black Knights- 5 (Da Nang 1966).yaml
@@ -1,0 +1,22 @@
+---
+name: VMFA-314
+nickname:  Black Knights
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VMFA-314 5
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VMFA-531 -Grey Ghosts- 10 (Da Nang 1965).yaml
+++ b/resources/squadrons/F-4B Phantom II/VMFA-531 -Grey Ghosts- 10 (Da Nang 1965).yaml
@@ -1,0 +1,22 @@
+---
+name: VMFA-531
+nickname: Grey Ghosts
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VMFA-531_10
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4B Phantom II/VMFA-531 -Grey Ghosts- 207 (USS FORRESTAL 1973).yaml
+++ b/resources/squadrons/F-4B Phantom II/VMFA-531 -Grey Ghosts- 207 (USS FORRESTAL 1973).yaml
@@ -1,0 +1,22 @@
+---
+name: VFMA-531
+nickname: Grey Ghosts
+country: USA
+role: Fighter Bomber
+aircraft: F-4B Phantom II
+livery: VMFA-531 207
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4E/USAF 338 TFW (Korat 1973).yaml
+++ b/resources/squadrons/F-4E/USAF 338 TFW (Korat 1973).yaml
@@ -1,0 +1,22 @@
+---
+name: USAF 338 TFW 
+nickname: Abusers
+country: USA
+role: Fighter Bomber
+aircraft: F-4E Phantom II
+livery: USAF JH 68-804 (SEA)
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4E/USAF 45th TFS (Ubon 1965).yaml
+++ b/resources/squadrons/F-4E/USAF 45th TFS (Ubon 1965).yaml
@@ -1,0 +1,22 @@
+---
+name: USAF 45th TFS
+nickname: Mig Killers
+country: USA
+role: Fighter Bomber
+aircraft: F-4E Phantom II
+livery: USAF FJ-693
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4E/USAF 469th TFS A (Korat 1968).yaml
+++ b/resources/squadrons/F-4E/USAF 469th TFS A (Korat 1968).yaml
@@ -1,0 +1,22 @@
+---
+name: USAF 469th TFS A
+nickname: Wild Weasels
+country: USA
+role: Fighter Bomber
+aircraft: F-4E Phantom II
+livery: USAF JV 69-123 (SEA)
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4E/USAF 469th TFS B (Korat 1972).yaml
+++ b/resources/squadrons/F-4E/USAF 469th TFS B (Korat 1972).yaml
@@ -1,0 +1,22 @@
+---
+name: USAF 469th TFS B
+nickname: Super Spook
+country: USA
+role: Fighter Bomber
+aircraft: F-4E Phantom II
+livery: USAF JV 69-290 (SEA)
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4E/USAF 469th TFS C (Korat 1970).yaml
+++ b/resources/squadrons/F-4E/USAF 469th TFS C (Korat 1970).yaml
@@ -1,0 +1,22 @@
+---
+name: USAF 469th TFS C
+nickname: Goblin
+country: USA
+role: Fighter Bomber
+aircraft: F-4E Phantom II
+livery: USAF JV 69-292 (SEA)
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4E/USAF 469th TFS D (Korat 1970).yaml
+++ b/resources/squadrons/F-4E/USAF 469th TFS D (Korat 1970).yaml
@@ -1,0 +1,22 @@
+---
+name: USAF 469th TFS D
+nickname: Archers
+country: USA
+role: Fighter Bomber
+aircraft: F-4E Phantom II
+livery: USAF JV 69-310 (SEA)
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4E/USAF 469th TFS E (Korat 1970).yaml
+++ b/resources/squadrons/F-4E/USAF 469th TFS E (Korat 1970).yaml
@@ -1,0 +1,22 @@
+---
+name: USAF 469th TFS E
+nickname: Pirates
+country: USA
+role: Fighter Bomber
+aircraft: F-4E Phantom II
+livery: USAF JV 69-313 (SEA)
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-4E/USMC VMFA 235 .yaml
+++ b/resources/squadrons/F-4E/USMC VMFA 235 .yaml
@@ -1,0 +1,22 @@
+---
+name: USMC VMFA 235 
+nickname: Death Angels
+country: USA
+role: Fighter Bomber
+aircraft: F-4E Phantom II
+livery: USMC VMFA 235
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-5E/Ala 21 - 51 Escuadron.yaml
+++ b/resources/squadrons/F-5E/Ala 21 - 51 Escuadron.yaml
@@ -1,0 +1,23 @@
+---
+name: Ala 23 - 232 Escuadron
+nickname: Patas Negras
+country: Spain
+role: Strike Fighter
+aircraft: F-5E Tiger II
+livery: Spain - Ala 23 -01 23-23
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP
+  

--- a/resources/squadrons/F-5E/Ala 23 - 232 Escuadron.yaml
+++ b/resources/squadrons/F-5E/Ala 23 - 232 Escuadron.yaml
@@ -1,0 +1,22 @@
+---
+name: Escuadrón de Vigilancia Aérea nº21 (Macan)
+nickname: Siroco
+country: Spain
+role: Strike Fighter
+aircraft: F-5E Tiger II
+livery: SP Spanish Air Force 21-51
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-5E/Borak Squadron.yaml
+++ b/resources/squadrons/F-5E/Borak Squadron.yaml
@@ -1,0 +1,22 @@
+---
+name: Borak Sqd. F-5E/F TIII))
+nickname: Tigre Wing
+country: Morocco
+role: Strike Fighter
+aircraft: F-5E Tiger II
+livery: MRAF
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-5E/Chanine Squadron.yaml
+++ b/resources/squadrons/F-5E/Chanine Squadron.yaml
@@ -1,0 +1,22 @@
+---
+name: Chanine Sqd. F-5E/F TIII))
+nickname: Tigre Wing
+country: Morocco
+role: Strike Fighter
+aircraft: F-5E Tiger II
+livery: MRAF
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-5E/ERIGE Squadron.yaml
+++ b/resources/squadrons/F-5E/ERIGE Squadron.yaml
@@ -1,0 +1,22 @@
+---
+name: EIRGE Sqd. F-5E/F TIII))
+nickname: Tigre Wing
+country: Morocco
+role: Strike Fighter
+aircraft: F-5E Tiger II
+livery: MRAF
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/F-5E/Escuadrón de Vigilancia Aérea nº21 (Macan).yaml
+++ b/resources/squadrons/F-5E/Escuadrón de Vigilancia Aérea nº21 (Macan).yaml
@@ -1,0 +1,25 @@
+---
+name: Escuadrón de Vigilancia Aérea nº21 (Macan)
+nickname: Siroco
+country: Spain
+role: Strike Fighter
+aircraft: F-5E Tiger II
+livery: SP Spanish Air Force 21-51
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP
+players:
+  - Mad Max
+  - Aranako

--- a/resources/squadrons/F-5E/South Vietnam 522nd Figher Sqn (Da Nang 1968).yaml
+++ b/resources/squadrons/F-5E/South Vietnam 522nd Figher Sqn (Da Nang 1968).yaml
@@ -1,0 +1,23 @@
+---
+name: 425th TFTS
+nickname: Black Widows
+country: USA
+role: Strike Fighter
+aircraft: F-5E Tiger II
+livery: USAF - 70s - USAF 425th TFTS (SEA)
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP
+  

--- a/resources/squadrons/F-5E/USAF - 425th TFTS -Black Widows- (Vietnam 1973).yaml
+++ b/resources/squadrons/F-5E/USAF - 425th TFTS -Black Widows- (Vietnam 1973).yaml
@@ -1,0 +1,23 @@
+---
+name: 522nd Figher Sqn
+nickname: Black Widows
+country: USA
+role: Strike Fighter
+aircraft: F-5E Tiger II
+livery: South Vietnam 522nd Figher Sqn 10525
+mission_types:
+  - Anti-ship
+  - BAI
+  - BARCAP
+  - CAS
+  - DEAD
+  - Escort
+  - Intercept
+  - OCA/Aircraft
+  - OCA/Runway
+  - SEAD
+  - SEAD Escort
+  - Strike
+  - Fighter sweep
+  - TARCAP
+  

--- a/resources/squadrons/Mi-8/SAAF 255th Sqn - copia.yaml
+++ b/resources/squadrons/Mi-8/SAAF 255th Sqn - copia.yaml
@@ -1,0 +1,11 @@
+---
+name: 255th Squadron
+nickname: 255th
+country: Syria
+role: Transport Helicopter
+aircraft: Mi-8MTV2 Hip
+livery: "Syria - New"
+mission_types:
+  - Transport
+  - CAS
+  - BAI

--- a/resources/squadrons/Mi-8/VPAF - 100th Helicopter Sqn.yaml
+++ b/resources/squadrons/Mi-8/VPAF - 100th Helicopter Sqn.yaml
@@ -1,0 +1,11 @@
+---
+name: VPAF Helo 100th Squadron
+nickname: 100th
+country: Vietnam
+role: Transport Helicopter
+aircraft: Mi-8MTV2 Hip
+livery: "North Vietnam"
+mission_types:
+  - Transport
+  - CAS
+  - BAI

--- a/resources/squadrons/Mi-8/VPAF - 110th Helicopter Sqn.yaml
+++ b/resources/squadrons/Mi-8/VPAF - 110th Helicopter Sqn.yaml
@@ -1,0 +1,11 @@
+---
+name: VPAF Helo 110th Squadron
+nickname: 110th
+country: Vietnam
+role: Transport Helicopter
+aircraft: Mi-8MTV2 Hip
+livery: "North Vietnam"
+mission_types:
+  - Transport
+  - CAS
+  - BAI

--- a/resources/squadrons/Mi-8/VPAF - 120th Helicopter Sqn.yaml
+++ b/resources/squadrons/Mi-8/VPAF - 120th Helicopter Sqn.yaml
@@ -1,0 +1,11 @@
+---
+name: VPAF Helo 120th Squadron
+nickname: 120th
+country: Vietnam
+role: Transport Helicopter
+aircraft: Mi-8MTV2 Hip
+livery: "North Vietnam"
+mission_types:
+  - Transport
+  - CAS
+  - BAI

--- a/resources/squadrons/Mi-8/VPAF - 130th Helicopter Sqn.yaml
+++ b/resources/squadrons/Mi-8/VPAF - 130th Helicopter Sqn.yaml
@@ -1,0 +1,11 @@
+---
+name: VPAF Helo 130th Squadron
+nickname: 130th
+country: Vietnam
+role: Transport Helicopter
+aircraft: Mi-8MTV2 Hip
+livery: "North Vietnam"
+mission_types:
+  - Transport
+  - CAS
+  - BAI

--- a/resources/squadrons/MiG-15bis/VPAF - 330th AWP.yaml
+++ b/resources/squadrons/MiG-15bis/VPAF - 330th AWP.yaml
@@ -1,0 +1,14 @@
+---
+name: VPAF - 330th AWP
+nickname: 330th
+country: Vietnam
+role: Air Superiority Fighter
+aircraft: MiG-15bis Fagot
+livery:
+mission_types:
+  - BARCAP
+  - TARCAP
+  - Escort
+  - Intercept
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/MiG-15bis/VPAF - 480th AWP.yaml
+++ b/resources/squadrons/MiG-15bis/VPAF - 480th AWP.yaml
@@ -1,0 +1,14 @@
+---
+name: VPAF - 480th AWP
+nickname: 480th
+country: Vietnam
+role: Air Superiority Fighter
+aircraft: MiG-15bis Fagot
+livery:
+mission_types:
+  - BARCAP
+  - TARCAP
+  - Escort
+  - Intercept
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/MiG-15bis/VPAF - VA-216.yaml
+++ b/resources/squadrons/MiG-15bis/VPAF - VA-216.yaml
@@ -1,0 +1,14 @@
+---
+name: VPAF - VA-216
+nickname: Mortal Vipers
+country: Vietnam
+role: Air Superiority Fighter
+aircraft: MiG-15bis Fagot
+livery:
+mission_types:
+  - BARCAP
+  - TARCAP
+  - Escort
+  - Intercept
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/MiG-19P/SAAF 725th Sqn.yaml
+++ b/resources/squadrons/MiG-19P/SAAF 725th Sqn.yaml
@@ -1,0 +1,14 @@
+---
+name: 725th Squadron
+nickname: 725th
+country: Syria
+role: Air Superiority Fighter
+aircraft: MiG-19P Farmer-B
+livery: "Syria - Silver"
+mission_types:
+  - BARCAP
+  - TARCAP
+  - Escort
+  - Intercept
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/MiG-19P/VPAF - 750th Sao Do.yaml
+++ b/resources/squadrons/MiG-19P/VPAF - 750th Sao Do.yaml
@@ -1,0 +1,14 @@
+---
+name: VVPAF - 750th Sao Do
+nickname: 750th
+country: Vietnam
+role: Air Superiority Fighter
+aircraft: MiG-19P Farmer-B
+livery: "VPAF Green"
+mission_types:
+  - BARCAP
+  - TARCAP
+  - Escort
+  - Intercept
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/MiG-19P/VPAF - 925th.yaml
+++ b/resources/squadrons/MiG-19P/VPAF - 925th.yaml
@@ -1,0 +1,14 @@
+---
+name: VVPAF - 925th
+nickname: 925th
+country: Vietnam
+role: Air Superiority Fighter
+aircraft: MiG-19P Farmer-B
+livery: "CC_NV925th"
+mission_types:
+  - BARCAP
+  - TARCAP
+  - Escort
+  - Intercept
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/Mig-21/VPAF - 921st Sao Do - 5040.yaml
+++ b/resources/squadrons/Mig-21/VPAF - 921st Sao Do - 5040.yaml
@@ -1,0 +1,14 @@
+---
+name: VPAF - 921st Sao Do - 5040
+nickname: 921st
+country: Vietnam
+role: Air Superiority Fighter
+aircraft: MiG-21bis Fishbed-N
+livery: "VPAF - 921st Sao Do - 5040"
+mission_types:
+  - BARCAP
+  - TARCAP
+  - Escort
+  - Intercept
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/Mig-21/VPAF - 927th Fighter Regiment.yaml
+++ b/resources/squadrons/Mig-21/VPAF - 927th Fighter Regiment.yaml
@@ -1,0 +1,14 @@
+---
+name: VPAF - 927th Fighter Regiment
+nickname: 927th
+country: Vietnam
+role: Air Superiority Fighter
+aircraft: MiG-21bis Fishbed-N
+livery: "VPAF - 927th Fighter Regiment Metal"
+mission_types:
+  - BARCAP
+  - TARCAP
+  - Escort
+  - Intercept
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/Mig-21/VPAF - 927th Lam Son - 6122.yaml
+++ b/resources/squadrons/Mig-21/VPAF - 927th Lam Son - 6122.yaml
@@ -1,0 +1,14 @@
+---
+name: VVPAF - 927th Lam Son - 6122
+nickname: 927-6122th
+country: Vietnam
+role: Air Superiority Fighter
+aircraft: MiG-21bis Fishbed-N
+livery: "VPAF - 927th Lam Son - 6122"
+mission_types:
+  - BARCAP
+  - TARCAP
+  - Escort
+  - Intercept
+  - Fighter sweep
+  - TARCAP

--- a/resources/squadrons/OV-10A Bronco/20th TASS FAC -First on Target - (Tay Ninh 1970) .yaml
+++ b/resources/squadrons/OV-10A Bronco/20th TASS FAC -First on Target - (Tay Ninh 1970) .yaml
@@ -1,0 +1,16 @@
+---
+name: 20th TASS FAC
+nickname: First on Target
+country: USA
+role: Close Air Support
+aircraft: OV-10A Bronco
+livery: TASS 20th USAF 64-14654
+mission_types:
+  - BAI
+  - CAS
+  - DEAD
+  - OCA/Aircraft
+  - OCA/Runway
+  - Strike
+players:
+  - Mad Max

--- a/resources/squadrons/OV-10A Bronco/VAL 4 -Black Ponies- (NSA Binh Thuy 1969) .yaml
+++ b/resources/squadrons/OV-10A Bronco/VAL 4 -Black Ponies- (NSA Binh Thuy 1969) .yaml
@@ -1,0 +1,16 @@
+---
+name: VAL 4 Black Ponies
+nickname: Black Ponies
+country: USA
+role: Close Air Support
+aircraft: OV-10A Bronco
+livery: VAL-4 104
+mission_types:
+  - BAI
+  - CAS
+  - DEAD
+  - OCA/Aircraft
+  - OCA/Runway
+  - Strike
+players:
+  - BlueCat

--- a/resources/squadrons/S-3B/VS-24 -Souts- (USS NIMITZ 1978).yaml
+++ b/resources/squadrons/S-3B/VS-24 -Souts- (USS NIMITZ 1978).yaml
@@ -1,0 +1,9 @@
+---
+name: VS-24 (Tanker)
+nickname: Scouts
+country: USA
+role: Tanker
+aircraft: S-3B Tanker
+livery: USN - VS-24 - CAG
+mission_types:
+  - Refueling

--- a/resources/squadrons/S-3B/VS-28 -Gamblers- (USS FORRESTAL 1983).yaml
+++ b/resources/squadrons/S-3B/VS-28 -Gamblers- (USS FORRESTAL 1983).yaml
@@ -1,0 +1,9 @@
+---
+name: VS-28 (Tanker)
+nickname: Gamblers
+country: USA
+role: Tanker
+aircraft: S-3B Tanker
+livery: USAF - VS-28 - CAG
+mission_types:
+  - Refueling


### PR DESCRIPTION
Adding several different squadrons (A-4, A-6, F-4B/C, Broncos, etc...) for "Yankee Station" campaign.  All Vietnam era related. All of them with corresponding liveries that can be easily found on DCS User Files download pages.