### PR TITLE
USS Samuel Chase class fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * **[New Game Wizard]** Faction selection overview doesn't update when inverting map
 * **[Payloads]** Added/Updated (missing) payloads
 * **[Aircraft Tasking]** Revised aircraft tasking, filtering out incompatible tasks for several aircraft
+* **[Data]** Corrected the class of the USS Samuel Chase from Logistics to LandingShip, in order to prevent it being spawned as part of AAA sites.
 
 # Retribution v1.2.1 (hotfix)
 

--- a/resources/units/ships/USS_Samuel_Chase.yaml
+++ b/resources/units/ships/USS_Samuel_Chase.yaml
@@ -1,4 +1,4 @@
-class: Logistics
+class: LandingShip
 price: 0
 variants:
   LS Samuel Chase: null


### PR DESCRIPTION
Corrected the class of the WWII asset pack ship USS Samuel Chase from Logistics (ground unit class) to LandingShip, in order to prevent it being spawned as part of AAA sites.