### PR TITLE
Improvements to disabled aircraft mod handling in Faction

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 ## Fixes
 * **[Mission Generation]** Anti-ship strikes should use "group attack" in their attack-task
 * **[New Game Wizard]** Faction selection overview doesn't update when inverting map
+* **[New Game Wizard]** Aircraft mods are now handled better when they are disabled
 * **[Payloads]** Added/Updated (missing) payloads
 * **[Aircraft Tasking]** Revised aircraft tasking, filtering out incompatible tasks for several aircraft
 * **[Data]** Corrected the class of the USS Samuel Chase from Logistics to LandingShip, in order to prevent it being spawned as part of AAA sites.

--- a/game/factions/faction.py
+++ b/game/factions/faction.py
@@ -537,14 +537,16 @@ class Faction:
             self.remove_ship("Destroyer_carrier")
 
     def remove_aircraft(self, name: str) -> None:
-        for i in list(self.all_aircrafts):
-            if i.dcs_unit_type.id == name:
-                self.all_aircrafts.remove(i)
+        for aircraft_set in [self.aircraft, self.awacs, self.tankers]:
+            for i in list(aircraft_set):
+                if i.dcs_unit_type.id == name:
+                    aircraft_set.remove(i)
 
     def remove_aircraft_by_name(self, name: str) -> None:
-        for i in list(self.all_aircrafts):
-            if i.display_name == name:
-                self.all_aircrafts.remove(i)
+        for aircraft_set in [self.aircraft, self.awacs, self.tankers]:
+            for i in list(aircraft_set):
+                if i.display_name == name:
+                    aircraft_set.remove(i)
 
     def remove_preset(self, name: str) -> None:
         for pg in self.preset_groups:

--- a/qt_ui/windows/newgame/WizardPages/QFactionSelection.py
+++ b/qt_ui/windows/newgame/WizardPages/QFactionSelection.py
@@ -238,7 +238,7 @@ class FactionSelection(QtWidgets.QWizardPage):
     @staticmethod
     def _filter_selected_units(qfu: QFactionUnits) -> Faction:
         fac = deepcopy(qfu.faction)
-        qfu.updateFactionUnits(fac.all_aircrafts)
+        qfu.updateFactionUnits(fac.aircraft)
         qfu.updateFactionUnits(fac.awacs)
         qfu.updateFactionUnits(fac.tankers)
         qfu.updateFactionUnits(fac.frontline_units)


### PR DESCRIPTION
Aircraft mods are now correctly removed from the three aircraft sets in Faction, instead of from the cached property all_aircrafts. Also corrected the aircraft set being included in _filter_selected_units in QFactionSelection.py