### PR TITLE
A-6A Intruder with Adecarcer's hardpoint options

### DIFF
--- a/pydcs_extensions/a6a/a6a.py
+++ b/pydcs_extensions/a6a/a6a.py
@@ -26,12 +26,86 @@ class VSN_A6A(PlaneType):
 
     livery_name = "VSN_A6A"  # from type
 
+    # We have also enabled Adecarcer's modified hardpoint options for the A-6A Intruder mod.
+    # This will, for instance, fix the MER bomb racks which have the "missing texture" material
+    # in the stock version of the mod. It will also allow mounting some weapons which are more
+    # appropriate for the A-6E variant of the aircraft. While not historically or technically
+    # accurate, this will allow employing the aircraft in a role which is closer to the EA-6B
+    # or A-6E, should the user wish to do so. The EA-6B mod is AI-only, so this will grant a
+    # player-flyable option. The use of custom loadouts is recommended.
+
     class Pylon1:
         F_5_275Gal_Fuel_tank = (1, Weapons.F_5_275Gal_Fuel_tank)
         AIM_9M_Sidewinder_IR_AAM = (1, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9X_Sidewinder_IR_AAM = (1, Weapons.AIM_9X_Sidewinder_IR_AAM)
+        LAU_7_with_AIM_9B_Sidewinder_IR_AAM = (
+            1,
+            Weapons.LAU_7_with_AIM_9B_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9J_Sidewinder_IR_AAM = (
+            1,
+            Weapons.LAU_7_with_AIM_9J_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9M_Sidewinder_IR_AAM = (
+            1,
+            Weapons.LAU_7_with_AIM_9M_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9P_Sidewinder_IR_AAM = (
+            1,
+            Weapons.LAU_7_with_AIM_9P_Sidewinder_IR_AAM,
+        )
+        AGM_45A_Shrike_ARM = (1, Weapons.AGM_45A_Shrike_ARM)
+        AGM_45B_Shrike_ARM__Imp_ = (1, Weapons.AGM_45B_Shrike_ARM__Imp_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile = (
+            1,
+            Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile,
+        )
+        LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (
+            1,
+            Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_,
+        )
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+            1,
+            Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_,
+        )
+        LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (
+            1,
+            Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_,
+        )
+        LAU_117_AGM_65G = (1, Weapons.LAU_117_AGM_65G)
+        AGM_84D_Harpoon_AShM = (1, Weapons.AGM_84D_Harpoon_AShM)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile__ = (
+            1,
+            Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile__,
+        )
         Mk_82___500lb_GP_Bomb_LD = (1, Weapons.Mk_82___500lb_GP_Bomb_LD)
+        MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (
+            1,
+            Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD,
+        )
+        _3_Mk_82 = (1, Weapons._3_Mk_82)
+        _5_x_Mk_82___500lb_GP_Bombs_LD = (1, Weapons._5_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (
+            1,
+            Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD,
+        )
+        Mk_82_Snakeye___500lb_GP_Bomb_HD = (1, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
+        _3_Mk_82_Snakeye = (1, Weapons._3_Mk_82_Snakeye)
+        _5_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (
+            1,
+            Weapons._5_x_Mk_82_Snakeye___500lb_GP_Bomb_HD,
+        )
+        Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (
+            1,
+            Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD,
+        )
+        # ERRR {BRU41A_6*MK82AIR}
         Mk_83___1000lb_GP_Bomb_LD = (1, Weapons.Mk_83___1000lb_GP_Bomb_LD)
+        MER2_with_2_x_Mk_83___1000lb_GP_Bombs_LD = (
+            1,
+            Weapons.MER2_with_2_x_Mk_83___1000lb_GP_Bombs_LD,
+        )
+        # ERRR {BRU42A_3*MK83}
         Mk_84___2000lb_GP_Bomb_LD = (1, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (
             1,
@@ -65,16 +139,125 @@ class VSN_A6A(PlaneType):
             1,
             Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
         )
-
-    # ERRR {ac94375e-aa45-491e-858b-a8b93ee8b959}
-    # ERRR <CLEAN>
+        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+            1,
+            Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
+        )
+        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+            1,
+            Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
+        )
+        # ERRR {BRU42A_3*MK20_ROCKEYE}
+        # ERRR {BRU41A_6*MK20_ROCKEYE}
+        GBU_10___2000lb_Laser_Guided_Bomb = (
+            1,
+            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
+        )
+        GBU_12___500lb_Laser_Guided_Bomb = (1, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
+        GBU_16___1000lb_Laser_Guided_Bomb = (
+            1,
+            Weapons.GBU_16___1000lb_Laser_Guided_Bomb,
+        )
+        # ERRR {CBU-99}
+        ADM_141A_TALD = (1, Weapons.ADM_141A_TALD)
+        SUU_25_x_8_LUU_2___Target_Marker_Flares = (
+            1,
+            Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares,
+        )
+        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+            1,
+            Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
+        )
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            1,
+            Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            1,
+            Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
+        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            1,
+            Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            1,
+            Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
 
     class Pylon2:
         F_5_275Gal_Fuel_tank = (2, Weapons.F_5_275Gal_Fuel_tank)
         AIM_9M_Sidewinder_IR_AAM = (2, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9X_Sidewinder_IR_AAM = (2, Weapons.AIM_9X_Sidewinder_IR_AAM)
+        L_081_Fantasmagoria_ELINT_pod = (2, Weapons.L_081_Fantasmagoria_ELINT_pod)
+        LAU_7_with_AIM_9B_Sidewinder_IR_AAM = (
+            2,
+            Weapons.LAU_7_with_AIM_9B_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9J_Sidewinder_IR_AAM = (
+            2,
+            Weapons.LAU_7_with_AIM_9J_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9M_Sidewinder_IR_AAM = (
+            2,
+            Weapons.LAU_7_with_AIM_9M_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9P_Sidewinder_IR_AAM = (
+            2,
+            Weapons.LAU_7_with_AIM_9P_Sidewinder_IR_AAM,
+        )
+        AGM_45A_Shrike_ARM = (2, Weapons.AGM_45A_Shrike_ARM)
+        AGM_45B_Shrike_ARM__Imp_ = (2, Weapons.AGM_45B_Shrike_ARM__Imp_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile = (
+            2,
+            Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile,
+        )
+        LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (
+            2,
+            Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_,
+        )
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+            2,
+            Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_,
+        )
+        LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (
+            2,
+            Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_,
+        )
+        LAU_117_AGM_65G = (2, Weapons.LAU_117_AGM_65G)
+        AGM_84D_Harpoon_AShM = (2, Weapons.AGM_84D_Harpoon_AShM)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile__ = (
+            2,
+            Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile__,
+        )
+        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (
+            2,
+            Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_,
+        )
         Mk_82___500lb_GP_Bomb_LD = (2, Weapons.Mk_82___500lb_GP_Bomb_LD)
+        MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (
+            2,
+            Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD,
+        )
+        _3_Mk_82 = (2, Weapons._3_Mk_82)
+        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (
+            2,
+            Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD,
+        )
+        Mk_82_Snakeye___500lb_GP_Bomb_HD = (2, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
+        _3_Mk_82_Snakeye = (2, Weapons._3_Mk_82_Snakeye)
+        # ERRR {BRU41A_6*MK82_SNAKEYE}
+        Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (
+            2,
+            Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD,
+        )
+        # ERRR {BRU41A_6*MK82AIR}
         Mk_83___1000lb_GP_Bomb_LD = (2, Weapons.Mk_83___1000lb_GP_Bomb_LD)
+        MER2_with_2_x_Mk_83___1000lb_GP_Bombs_LD = (
+            2,
+            Weapons.MER2_with_2_x_Mk_83___1000lb_GP_Bombs_LD,
+        )
+        # ERRR {BRU42A_3*MK83}
         Mk_84___2000lb_GP_Bomb_LD = (2, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         MER6_with_6_x_Mk_82___500lb_GP_Bombs_LD = (
             2,
@@ -116,13 +299,66 @@ class VSN_A6A(PlaneType):
             2,
             Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
         )
-
-    # ERRR {ac94375e-aa45-491e-858b-a8b93ee8b959}
-    # ERRR <CLEAN>
+        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+            2,
+            Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
+        )
+        # ERRR {BRU42A_3*MK20_ROCKEYE}
+        # ERRR {BRU41A_6*MK20_ROCKEYE}
+        GBU_10___2000lb_Laser_Guided_Bomb = (
+            2,
+            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
+        )
+        GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
+        GBU_16___1000lb_Laser_Guided_Bomb = (
+            2,
+            Weapons.GBU_16___1000lb_Laser_Guided_Bomb,
+        )
+        # ERRR {CBU-99}
+        ADM_141A_TALD = (2, Weapons.ADM_141A_TALD)
+        SUU_25_x_8_LUU_2___Target_Marker_Flares = (
+            2,
+            Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares,
+        )
+        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+            2,
+            Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
+        )
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            2,
+            Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            2,
+            Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
+        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            2,
+            Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            2,
+            Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
 
     class Pylon3:
         F_5_275Gal_Fuel_tank = (3, Weapons.F_5_275Gal_Fuel_tank)
+        L_081_Fantasmagoria_ELINT_pod = (3, Weapons.L_081_Fantasmagoria_ELINT_pod)
+        Mercury_LLTV_Pod = (3, Weapons.Mercury_LLTV_Pod)
         Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
+        _3_Mk_82 = (3, Weapons._3_Mk_82)
+        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (
+            3,
+            Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD,
+        )
+        Mk_82_Snakeye___500lb_GP_Bomb_HD = (3, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
+        _3_Mk_82_Snakeye = (3, Weapons._3_Mk_82_Snakeye)
+        # ERRR {BRU41A_6*MK82_SNAKEYE}
+        Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (
+            3,
+            Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD,
+        )
+        # ERRR {BRU41A_6*MK82AIR}
         Mk_83___1000lb_GP_Bomb_LD = (3, Weapons.Mk_83___1000lb_GP_Bomb_LD)
         Mk_84___2000lb_GP_Bomb_LD = (3, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         MER6_with_6_x_Mk_82___500lb_GP_Bombs_LD = (
@@ -141,16 +377,97 @@ class VSN_A6A(PlaneType):
             3,
             Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD,
         )
-
-    # ERRR {ac94375e-aa45-491e-858b-a8b93ee8b959}
-    # ERRR <CLEAN>
+        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+            3,
+            Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
+        )
+        # ERRR {BRU42A_3*MK20_ROCKEYE}
+        # ERRR {BRU41A_6*MK20_ROCKEYE}
+        GBU_10___2000lb_Laser_Guided_Bomb = (
+            3,
+            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
+        )
+        GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
+        GBU_16___1000lb_Laser_Guided_Bomb = (
+            3,
+            Weapons.GBU_16___1000lb_Laser_Guided_Bomb,
+        )
+        # ERRR {CBU-99}
+        ADM_141A_TALD = (3, Weapons.ADM_141A_TALD)
 
     class Pylon4:
         F_5_275Gal_Fuel_tank = (4, Weapons.F_5_275Gal_Fuel_tank)
         AIM_9M_Sidewinder_IR_AAM = (4, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9X_Sidewinder_IR_AAM = (4, Weapons.AIM_9X_Sidewinder_IR_AAM)
+        L_081_Fantasmagoria_ELINT_pod = (4, Weapons.L_081_Fantasmagoria_ELINT_pod)
+        LAU_7_with_AIM_9B_Sidewinder_IR_AAM = (
+            4,
+            Weapons.LAU_7_with_AIM_9B_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9J_Sidewinder_IR_AAM = (
+            4,
+            Weapons.LAU_7_with_AIM_9J_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9M_Sidewinder_IR_AAM = (
+            4,
+            Weapons.LAU_7_with_AIM_9M_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9P_Sidewinder_IR_AAM = (
+            4,
+            Weapons.LAU_7_with_AIM_9P_Sidewinder_IR_AAM,
+        )
+        AGM_45A_Shrike_ARM = (4, Weapons.AGM_45A_Shrike_ARM)
+        AGM_45B_Shrike_ARM__Imp_ = (4, Weapons.AGM_45B_Shrike_ARM__Imp_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile = (
+            4,
+            Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile,
+        )
+        LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (
+            4,
+            Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_,
+        )
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+            4,
+            Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_,
+        )
+        LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (
+            4,
+            Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_,
+        )
+        LAU_117_AGM_65G = (4, Weapons.LAU_117_AGM_65G)
+        AGM_84D_Harpoon_AShM = (4, Weapons.AGM_84D_Harpoon_AShM)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile__ = (
+            4,
+            Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile__,
+        )
+        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (
+            4,
+            Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_,
+        )
         Mk_82___500lb_GP_Bomb_LD = (4, Weapons.Mk_82___500lb_GP_Bomb_LD)
+        MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (
+            4,
+            Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD,
+        )
+        _3_Mk_82 = (4, Weapons._3_Mk_82)
+        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (
+            4,
+            Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD,
+        )
+        Mk_82_Snakeye___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
+        _3_Mk_82_Snakeye = (4, Weapons._3_Mk_82_Snakeye)
+        # ERRR {BRU41A_6*MK82_SNAKEYE}
+        Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (
+            4,
+            Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD,
+        )
+        # ERRR {BRU41A_6*MK82AIR}
         Mk_83___1000lb_GP_Bomb_LD = (4, Weapons.Mk_83___1000lb_GP_Bomb_LD)
+        MER2_with_2_x_Mk_83___1000lb_GP_Bombs_LD = (
+            4,
+            Weapons.MER2_with_2_x_Mk_83___1000lb_GP_Bombs_LD,
+        )
+        # ERRR {BRU42A_3*MK83}
         Mk_84___2000lb_GP_Bomb_LD = (4, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         MER6_with_6_x_Mk_82___500lb_GP_Bombs_LD = (
             4,
@@ -192,16 +509,120 @@ class VSN_A6A(PlaneType):
             4,
             Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
         )
-
-    # ERRR {ac94375e-aa45-491e-858b-a8b93ee8b959}
-    # ERRR <CLEAN>
+        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+            4,
+            Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
+        )
+        # ERRR {BRU42A_3*MK20_ROCKEYE}
+        # ERRR {BRU41A_6*MK20_ROCKEYE}
+        GBU_10___2000lb_Laser_Guided_Bomb = (
+            4,
+            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
+        )
+        GBU_12___500lb_Laser_Guided_Bomb = (4, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
+        GBU_16___1000lb_Laser_Guided_Bomb = (
+            4,
+            Weapons.GBU_16___1000lb_Laser_Guided_Bomb,
+        )
+        # ERRR {CBU-99}
+        ADM_141A_TALD = (4, Weapons.ADM_141A_TALD)
+        SUU_25_x_8_LUU_2___Target_Marker_Flares = (
+            4,
+            Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares,
+        )
+        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+            4,
+            Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
+        )
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            4,
+            Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            4,
+            Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
+        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            4,
+            Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            4,
+            Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
 
     class Pylon5:
         F_5_275Gal_Fuel_tank = (5, Weapons.F_5_275Gal_Fuel_tank)
         AIM_9M_Sidewinder_IR_AAM = (5, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9X_Sidewinder_IR_AAM = (5, Weapons.AIM_9X_Sidewinder_IR_AAM)
+        LAU_7_with_AIM_9B_Sidewinder_IR_AAM = (
+            5,
+            Weapons.LAU_7_with_AIM_9B_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9J_Sidewinder_IR_AAM = (
+            5,
+            Weapons.LAU_7_with_AIM_9J_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9M_Sidewinder_IR_AAM = (
+            5,
+            Weapons.LAU_7_with_AIM_9M_Sidewinder_IR_AAM,
+        )
+        LAU_7_with_AIM_9P_Sidewinder_IR_AAM = (
+            5,
+            Weapons.LAU_7_with_AIM_9P_Sidewinder_IR_AAM,
+        )
+        AGM_45A_Shrike_ARM = (5, Weapons.AGM_45A_Shrike_ARM)
+        AGM_45B_Shrike_ARM__Imp_ = (5, Weapons.AGM_45B_Shrike_ARM__Imp_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile = (
+            5,
+            Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile,
+        )
+        LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (
+            5,
+            Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_,
+        )
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+            5,
+            Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_,
+        )
+        LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (
+            5,
+            Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_,
+        )
+        LAU_117_AGM_65G = (5, Weapons.LAU_117_AGM_65G)
+        AGM_84D_Harpoon_AShM = (5, Weapons.AGM_84D_Harpoon_AShM)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile__ = (
+            5,
+            Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile__,
+        )
         Mk_82___500lb_GP_Bomb_LD = (5, Weapons.Mk_82___500lb_GP_Bomb_LD)
+        MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (
+            5,
+            Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD,
+        )
+        _3_Mk_82 = (5, Weapons._3_Mk_82)
+        _5_x_Mk_82___500lb_GP_Bombs_LD = (5, Weapons._5_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD = (
+            5,
+            Weapons.BRU_41A_with_6_x_Mk_82___500lb_GP_Bomb_LD,
+        )
+        Mk_82_Snakeye___500lb_GP_Bomb_HD = (5, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
+        _3_Mk_82_Snakeye = (5, Weapons._3_Mk_82_Snakeye)
+        _5_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (
+            5,
+            Weapons._5_x_Mk_82_Snakeye___500lb_GP_Bomb_HD,
+        )
+        Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (
+            5,
+            Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD,
+        )
+        # ERRR {BRU41A_6*MK82AIR}
         Mk_83___1000lb_GP_Bomb_LD = (5, Weapons.Mk_83___1000lb_GP_Bomb_LD)
+        MER2_with_2_x_Mk_83___1000lb_GP_Bombs_LD = (
+            5,
+            Weapons.MER2_with_2_x_Mk_83___1000lb_GP_Bombs_LD,
+        )
+        # ERRR {BRU42A_3*MK83}
         Mk_84___2000lb_GP_Bomb_LD = (5, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (
             5,
@@ -235,9 +656,51 @@ class VSN_A6A(PlaneType):
             5,
             Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
         )
-
-    # ERRR {ac94375e-aa45-491e-858b-a8b93ee8b959}
-    # ERRR <CLEAN>
+        Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+            5,
+            Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
+        )
+        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+            5,
+            Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets,
+        )
+        # ERRR {BRU42A_3*MK20_ROCKEYE}
+        # ERRR {BRU41A_6*MK20_ROCKEYE}
+        GBU_10___2000lb_Laser_Guided_Bomb = (
+            5,
+            Weapons.GBU_10___2000lb_Laser_Guided_Bomb,
+        )
+        GBU_12___500lb_Laser_Guided_Bomb = (5, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
+        GBU_16___1000lb_Laser_Guided_Bomb = (
+            5,
+            Weapons.GBU_16___1000lb_Laser_Guided_Bomb,
+        )
+        # ERRR {CBU-99}
+        ADM_141A_TALD = (5, Weapons.ADM_141A_TALD)
+        SUU_25_x_8_LUU_2___Target_Marker_Flares = (
+            5,
+            Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares,
+        )
+        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+            5,
+            Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG,
+        )
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            5,
+            Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            5,
+            Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
+        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+            5,
+            Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+        )
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+            5,
+            Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+        )
 
     pylons: Set[int] = {1, 2, 3, 4, 5}
 


### PR DESCRIPTION
Enabled Adecarcer's modified hardpoint options for the A-6A Intruder mod. This will, for instance, fix the MER bomb racks which have the "missing texture" material in the stock version of the mod. It will also allow mounting some weapons which are more appropriate for the A-6E variant of the aircraft. While not historically and technically accurate, this will allow employing the aircraft in a role which is closer to the EA-6B or A-6E, should the user wish to do so. The EA-6B mod is AI-only, so this will grant a player-flyable option. The use of custom loadouts is recommended.