### PR TITLE
AI unlimited fuel initial implementation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
 * **[COMMs]** Ability to set a specific callsign to a flight.
 * **[Mission Generator]** Channel terrain fix on exclusion zones, sea zones and inclusion zones
 * **[Options]** Cheat-option for accessing Air Wing Config Dialog after campaign start
+* **[Options]** Option to enable unlimited fuel for AI (player and non-player flights)
 
 ## Fixes
 * **[Mission Generation]** Anti-ship strikes should use "group attack" in their attack-task

--- a/game/missiongenerator/aircraft/aircraftbehavior.py
+++ b/game/missiongenerator/aircraft/aircraftbehavior.py
@@ -94,7 +94,7 @@ class AircraftBehavior:
         restrict_jettison: Optional[bool] = None,
         mission_uses_gun: bool = True,
         rtb_on_bingo: bool = True,
-        ai_unlimited_fuel: bool = None,
+        ai_unlimited_fuel: Optional[bool] = None,
     ) -> None:
         group.points[0].tasks.clear()
         if ai_unlimited_fuel is None:

--- a/game/missiongenerator/aircraft/aircraftbehavior.py
+++ b/game/missiongenerator/aircraft/aircraftbehavior.py
@@ -94,7 +94,7 @@ class AircraftBehavior:
         restrict_jettison: Optional[bool] = None,
         mission_uses_gun: bool = True,
         rtb_on_bingo: bool = True,
-        ai_unlimited_fuel: bool = True,
+        ai_unlimited_fuel: bool = False,
     ) -> None:
         group.points[0].tasks.clear()
         group.points[0].tasks.append(OptReactOnThreat(react_on_threat))
@@ -123,7 +123,7 @@ class AircraftBehavior:
 
         # Activate AI unlimited fuel, based either on the argument or the setting
         if ai_unlimited_fuel:
-            # Force AI unlimited fuel for the flight
+            # If the ai_unlimited_fuel argument is passed : force AI unlimited fuel for the flight, no matter
             group.points[0].tasks.insert(0, SetUnlimitedFuelCommand(True))
         elif flight.squadron.coalition.game.settings.ai_unlimited_fuel:
             # If this is a user flight and the setting is checked : add task at first waypoint.

--- a/game/missiongenerator/aircraft/aircraftbehavior.py
+++ b/game/missiongenerator/aircraft/aircraftbehavior.py
@@ -26,6 +26,7 @@ from dcs.task import (
     MainTask,
     PinpointStrike,
     AFAC,
+    SetUnlimitedFuelCommand,
 )
 from dcs.unitgroup import FlyingGroup
 
@@ -93,6 +94,7 @@ class AircraftBehavior:
         restrict_jettison: Optional[bool] = None,
         mission_uses_gun: bool = True,
         rtb_on_bingo: bool = True,
+        ai_unlimited_fuel: bool = True,
     ) -> None:
         group.points[0].tasks.clear()
         group.points[0].tasks.append(OptReactOnThreat(react_on_threat))
@@ -118,6 +120,15 @@ class AircraftBehavior:
         group.points[0].tasks.append(OptJettisonEmptyTanks())
         # Do not restrict afterburner.
         # https://forums.eagle.ru/forum/english/digital-combat-simulator/dcs-world-2-5/bugs-and-problems-ai/ai-ad/7121294-ai-stuck-at-high-aoa-after-making-sharp-turn-if-afterburner-is-restricted
+
+        # Activate AI unlimited fuel, based either on the argument or the setting
+        if ai_unlimited_fuel:
+            # Force AI unlimited fuel for the flight
+            group.points[0].tasks.insert(0, SetUnlimitedFuelCommand(True))
+        elif flight.squadron.coalition.game.settings.ai_unlimited_fuel:
+            # If this is a user flight and the setting is checked : add task at first waypoint.
+            if flight.client_count:
+                group.points[0].tasks.insert(0, SetUnlimitedFuelCommand(True))
 
     @staticmethod
     def configure_eplrs(group: FlyingGroup[Any], flight: Flight) -> None:

--- a/game/missiongenerator/aircraft/aircraftbehavior.py
+++ b/game/missiongenerator/aircraft/aircraftbehavior.py
@@ -94,9 +94,18 @@ class AircraftBehavior:
         restrict_jettison: Optional[bool] = None,
         mission_uses_gun: bool = True,
         rtb_on_bingo: bool = True,
-        ai_unlimited_fuel: bool = False,
+        ai_unlimited_fuel: bool = None,
     ) -> None:
         group.points[0].tasks.clear()
