### PR TITLE
Add LARC-V amphibious cargo vehicle

### DIFF
--- a/resources/units/ground_units/LARC-V.yaml
+++ b/resources/units/ground_units/LARC-V.yaml
@@ -1,0 +1,4 @@
+class: Logistics
+price: 2
+variants:
+  LARC-V: null


### PR DESCRIPTION
Adds missing LARC-V amphibious cargo vehicle. This is used by my Vietnam War faction, coming in the next PR.