### PR TITLE
Settings doctrine page

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 * **[Plugins]** Added "EWR Jammer" plugin (only for humans, may change in the future).
 * **[Campaign]** New campaign (Operation Desert Sabre) by Chimiste
 * **[Plugins]** Updated CTLD to latest released version
+* **[Options]** Renamed Maximum frontline length -> Maximum frontline width.
 
 ## Fixes
 * **[New Game Wizard]** Settings would not persist when going back to a previous page (obsolete due to overhaul).

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,17 @@
 * **[Campaign Design]** Ability to define SCENERY REMOVE OBJECTS ZONE triggers with the roadbase objects in campaign miz. This might not work reliably in multiplayer due to DCS issues. FARPs can be used to remove scenery objects in multiplayer.
 * **[Campaign Management]** Improved squadron retreat logic at longer ranges.
 * **[Options]** Ability to load & save your settings.
+* **[Options]** Added a separate Doctrine page in settings with the following new options:
+  * Minimum number of aircraft for autoplanner to plan OCA packages against 
+  * Airbase threat range (nmi)
+  * TARCAP threat buffer distance (nmi)
+  * AEW&C threat buffer distance (nmi)
+  * Theater tanker threat buffer distance (nmi)
+* **[Options]** Improved the option to configure OPFOR autoplanner aggressiveness. The AI might now take even more risks and plan missions against defended targets.
+* Added three new options in Settings:
+  * Autoplanner plans refueling flights for Strike packages
+  * Autoplanner plans refueling flights for OCA packages
+  * Autoplanner plans refueling flights for DEAD packages
 * **[UI]** Added fuel selector in flight's edit window.
 * **[Plugins]** Expose Splash Damage's "game_messages" option and set its default to false.
 * **[Mission Generation]** Improved AI SEAD capabilities, allowing for mixed loadouts using Decoys, ARMs & ASMs.
@@ -39,7 +50,7 @@
 * **[Mission Generation]** Unused aircraft are no longer claimed, fixing a bug where these aircraft would no longer be available after aborting the mission.
 * **[Mission Generation]** Fixed (potential) bug in helipad assignments at FOBs/FARPs.
 * **[Mission Generation]** Fix AI immediately returning to base when forced to air-start due to insufficient parking space.
-
+* **[New Game Wizard]** Fixed a bug where F-16Ds were not correctly removed from the faction when the F-16I/F-16D mod was not selected
 
 # Retribution v1.1.1  (hotfix)
 

--- a/changelog.md
+++ b/changelog.md
@@ -51,7 +51,7 @@
 * **[Mission Generation]** Unused aircraft are no longer claimed, fixing a bug where these aircraft would no longer be available after aborting the mission.
 * **[Mission Generation]** Fixed (potential) bug in helipad assignments at FOBs/FARPs.
 * **[Mission Generation]** Fix AI immediately returning to base when forced to air-start due to insufficient parking space.
-* **[New Game Wizard]** Fixed a bug where F-16Ds were not correctly removed from the faction when the F-16I/F-16D mod was not selected
+* **[Modding]** Fixed a bug where F-16Ds were not correctly removed from the faction when the F-16I/F-16D mod was not selected
 
 # Retribution v1.1.1  (hotfix)
 

--- a/game/ato/flightplans/aewc.py
+++ b/game/ato/flightplans/aewc.py
@@ -48,7 +48,9 @@ class Builder(IBuilder[AewcFlightPlan, PatrollingLayout]):
         orbit_heading = heading_to_threat_boundary
 
         # Station 80nm outside the threat zone.
-        threat_buffer = nautical_miles(80)
+        threat_buffer = nautical_miles(
+            self.flight.coalition.game.settings.aewc_threat_buffer_min_distance
+        )
         if self.threat_zones.threatened(location.position):
             orbit_distance = distance_to_threat + threat_buffer
         else:

--- a/game/ato/flightplans/capbuilder.py
+++ b/game/ato/flightplans/capbuilder.py
@@ -60,7 +60,9 @@ class CapBuilder(IBuilder[FlightPlanT, LayoutT], ABC):
             # distance from the nearest enemy airbase, but since they are by
             # definition in enemy territory they can't avoid the threat zone
             # without being useless.