+        if ai_unlimited_fuel is None:
+            ai_unlimited_fuel = (
+                flight.squadron.coalition.game.settings.ai_unlimited_fuel
+            )
+
+        # Activate AI unlimited fuel for all flights at startup
+        if ai_unlimited_fuel:
+            group.points[0].tasks.append(SetUnlimitedFuelCommand(True))
+
         group.points[0].tasks.append(OptReactOnThreat(react_on_threat))
         if roe is not None:
             group.points[0].tasks.append(OptROE(roe))
@@ -104,8 +113,6 @@ class AircraftBehavior:
             group.points[0].tasks.append(OptRestrictJettison(restrict_jettison))
         if rtb_winchester is not None:
             group.points[0].tasks.append(OptRTBOnOutOfAmmo(rtb_winchester))
-
-        ai_unlimited_fuel = flight.squadron.coalition.game.settings.ai_unlimited_fuel
 
         # Confiscate the bullets of AI missions that do not rely on the gun. There is no
         # "all but gun" RTB winchester option, so air to ground missions with mixed
@@ -122,10 +129,6 @@ class AircraftBehavior:
         group.points[0].tasks.append(OptJettisonEmptyTanks())
         # Do not restrict afterburner.
         # https://forums.eagle.ru/forum/english/digital-combat-simulator/dcs-world-2-5/bugs-and-problems-ai/ai-ad/7121294-ai-stuck-at-high-aoa-after-making-sharp-turn-if-afterburner-is-restricted
-
-        # Activate AI unlimited fuel for player flights at startup
-        if ai_unlimited_fuel and flight.client_count:
-            group.points[0].tasks.insert(0, SetUnlimitedFuelCommand(True))
 
     @staticmethod
     def configure_eplrs(group: FlyingGroup[Any], flight: Flight) -> None:

--- a/game/missiongenerator/aircraft/aircraftbehavior.py
+++ b/game/missiongenerator/aircraft/aircraftbehavior.py
@@ -105,6 +105,8 @@ class AircraftBehavior:
         if rtb_winchester is not None:
             group.points[0].tasks.append(OptRTBOnOutOfAmmo(rtb_winchester))
 
+        ai_unlimited_fuel = flight.squadron.coalition.game.settings.ai_unlimited_fuel
+
         # Confiscate the bullets of AI missions that do not rely on the gun. There is no
         # "all but gun" RTB winchester option, so air to ground missions with mixed
         # weapon types will insist on using all of their bullets after running out of
@@ -121,14 +123,9 @@ class AircraftBehavior:
         # Do not restrict afterburner.
         # https://forums.eagle.ru/forum/english/digital-combat-simulator/dcs-world-2-5/bugs-and-problems-ai/ai-ad/7121294-ai-stuck-at-high-aoa-after-making-sharp-turn-if-afterburner-is-restricted
 
-        # Activate AI unlimited fuel, based either on the argument or the setting
-        if ai_unlimited_fuel:
-            # If the ai_unlimited_fuel argument is passed : force AI unlimited fuel for the flight, no matter
+        # Activate AI unlimited fuel for player flights at startup
+        if ai_unlimited_fuel and flight.client_count:
             group.points[0].tasks.insert(0, SetUnlimitedFuelCommand(True))
-        elif flight.squadron.coalition.game.settings.ai_unlimited_fuel:
-            # If this is a user flight and the setting is checked : add task at first waypoint.
-            if flight.client_count:
-                group.points[0].tasks.insert(0, SetUnlimitedFuelCommand(True))
 
     @staticmethod
     def configure_eplrs(group: FlyingGroup[Any], flight: Flight) -> None:

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, TYPE_CHECKING
 from dcs import Mission, Point
 from dcs.action import DoScript
 from dcs.flyingunit import FlyingUnit
-from dcs.task import OptReactOnThreat, SetUnlimitedFuelCommand
+from dcs.task import OptReactOnThreat
 from dcs.translation import String
 from dcs.triggers import TriggerStart
 from dcs.unit import Skill
@@ -125,13 +125,6 @@ class FlightGroupConfigurator:
             divert_position,
             self.flight.flight_plan.waypoints,
         )
