### PR TITLE
Add DEAD mission type to Apache and update loadouts

### DIFF
--- a/resources/customized_payloads/AH-64D_BLK_II.lua
+++ b/resources/customized_payloads/AH-64D_BLK_II.lua
@@ -9,7 +9,7 @@ local unitPayloads = {
 					["num"] = 3,
 				},
 				[2] = {
-					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
+					["CLSID"] = "{M299_4xAGM_114L}",
 					["num"] = 4,
 				},
 				[3] = {
@@ -17,7 +17,7 @@ local unitPayloads = {
 					["num"] = 2,
 				},
 				[4] = {
-					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
+					["CLSID"] = "{M299_4xAGM_114L}",
 					["num"] = 1,
 				},
 			},
@@ -75,8 +75,8 @@ local unitPayloads = {
 			},
 		},
 		[4] = {
-			["displayName"] = "Retribution Escort",
-			["name"] = "Retribution Escort",
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{M299_4xAGM_114L}",
@@ -88,6 +88,31 @@ local unitPayloads = {
 				},
 				[3] = {
 					["CLSID"] = "{M299_4xAGM_114L}",
+					["num"] = 2,
+				},
+				[4] = {
+					["CLSID"] = "{M299_4xAGM_114L}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
+		[5] = {
+			["displayName"] = "Retribution Escort",
+			["name"] = "Retribution Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{M299_4xAGM_114L}",
+					["num"] = 4,
+				},
+				[3] = {
+					["CLSID"] = "{88D18A5E-99C8-4B04-B40B-1C02F2018B6E}",
 					["num"] = 2,
 				},
 				[4] = {

--- a/resources/units/aircraft/AH-64D_BLK_II.yaml
+++ b/resources/units/aircraft/AH-64D_BLK_II.yaml
@@ -37,5 +37,6 @@ radios:
 tasks:
   BAI: 510
   CAS: 510
+  DEAD: 115
   Escort: 100
   OCA/Aircraft: 510


### PR DESCRIPTION
Now that the Apache can carry the Lima Hellfire, it is pretty great for SHORAD DEAD. I am adding the mission type to the chopper. This is also important for chopper-only campaigns as it is the only BLUFOR chopper capable of DEAD.