-            min_distance_from_enemy = nautical_miles(20)
+            min_distance_from_enemy = nautical_miles(
+                self.coalition.game.settings.tarcap_threat_buffer_min_distance
+            )
             distance_to_airfield = meters(
                 closest_airfield.position.distance_to_point(
                     self.package.target.position

--- a/game/ato/flightplans/cas.py
+++ b/game/ato/flightplans/cas.py
@@ -53,7 +53,7 @@ class CasFlightPlan(PatrollingFlightPlan[CasLayout], UiZoneDisplay):
 
     @property
     def engagement_distance(self) -> Distance:
-        max_length = self.flight.coalition.game.settings.max_frontline_length * 1000
+        max_length = self.flight.coalition.game.settings.max_frontline_width * 1000
         return meters(max_length) / 2
 
     @property

--- a/game/ato/flightplans/theaterrefueling.py
+++ b/game/ato/flightplans/theaterrefueling.py
@@ -36,7 +36,9 @@ class Builder(IBuilder[TheaterRefuelingFlightPlan, PatrollingLayout]):
         orbit_heading = heading_to_threat_boundary
 
         # Station 70nm outside the threat zone.
-        threat_buffer = nautical_miles(70)
+        threat_buffer = nautical_miles(
+            self.flight.coalition.game.settings.tanker_threat_buffer_min_distance
+        )
         if self.threat_zones.threatened(location.position):
             orbit_distance = distance_to_threat + threat_buffer
         else:

--- a/game/commander/tasks/primitive/dead.py
+++ b/game/commander/tasks/primitive/dead.py
@@ -44,3 +44,5 @@ class PlanDead(PackagePlanningTask[IadsGroundObject]):
             self.propose_flight(FlightType.SEAD, 2)
         self.propose_flight(FlightType.SEAD_ESCORT, 2, EscortType.Sead)
         self.propose_flight(FlightType.ESCORT, 2, EscortType.AirToAir)
+        if self.target.control_point.coalition.game.settings.autoplan_tankers_for_dead:
+            self.propose_flight(FlightType.REFUELING, 1)

--- a/game/commander/tasks/primitive/oca.py
+++ b/game/commander/tasks/primitive/oca.py
@@ -29,3 +29,5 @@ class PlanOcaStrike(PackagePlanningTask[ControlPoint]):
         if self.aircraft_cold_start:
             self.propose_flight(FlightType.OCA_AIRCRAFT, 2)
         self.propose_common_escorts()
+        if self.target.coalition.game.settings.autoplan_tankers_for_oca:
+            self.propose_flight(FlightType.REFUELING, 1)

--- a/game/commander/tasks/primitive/strike.py
+++ b/game/commander/tasks/primitive/strike.py
@@ -24,3 +24,5 @@ class PlanStrike(PackagePlanningTask[TheaterGroundObject]):
         tgt_count = self.target.alive_unit_count
         self.propose_flight(FlightType.STRIKE, min(4, (tgt_count // 2) + 1))
         self.propose_common_escorts()
+        if self.target.coalition.game.settings.autoplan_tankers_for_strike:
+            self.propose_flight(FlightType.REFUELING, 1)

--- a/game/commander/theaterstate.py
+++ b/game/commander/theaterstate.py
@@ -173,7 +173,11 @@ class TheaterState(WorldState["TheaterState"]):
                 cp: BattlePositions.for_control_point(cp)
                 for cp in ordered_capturable_points
             },
-            oca_targets=list(finder.oca_targets(min_aircraft=20)),
+            oca_targets=list(
+                finder.oca_targets(
+                    min_aircraft=game.settings.oca_target_autoplanner_min_aircraft_count
+                )
+            ),
             strike_targets=list(finder.strike_targets()),
             enemy_barcaps=list(game.theater.control_points_for(not player)),
             threat_zones=game.threat_zone_for(not player),

--- a/game/factions/faction.py
+++ b/game/factions/faction.py
@@ -330,10 +330,10 @@ class Faction:
             self.remove_aircraft("F-15D")
         if not mod_settings.f_16_idf:
             self.remove_aircraft("F-16I")
-            self.remove_aircraft("F_16D_52")
-            self.remove_aircraft("F_16D_50")
-            self.remove_aircraft("F_16D_50_NS")
-            self.remove_aircraft("F_16D_52_NS")
+            self.remove_aircraft("F-16D_52")
+            self.remove_aircraft("F-16D_50")
+            self.remove_aircraft("F-16D_50_NS")
+            self.remove_aircraft("F-16D_52_NS")
             self.remove_aircraft("F-16D_Barak_30")
             self.remove_aircraft("F-16D_Barak_40")
         else:

--- a/game/missiongenerator/frontlineconflictdescription.py
+++ b/game/missiongenerator/frontlineconflictdescription.py
@@ -64,7 +64,7 @@ class FrontLineConflictDescription:
         attack_heading = frontline.blue_forward_heading
         position = cls.find_ground_position(
             frontline.position,
-            settings.max_frontline_length * 1000,
+            settings.max_frontline_width * 1000,
             attack_heading.right,
             theater,
         )
@@ -82,13 +82,13 @@ class FrontLineConflictDescription:
         right_heading = heading.right
         left_position = cls.extend_ground_position(
             center_position,
-            int(settings.max_frontline_length * 1000 / 2),
+            int(settings.max_frontline_width * 1000 / 2),
             left_heading,
             theater,
         )
         right_position = cls.extend_ground_position(
             center_position,
-            int(settings.max_frontline_length * 1000 / 2),
+            int(settings.max_frontline_width * 1000 / 2),
             right_heading,
             theater,
         )

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -46,6 +46,9 @@ PILOTS_AND_SQUADRONS_SECTION = "Pilots and Squadrons"
 HQ_AUTOMATION_SECTION = "HQ Automation"
 FLIGHT_PLANNER_AUTOMATION = "Flight Planner Automation"
 
+CAMPAIGN_DOCTRINE_PAGE = "Campaign Doctrine"
+DOCTRINE_DISTANCES_SECTION = "Doctrine distances"
+
 MISSION_GENERATOR_PAGE = "Mission Generator"
 
 GAMEPLAY_SECTION = "Gameplay"
@@ -192,6 +195,100 @@ class Settings:
             "preferred even if there is a closer squadron capable of the mission as a"
             "secondary task. Expect longer flights, but squadrons will be more often "
             "assigned to their primary task."
+        ),
+    )
+    autoplan_tankers_for_strike: bool = boolean_option(
+        "Autoplanner plans refueling flights for Strike packages",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=True,
+        invert=False,
+        detail=(
+            "If checked, the autoplanner will include tankers in Strike packages, "
+            "provided the faction has access to them."
+        ),
+    )
+    autoplan_tankers_for_oca: bool = boolean_option(
+        "Autoplanner plans refueling flights for OCA packages",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=True,
+        invert=False,
+        detail=(
+            "If checked, the autoplanner will include tankers in OCA packages, "
+            "provided the faction has access to them."
+        ),
+    )
+    autoplan_tankers_for_dead: bool = boolean_option(
+        "Autoplanner plans refueling flights for DEAD packages",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=True,
+        invert=False,
+        detail=(
+            "If checked, the autoplanner will include tankers in DEAD packages, "
+            "provided the faction has access to them."
+        ),
+    )
+    oca_target_autoplanner_min_aircraft_count: int = bounded_int_option(
+        "Minimum number of aircraft for autoplanner to plan OCA packages against",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=20,
+        min=0,
+        max=100,
+        detail=(
+            "How many aircraft there has to be at an airfield for "
+            "the autoplanner to plan an OCA strike against it."
+        ),
+    )
+    opfor_autoplanner_aggressiveness: int = bounded_int_option(
+        "OPFOR autoplanner aggressiveness (%)",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=20,
+        min=0,
+        max=100,
+    )
+    airbase_threat_range: int = bounded_int_option(
+        "Airbase threat range (nmi)",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=DOCTRINE_DISTANCES_SECTION,
+        default=10,
+        min=0,
+        max=300,
+    )
+    tarcap_threat_buffer_min_distance: int = bounded_int_option(
+        "TARCAP threat buffer distance (nmi)",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=DOCTRINE_DISTANCES_SECTION,
+        default=20,
+        min=0,
+        max=100,
+        detail=("How close to known threats will the TARCAP racetrack " "extend."),
+    )
+    aewc_threat_buffer_min_distance: int = bounded_int_option(
+        "AEW&C threat buffer distance (nmi)",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=DOCTRINE_DISTANCES_SECTION,
+        default=80,
+        min=0,
+        max=300,
+        detail=(
+            "How far, at minimum, will AEW&C racetracks be planned"
+            "to known threat zones."
+        ),
+    )
+    tanker_threat_buffer_min_distance: int = bounded_int_option(
+        "Theater tanker threat buffer distance (nmi)",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=DOCTRINE_DISTANCES_SECTION,
+        default=70,
+        min=0,
+        max=300,
+        detail=(
+            "How far, at minimum, will theater tanker racetracks be "
+            "planned to known threat zones."
         ),
     )
     # Pilots and Squadrons

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -602,8 +602,8 @@ class Settings:
         max=150,
     )
     # Mission specific
-    max_frontline_length: int = bounded_int_option(
-        "Maximum frontline length (km)",
+    max_frontline_width: int = bounded_int_option(
+        "Maximum frontline width (km)",
         page=MISSION_GENERATOR_PAGE,
         section=GAMEPLAY_SECTION,
         default=80,

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -231,7 +231,7 @@ class Settings:
         ),
     )
     oca_target_autoplanner_min_aircraft_count: int = bounded_int_option(
-        "Minimum number of aircraft for autoplanner to plan OCA packages against",
+        "Minimum number of aircraft (at vulnerable airfields) for autoplanner to plan OCA packages against",
         page=CAMPAIGN_DOCTRINE_PAGE,
         section=GENERAL_SECTION,
         default=20,
@@ -249,14 +249,23 @@ class Settings:
         default=20,
         min=0,
         max=100,
+        detail=(
+            "Chance (larger number -> higher chance) that the OPFOR AI "
+            "autoplanner will take risks and plan flights against targets "
+            "within threatened airspace."
+        ),
     )
     airbase_threat_range: int = bounded_int_option(
         "Airbase threat range (nmi)",
         page=CAMPAIGN_DOCTRINE_PAGE,
         section=DOCTRINE_DISTANCES_SECTION,
-        default=10,
+        default=100,
         min=0,
         max=300,
+        detail=(
+            "Will impact both defensive (BARCAP) and offensive flights. Also has a performance impact,"
+            "lower threat range generally means less BARCAPs are planned."
+        ),
     )
     tarcap_threat_buffer_min_distance: int = bounded_int_option(
         "TARCAP threat buffer distance (nmi)",
@@ -265,7 +274,7 @@ class Settings:
         default=20,
         min=0,
         max=100,
-        detail=("How close to known threats will the TARCAP racetrack " "extend."),
+        detail=("How close to known threats will the TARCAP racetrack extend."),
     )
     aewc_threat_buffer_min_distance: int = bounded_int_option(
         "AEW&C threat buffer distance (nmi)",
@@ -600,19 +609,6 @@ class Settings:
         default=80,
         min=1,
         max=100,
-    )
-    opfor_autoplanner_aggressiveness: int = bounded_int_option(
-        "OPFOR autoplanner aggressiveness (%)",
-        page=MISSION_GENERATOR_PAGE,
-        section=GAMEPLAY_SECTION,
-        default=20,
-        min=0,
-        max=100,
-        detail=(
-            "Chance (larger number -> higher chance) that the OPFOR AI "
-            "autoplanner will take risks and plan flights against targets "
-            "within threatened airspace."
-        ),
     )
     game_masters_count: int = bounded_int_option(
         "Number of game masters",

--- a/game/version.py
+++ b/game/version.py
@@ -172,7 +172,7 @@ VERSION = _build_version_string()
 #: * Support for scenery objectives defined by quad zones.
 #: * Campaign designers can now define almost all settings:
 #:    `settings:`
-#:    `  max_frontline_length: 25`        (in km)
+#:    `  max_frontline_width: 25`        (in km)
 #:    `  perf_culling_distance: 35`    (in km)
 #:
 #: Version 10.6

--- a/qt_ui/uiconstants.py
+++ b/qt_ui/uiconstants.py
@@ -77,6 +77,7 @@ def load_icons():
         "./resources/ui/misc/" + get_theme_icons() + "/money_icon.png"
     )
     ICONS["Campaign Management"] = ICONS["Money"]
+    ICONS["Campaign Doctrine"] = QPixmap("./resources/ui/misc/blue-sam.png")
     ICONS["PassTurn"] = QPixmap(
         "./resources/ui/misc/" + get_theme_icons() + "/hourglass.png"
     )

--- a/resources/campaigns/Operation-Desert-Sabre.yaml
+++ b/resources/campaigns/Operation-Desert-Sabre.yaml
@@ -15,7 +15,7 @@ recommended_player_income_multiplier: 1.0
 recommended_enemy_income_multiplier: 1.0
 advanced_iads: false
 settings:
-  max_frontline_length: 30
+  max_frontline_width: 30
   player_income_multiplier: 1.5
 squadrons:
   CVN-74 John Stennis:

--- a/resources/campaigns/WRL_AssaultonDamascus.yaml
+++ b/resources/campaigns/WRL_AssaultonDamascus.yaml
@@ -15,7 +15,7 @@ recommended_player_income_multiplier: 5.0
 recommended_enemy_income_multiplier: 1.0
 advanced_iads: false
 settings:
-  max_frontline_length: 30
+  max_frontline_width: 30
 squadrons:
   CVN-74 John Stennis:
     - primary: BARCAP

--- a/resources/campaigns/WRL_Battle4Georgia.yaml
+++ b/resources/campaigns/WRL_Battle4Georgia.yaml
@@ -15,7 +15,7 @@ recommended_player_income_multiplier: 5.0
 recommended_enemy_income_multiplier: 1.0
 advanced_iads: false
 settings:
-  max_frontline_length: 30
+  max_frontline_width: 30
 squadrons:
   Blue CV-1:
     - primary: BARCAP

--- a/resources/campaigns/WRL_Battle4area51.yaml
+++ b/resources/campaigns/WRL_Battle4area51.yaml
@@ -14,7 +14,7 @@ recommended_enemy_money: 2000
 recommended_player_income_multiplier: 5.0
 recommended_enemy_income_multiplier: 1.0
 settings:
-  max_frontline_length: 20
+  max_frontline_width: 20
 advanced_iads: true # Campaign has connection_nodes / power_sources / command_centers
 iads_config:
 #COMMAND

--- a/resources/campaigns/WRL_Kutaisi2Vaziani.yaml
+++ b/resources/campaigns/WRL_Kutaisi2Vaziani.yaml
@@ -14,7 +14,7 @@ recommended_enemy_money: 2000
 recommended_player_income_multiplier: 5.0
 recommended_enemy_income_multiplier: 1.0
 settings:
-  max_frontline_length: 30
+  max_frontline_width: 30
 advanced_iads: true # Campaign has connection_nodes / power_sources / command_centers
 iads_config:
 #REDFOR BASE DEFENSE

--- a/resources/campaigns/WRL_PG_Wargames.yaml
+++ b/resources/campaigns/WRL_PG_Wargames.yaml
@@ -15,7 +15,7 @@ recommended_player_income_multiplier: 5.0
 recommended_enemy_income_multiplier: 1.0
 advanced_iads: false
 settings:
-  max_frontline_length: 30
+  max_frontline_width: 30
 squadrons:
 #Bandar Abbas Intl
   2:


### PR DESCRIPTION
Added a separate Doctrine page in settings with the following new options:
- Minimum number of aircraft for autoplanner to plan OCA packages against
- Airbase threat range (nmi)
- TARCAP threat buffer distance (nmi)
- AEW&C threat buffer distance (nmi)
- Theater tanker threat buffer distance (nmi)

Added three new options in Settings:
- Autoplanner plans refueling flights for Strike packages
- Autoplanner plans refueling flights for OCA packages
- Autoplanner plans refueling flights for DEAD packages

Implemented handling for the OPFOR autoplanner aggressiveness in objectivefinder.py vulnerable_control_points().

Fixed a bug in faction.py where F-16Ds were not correctly removed from the faction when the F-16I/F-16D mod was not selected.

Renamed Maximum frontline length -> Maximum frontline width.