### PR TITLE
Settings option: Generate SCENERY REMOVE OBJECTS ZONE triggers at roadbase

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * **[Campaign Design]** Ability to define almost all possible settings in the campaign's yaml file.
 * **[Campaign Design]** Ability to add roadbases and/or ground spawns to campaigns.
 * **[Campaign Design]** Ability to define SCENERY REMOVE OBJECTS ZONE triggers with the roadbase objects in campaign miz. This might not work reliably in multiplayer due to DCS issues. FARPs can be used to remove scenery objects in multiplayer.
+* **[Options]** Implemented an option in settings to disable the above SCENERY REMOVE OBJECTS ZONE triggers.
 * **[Campaign Management]** Improved squadron retreat logic at longer ranges.
 * **[Options]** Ability to load & save your settings.
 * **[Options]** Added a separate Doctrine page in settings with the following new options:

--- a/game/missiongenerator/triggergenerator.py
+++ b/game/missiongenerator/triggergenerator.py
@@ -250,11 +250,12 @@ class TriggerGenerator:
         self._set_allegiances(player_coalition, enemy_coalition)
         self._gen_markers()
         self._generate_capture_triggers(player_coalition, enemy_coalition)
-        try:
-            self._generate_clear_statics_trigger(self.game.scenery_clear_zones)
-            self.game.scenery_clear_zones.clear()
-        except AttributeError:
-            logging.info(f"Unable to create Clear Statics triggers")
+        if self.game.settings.ground_start_scenery_remove_triggers:
+            try:
+                self._generate_clear_statics_trigger(self.game.scenery_clear_zones)
+                self.game.scenery_clear_zones.clear()
+            except AttributeError:
+                logging.info(f"Unable to create Clear Statics triggers")
 
     @classmethod
     def get_capture_zone_flag(cls) -> int:

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -668,6 +668,16 @@ class Settings:
             "AI will always air-start from these bases (due to DCS limitation)."
         ),
     )
+    ground_start_scenery_remove_triggers: bool = boolean_option(
+        "Generate SCENERY REMOVE OBJECTS ZONE triggers at roadbase first waypoints",
+        MISSION_GENERATOR_PAGE,
+        GAMEPLAY_SECTION,
+        default=True,
+        detail=(
+            "Can be used to remove lightposts and other obstacles from roadbase runways."
+            "Might not work in DCS multiplayer."
+        ),
+    )
     ground_start_trucks: bool = boolean_option(
         "Spawn trucks at ground spawns in airbases instead of FARP statics",
         MISSION_GENERATOR_PAGE,


### PR DESCRIPTION
Implemented an option in settings to disable or enable the SCENERY REMOVE OBJECTS ZONE triggers generated at roadbases (at the first waypoint).