### PR TITLE
Convert OPFOR untasked flights into Client slots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
 * **[Modding]** Custom weapons injection system (definition in aircraft's yaml file)
 * **[Payload Editor]** Ability to save/back-up payloads
 * **[Options]** New option in Settings: CAS engagement range (nmi)
+* **[Options]** New option in Settings: Convert untasked OPFOR aircraft into client slots
+* **[Options]** Split the **Disable idle aircraft at airfields** setting into **Disable untasked BLUFOR aircraft at airfields** and **Disable untasked OPFOR aircraft at airfields**.
 
 ## Fixes
 * **[Mission Generation]** Anti-ship strikes should use "group attack" in their attack-task

--- a/game/missiongenerator/aircraft/flightgroupspawner.py
+++ b/game/missiongenerator/aircraft/flightgroupspawner.py
@@ -108,6 +108,11 @@ class FlightGroupSpawner:
                 name=namegen.next_aircraft_name(self.country, self.flight),
                 cp=self.flight.squadron.location,
             )
+        elif isinstance(self.flight.squadron.location, Fob):
+            group = self._generate_at_cp_ground_spawn(
+                name=namegen.next_aircraft_name(self.country, self.flight),
+                cp=self.flight.squadron.location,
+            )
         elif isinstance(self.flight.squadron.location, Airfield):
             group = self._generate_at_airfield(
                 name=namegen.next_aircraft_name(self.country, self.flight),

--- a/game/missiongenerator/missiongenerator.py
+++ b/game/missiongenerator/missiongenerator.py
@@ -259,11 +259,10 @@ class MissionGenerator:
             self.game.red.ato,
             tgo_generator.runways,
         )
-        if not self.game.settings.perf_disable_idle_aircraft:
-            aircraft_generator.spawn_unused_aircraft(
-                self.p_country,
-                self.e_country,
-            )
+        aircraft_generator.spawn_unused_aircraft(
+            self.p_country,
+            self.e_country,
+        )
 
         self.mission_data.flights = aircraft_generator.flights
 

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -589,6 +589,16 @@ class Settings:
             "option only allows the player to wait on the ground.</strong>"
         ),
     )
+    untasked_opfor_client_slots: bool = boolean_option(
+        "Convert untasked OPFOR aircraft into client slots",
+        page=MISSION_GENERATOR_PAGE,
+        section=GAMEPLAY_SECTION,
+        default=False,
+        detail=(
+            "Warning: Enabling this will significantly reduce the number of "
+            "targets available for OCA/Aircraft missions."
+        ),
+    )
     atflir_autoswap: bool = boolean_option(
         "Auto-swap ATFLIR to LITENING",
         MISSION_GENERATOR_PAGE,
@@ -802,8 +812,14 @@ class Settings:
         section=PERFORMANCE_SECTION,
         default=True,
     )
-    perf_disable_idle_aircraft: bool = boolean_option(
-        "Disable idle aircraft at airfields",
+    perf_disable_untasked_blufor_aircraft: bool = boolean_option(
+        "Disable untasked BLUFOR aircraft at airfields",
+        page=MISSION_GENERATOR_PAGE,
+        section=PERFORMANCE_SECTION,
+        default=False,
+    )
+    perf_disable_untasked_opfor_aircraft: bool = boolean_option(
+        "Disable untasked OPFOR aircraft at airfields",
         page=MISSION_GENERATOR_PAGE,
         section=PERFORMANCE_SECTION,
         default=False,


### PR DESCRIPTION
Added a new option in settings: Convert untasked OPFOR aircraft into client slots. This option will essentially convert the campaign into a sort of team vs. team engagement. There is still no way to plan the OPFOR missions, and there are no guarantees that there even will be any untasked aircraft available for players.

Split the Disable idle aircraft at airfields setting into Disable untasked BLUFOR aircraft at airfields and Disable untasked OPFOR aircraft at airfields.