### PR TITLE
A-7E Corsair II OCA/Runway loadout fix

### DIFF
--- a/resources/customized_payloads/A-7E.lua
+++ b/resources/customized_payloads/A-7E.lua
@@ -154,7 +154,7 @@ local unitPayloads = {
 					},
 				},
 				[4] = {
-					["CLSID"] = "{AGM_122_SIDEARM}",
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
 					["num"] = 4,
 				},
 				[5] = {


### PR DESCRIPTION
Replaced the A-7E Corsair II OCA/Runway loadout AGM-122 Sidearm ARM with an AIM-9 Sidewinder.