-
-        # Unlimited fuel option : enable on player flights. Must be first option to work.
-        if (
-            self.flight.squadron.coalition.game.settings.ai_unlimited_fuel
-            and self.flight.client_count
-        ):
-            self.group.points[0].tasks.insert(0, SetUnlimitedFuelCommand(True))
 
         return FlightData(
             package=self.flight.package,

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, TYPE_CHECKING
 from dcs import Mission, Point
 from dcs.action import DoScript
 from dcs.flyingunit import FlyingUnit
-from dcs.task import OptReactOnThreat
+from dcs.task import OptReactOnThreat, SetUnlimitedFuelCommand
 from dcs.translation import String
 from dcs.triggers import TriggerStart
 from dcs.unit import Skill
@@ -125,6 +125,13 @@ class FlightGroupConfigurator:
             divert_position,
             self.flight.flight_plan.waypoints,
         )
+
+        # Unlimited fuel option : enable on player flights. Must be first option to work.
+        if (
+            self.flight.squadron.coalition.game.settings.ai_unlimited_fuel
+            and self.flight.client_count
+        ):
+            self.group.points[0].tasks.insert(0, SetUnlimitedFuelCommand(True))
 
         return FlightData(
             package=self.flight.package,

--- a/game/missiongenerator/aircraft/waypoints/joinpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/joinpoint.py
@@ -26,7 +26,7 @@ class JoinPointBuilder(PydcsWaypointBuilder):
             self.flight.squadron.coalition.game.settings.ai_unlimited_fuel
             and not self.flight.client_count
         ):
-            waypoint.tasks.append(SetUnlimitedFuelCommand(True))
+            waypoint.tasks.insert(0, SetUnlimitedFuelCommand(True))
 
         if self.flight.is_helo:
             waypoint.tasks.append(OptFormation.rotary_wedge())

--- a/game/missiongenerator/aircraft/waypoints/joinpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/joinpoint.py
@@ -21,12 +21,9 @@ from .pydcswaypointbuilder import PydcsWaypointBuilder
 
 class JoinPointBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
-        # Unlimited fuel option : enable on non-player flights. Must be first option to work.
-        if (
-            self.flight.squadron.coalition.game.settings.ai_unlimited_fuel
-            and not self.flight.client_count
-        ):
-            waypoint.tasks.insert(0, SetUnlimitedFuelCommand(True))
+        # Unlimited fuel option : disable at join. Must be first option to work.
+        if self.flight.squadron.coalition.game.settings.ai_unlimited_fuel:
+            waypoint.tasks.insert(0, SetUnlimitedFuelCommand(False))
 
         if self.flight.is_helo:
             waypoint.tasks.append(OptFormation.rotary_wedge())

--- a/game/missiongenerator/aircraft/waypoints/joinpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/joinpoint.py
@@ -9,16 +9,25 @@ from dcs.task import (
     OptFormation,
     Targets,
     OptROE,
+    SetUnlimitedFuelCommand,
 )
 
 from game.ato import FlightType
 from game.theater import NavalControlPoint
 from game.utils import nautical_miles, feet
+from game.settings import Settings
 from .pydcswaypointbuilder import PydcsWaypointBuilder
 
 
 class JoinPointBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
+        # Unlimited fuel option : enable on non-player flights. Must be first option to work.
+        if (
+            self.flight.squadron.coalition.game.settings.ai_unlimited_fuel
+            and not self.flight.client_count
+        ):
+            waypoint.tasks.append(SetUnlimitedFuelCommand(True))
+
         if self.flight.is_helo:
             waypoint.tasks.append(OptFormation.rotary_wedge())
         else:

--- a/game/missiongenerator/aircraft/waypoints/racetrack.py
+++ b/game/missiongenerator/aircraft/waypoints/racetrack.py
@@ -8,6 +8,7 @@ from dcs.task import (
     OrbitAction,
     Tanker,
     Targets,
+    SetUnlimitedFuelCommand,
 )
 
 from game.ato import FlightType
@@ -19,6 +20,10 @@ from .pydcswaypointbuilder import PydcsWaypointBuilder
 class RaceTrackBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
         flight_plan = self.flight.flight_plan
+
+        # Unlimited fuel option : disable at racetrack start. Must be first option to work.
+        if self.flight.squadron.coalition.game.settings.ai_unlimited_fuel:
+            waypoint.tasks.insert(0, SetUnlimitedFuelCommand(False))
 
         if not isinstance(flight_plan, PatrollingFlightPlan):
             flight_plan_type = flight_plan.__class__.__name__

--- a/game/missiongenerator/aircraft/waypoints/racetrackend.py
+++ b/game/missiongenerator/aircraft/waypoints/racetrackend.py
@@ -1,12 +1,20 @@
 import logging
 
 from dcs.point import MovingPoint
