### PR TITLE
Restored TheaterGroundObject handling in antishipingress.py

### DIFF
--- a/game/missiongenerator/aircraft/waypoints/antishipingress.py
+++ b/game/missiongenerator/aircraft/waypoints/antishipingress.py
@@ -3,7 +3,7 @@ import logging
 from dcs.point import MovingPoint
 from dcs.task import AttackGroup, OptFormation, WeaponType
 
-from game.theater import NavalControlPoint
+from game.theater import NavalControlPoint, TheaterGroundObject
 from .pydcswaypointbuilder import PydcsWaypointBuilder
 
 
@@ -17,6 +17,9 @@ class AntiShipIngressBuilder(PydcsWaypointBuilder):
             carrier_name = target.get_carrier_group_name()
             if carrier_name:
                 group_names.append(carrier_name)
+        elif isinstance(target, TheaterGroundObject):
+            for group in target.groups:
+                group_names.append(group.group_name)
         else:
             logging.error(
                 "Unexpected target type for Anti-Ship mission: %s",


### PR DESCRIPTION
Restores handling of TheaterGroundObject targets in antishipingress.py This is needed when anti-ship missions are planned against other ship groups than NavalControlPoints (carrier groups or LHA strike groups).