### PR TITLE
Exercise Bright Star - remove squadrons from Nevatim because the airfield is borked

### DIFF
--- a/resources/campaigns/exercise_bright_star.yaml
+++ b/resources/campaigns/exercise_bright_star.yaml
@@ -58,6 +58,11 @@ squadrons:
       size: 8
   # Hatzerim (141)
   7:
+    - primary: CAS
+      secondary: air-to-ground
+      aircraft:
+        - A-10C Thunderbolt II (Suite 7)
+      size: 6
     - primary: Escort
       secondary: any
       aircraft:
@@ -97,20 +102,16 @@ squadrons:
         - UH-60A
       size: 4
   # Nevatim (106)
-  8:
-    - primary: AEW&C
-      aircraft:
-        - E-3A
-      size: 2
-    - primary: Refueling
-      aircraft:
-        - KC-135 Stratotanker
-      size: 2
-    - primary: CAS
-      secondary: air-to-ground
-      aircraft:
-        - A-10C Thunderbolt II (Suite 7)
-      size: 8
+# Nevatim temporarilly disabled because airfield is borked
+#  8:
+#    - primary: AEW&C
+#      aircraft:
+#        - E-3A
+#      size: 2
+#    - primary: Refueling
+#      aircraft:
+#        - KC-135 Stratotanker
+#      size: 2
   # Melez (30)
   5:
     - primary: CAS


### PR DESCRIPTION
A-10s have been reduced to 6 and moved to Hatzerim. KC-135 and E-3 squadrons have been given the month off.