### PR TITLE
Swedish Military Assets Pack bugfix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,7 @@
 * **[Mission Generation]** Helicopters oscillating due to over-speeding
 * **[Mission Generation]** Fix infinite loop when using "Fast-Forward to first contact"
 * **[Capture Logic]** Release all parking slots when an airbase is captured
+* **[Modding]** Swedish Military Assets Pack air defence presets are now correctly removed from the faction when the mod is disabled.
 
 # Retribution v1.2.1 (hotfix)
 

--- a/game/factions/faction.py
+++ b/game/factions/faction.py
@@ -504,6 +504,10 @@ class Faction:
             self.remove_ship("HSwMS_Visby")
             self.remove_ship("Strb90")
             self.remove_aircraft("HKP15B")
+            self.remove_preset("LvS-103 Rb103A")
+            self.remove_preset("LvS-103 Rb103A Mobile")
+            self.remove_preset("LvS-103 Rb103B")
+            self.remove_preset("LvS-103 Rb103B Mobile")
         # SWPack
         if not mod_settings.SWPack:
             self.remove_aircraft("AWINGA")


### PR DESCRIPTION
Swedish Military Assets Pack air defence presets are now correctly removed from the faction when the mod is disabled.