+from dcs.task import SetUnlimitedFuelCommand
 
 from game.ato.flightplans.patrolling import PatrollingFlightPlan
 from .pydcswaypointbuilder import PydcsWaypointBuilder
 
 
 class RaceTrackEndBuilder(PydcsWaypointBuilder):
+    def add_tasks(self, waypoint: MovingPoint) -> None:
+        flight_plan = self.flight.flight_plan
+
+        # Unlimited fuel option : enable at racetrack end. Must be first option to work.
+        if self.flight.squadron.coalition.game.settings.ai_unlimited_fuel:
+            waypoint.tasks.insert(0, SetUnlimitedFuelCommand(True))
+
     def build(self) -> MovingPoint:
         waypoint = super().build()
 

--- a/game/missiongenerator/aircraft/waypoints/splitpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/splitpoint.py
@@ -13,7 +13,7 @@ class SplitPointBuilder(PydcsWaypointBuilder):
             self.flight.squadron.coalition.game.settings.ai_unlimited_fuel
             and not self.flight.client_count
         ):
-            waypoint.tasks.append(SetUnlimitedFuelCommand(False))
+            waypoint.tasks.insert(0, SetUnlimitedFuelCommand(False))
 
         if not self.flight.flight_type.is_air_to_air:
             # Capture any non A/A type to avoid issues with SPJs that use the primary radar such as the F/A-18C.

--- a/game/missiongenerator/aircraft/waypoints/splitpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/splitpoint.py
@@ -1,11 +1,20 @@
 from dcs.point import MovingPoint
-from dcs.task import OptECMUsing, OptFormation, RunScript
+from dcs.task import OptECMUsing, OptFormation, RunScript, SetUnlimitedFuelCommand
+
+from game.settings import Settings
 
 from .pydcswaypointbuilder import PydcsWaypointBuilder
 
 
 class SplitPointBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
+        # Unlimited fuel option : disable on non-player flights. Must be first option to work.
+        if (
+            self.flight.squadron.coalition.game.settings.ai_unlimited_fuel
+            and not self.flight.client_count
+        ):
+            waypoint.tasks.append(SetUnlimitedFuelCommand(False))
+
         if not self.flight.flight_type.is_air_to_air:
             # Capture any non A/A type to avoid issues with SPJs that use the primary radar such as the F/A-18C.
             # You can bully them with STT to not be able to fire radar guided missiles at you,

--- a/game/missiongenerator/aircraft/waypoints/splitpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/splitpoint.py
@@ -8,12 +8,9 @@ from .pydcswaypointbuilder import PydcsWaypointBuilder
 
 class SplitPointBuilder(PydcsWaypointBuilder):
     def add_tasks(self, waypoint: MovingPoint) -> None:
-        # Unlimited fuel option : disable on non-player flights. Must be first option to work.
-        if (
-            self.flight.squadron.coalition.game.settings.ai_unlimited_fuel
-            and not self.flight.client_count
-        ):
-            waypoint.tasks.insert(0, SetUnlimitedFuelCommand(False))
+        # Unlimited fuel option : enable at split. Must be first option to work.
+        if self.flight.squadron.coalition.game.settings.ai_unlimited_fuel:
+            waypoint.tasks.insert(0, SetUnlimitedFuelCommand(True))
 
         if not self.flight.flight_type.is_air_to_air:
             # Capture any non A/A type to avoid issues with SPJs that use the primary radar such as the F/A-18C.

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -822,6 +822,17 @@ class Settings:
         ),
     )
 
+    ai_unlimited_fuel: bool = boolean_option(
+        "AI flights have unlimited fuel",
+        MISSION_GENERATOR_PAGE,
+        GAMEPLAY_SECTION,
+        default=True,
+        detail=(
+            "AI flights have unlimited fuel applied at join, and removed at split for applicable flights. "
+            "For player flights, unlimited fuel is applied from start to finish."
+        ),
+    )
+
     # Performance
     perf_smoke_gen: bool = boolean_option(
         "Smoke visual effect on the front line",

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -828,8 +828,7 @@ class Settings:
         GAMEPLAY_SECTION,
         default=True,
         detail=(
-            "AI flights have unlimited fuel applied at join, and removed at split for applicable flights. "
-            "For player flights, unlimited fuel is applied from start to finish."
+            "AI aircraft have unlimited fuel applied at start, removed at join/racetrack start, and reapplied at split/racetrack end for applicable flights. "
         ),
     )
 


### PR DESCRIPTION
AI unlimited fuel implementation for DCS 2.9.

For player flights, adds command at first waypoint.

For AI-only flights, adds command at join and removes it at split.