### PR TITLE
Removed IDF Mods Project Iron Dome mod artillery

### DIFF
--- a/qt_ui/uiconstants.py
+++ b/qt_ui/uiconstants.py
@@ -220,4 +220,3 @@ def load_vehicle_icons():
             VEHICLES_ICONS[vehicle[:-7]] = QPixmap(
                 os.path.join("./resources/ui/units/vehicles/icons/", vehicle)
             )
-    VEHICLES_ICONS["(IDF Mods Project) BM-21 Grad 122mm"] = VEHICLES_ICONS["Grad-URAL"]

--- a/resources/factions/israel_2000.json
+++ b/resources/factions/israel_2000.json
@@ -40,10 +40,7 @@
   ],
   "artillery_units": [
     "M109A6 Paladin",
-    "M270 Multiple Launch Rocket System",
-    "(IDF Mods Project) BM-21 Grad 122mm",
-    "(IDF Mods Project) Urgan BM-27 220mm",
-    "(IDF Mods Project) 9A52 Smerch CM 300mm"
+    "M270 Multiple Launch Rocket System"
   ],
   "logistics_units": [
     "Truck M818 6x6"

--- a/resources/factions/israel_2011_ODS.json
+++ b/resources/factions/israel_2011_ODS.json
@@ -51,10 +51,7 @@
     ],
   "artillery_units": [
     "M109A6 Paladin",
-    "M270 Multiple Launch Rocket System",
-    "(IDF Mods Project) BM-21 Grad 122mm",
-    "(IDF Mods Project) Urgan BM-27 220mm",
-    "(IDF Mods Project) 9A52 Smerch CM 300mm"
+    "M270 Multiple Launch Rocket System"
   ],
   "logistics_units": [
     "Truck M818 6x6"


### PR DESCRIPTION
Removed IDF Mods Project Iron Dome mod artillery assets, since they are not included in the IDF Assets Pack mod which is currently supported in Retribution.