### PR TITLE
Add Blackshark III to Redfor China 2010 faction

### DIFF
--- a/resources/factions/redfor_china_2010.json
+++ b/resources/factions/redfor_china_2010.json
@@ -10,6 +10,7 @@
     "J-15 Flanker X-2",
     "J-7B",
     "Ka-50 Hokum",
+    "Ka-50 Hokum (Blackshark 3)",
     "L-39ZA Albatros",
     "Mi-24V Hind-E",
     "Mi-24P Hind-F",


### PR DESCRIPTION
Looks like this faction didn't get updated after BS3 release. Updating it to add the Blackshark III.