### PR TITLE
Improved convoy form-up behaviour

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * **[Plugins]** Expose Splash Damage's "game_messages" option and set its default to false.
 * **[Mission Generation]** Improved AI SEAD capabilities, allowing for mixed loadouts using Decoys, ARMs & ASMs.
 * **[Mission Generation]** Tornadoes now use SEAD tasking for SEAD/DEAD missions.
+* **[Mission Generation]** Convoys now try to get moving immediately (with cone formation) to avoid taking a long time to form up to move on road. Credit to Farrago for this approach.
 * **[Modding]** Support for A-7E Corsair II (presumed latest available version)
 * **[Squadrons]** Added many new squadron's by Adecarcer
 * **[Plugins]** Updated 'expl_table' in Splash Damage script.

--- a/game/missiongenerator/convoygenerator.py
+++ b/game/missiongenerator/convoygenerator.py
@@ -11,6 +11,7 @@ from dcs.unitgroup import VehicleGroup
 
 from game.dcs.groundunittype import GroundUnitType
 from game.missiongenerator.groundforcepainter import GroundForcePainter
+from game.theater import FrontLine
 from game.transfers import Convoy
 from game.unitmap import UnitMap
 from game.utils import kph
@@ -42,6 +43,22 @@ class ConvoyGenerator:
         )
 
         if self.game.settings.convoys_travel_full_distance:
+            frontline = FrontLine(convoy.origin, convoy.destination)
+            # Add one waypoint with PointAction.Cone and then order the convoy on road.
+            # This is done to make the convoy start to move immediately, instead of
+            # waiting a long time for them to form up and actually start moving.
+            # Credit to Farrago for suggesting this.
+            group.add_waypoint(
+                frontline.segments[0].point_a,
+                speed=kph(40).kph,
+                move_formation=PointAction.Cone,
+            )
+            if len(frontline.segments) > 1:
+                group.add_waypoint(
+                    frontline.segments[1].point_a,
+                    speed=kph(40).kph,
+                    move_formation=PointAction.OnRoad,
+                )
             end_point = convoy.route_end
         else:
             # convoys_travel_full_distance is disabled, so have the convoy only move the


### PR DESCRIPTION
Adds one waypoint with PointAction.Cone and then orders convoys on road. This is done to make convoys start to move immediately, instead of waiting (potentially) a long time for them to form up and actually start moving.

Credit to Farrago for suggesting this.