### PR TITLE
Campaign updates for chopper escort autoplan support

### DIFF
--- a/resources/campaigns/battle_for_no_mans_land.yaml
+++ b/resources/campaigns/battle_for_no_mans_land.yaml
@@ -38,12 +38,12 @@ squadrons:
   #Port Stanley
   1:
     - primary: DEAD
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - AH-64D Apache Longbow
       size: 6
     - primary: BAI
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - AH-64D Apache Longbow
       size: 6
@@ -56,14 +56,15 @@ squadrons:
   #San Carlos FOB
   3:
     - primary: BAI
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - Mi-24P Hind-F
       size: 6
   #Goose Green
   24:
     - primary: DEAD
-      secondary: air-to-ground
+      secondary: any
       aircraft:
+        - Ka-50 Hokum III
         - Ka-50 Hokum (Blackshark 3)
       size: 6

--- a/resources/campaigns/exercise_bright_star.yaml
+++ b/resources/campaigns/exercise_bright_star.yaml
@@ -95,6 +95,11 @@ squadrons:
       aircraft:
         - CH-47D
       size: 20
+    - primary: BAI
+      secondary: any
+      aircraft:
+        - AH-64D Apache Longbow
+      size: 8
     - primary: Air Assault
       secondary: any
       aircraft:
@@ -115,8 +120,9 @@ squadrons:
   # Melez (30)
   5:
     - primary: CAS
-      secondary: air-to-ground
+      secondary: any
       aircraft:
+        - Ka-50 Hokum III
         - Ka-50 Hokum (Blackshark 3)
       size: 4
     - primary: BAI

--- a/resources/campaigns/exercise_vegas_nerve.yaml
+++ b/resources/campaigns/exercise_vegas_nerve.yaml
@@ -53,7 +53,7 @@ squadrons:
         - A-10C Thunderbolt II (Suite 7)
       size: 8
     - primary: CAS
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - AH-64D Apache Longbow
       size: 10
@@ -88,12 +88,13 @@ squadrons:
   # Creech
   1:
     - primary: CAS
-      secondary: air-to-ground
+      secondary: any
       aircraft:
+        - Ka-50 Hokum III
         - Ka-50 Hokum (Blackshark 3)
       size: 8
     - primary: Air Assault
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - Mi-24P Hind-F
       size: 4

--- a/resources/campaigns/grabthars_hammer.yaml
+++ b/resources/campaigns/grabthars_hammer.yaml
@@ -36,7 +36,7 @@ squadrons:
         - F-15C Eagle
       size: 8
     - primary: CAS
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - AH-64D Apache Longbow
       size: 8
@@ -147,14 +147,15 @@ squadrons:
   #Ushuaia
   7:
     - primary: CAS
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - Ka-50 Hokum III
+        - Ka-50 Hokum (Blackshark 3)
       size: 8
   #Ushuaia Helo Port
   8:
     - primary: Air Assault
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - Mi-24P Hind-F
       size: 8

--- a/resources/campaigns/operation_aegean_aegis.yaml
+++ b/resources/campaigns/operation_aegean_aegis.yaml
@@ -48,7 +48,7 @@ squadrons:
   #Tarawa Class LHA
   Blue-LHA:
     - primary: DEAD
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - AH-64D Apache Longbow
       size: 12
@@ -72,7 +72,7 @@ squadrons:
   #Akrotiri
   44:
     - primary: BAI
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - AH-1W SuperCobra
       size: 4
@@ -81,8 +81,8 @@ squadrons:
       aircraft:
         - OH-58D Kiowa Warrior
       size: 4
-    - primary: Air Assault
-      secondary: air-to-ground
+    - primary: Transport
+      secondary: any
       aircraft:
         - UH-60A
       size: 4
@@ -95,6 +95,7 @@ squadrons:
   #Ercan
   49:
     - primary: Transport
+      secondary: any
       aircraft:
         - CH-47D
       size: 6

--- a/resources/campaigns/operation_noisy_cricket.yaml
+++ b/resources/campaigns/operation_noisy_cricket.yaml
@@ -100,7 +100,7 @@ squadrons:
   #Qeshm Island (12)
   13:
     - primary: Air Assault
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - Mi-24P Hind-F
       size: 12

--- a/resources/campaigns/operation_peace_spring.yaml
+++ b/resources/campaigns/operation_peace_spring.yaml
@@ -80,7 +80,7 @@ squadrons:
         - F-16CM Fighting Falcon (Block 50)
       size: 28
     - primary: CAS
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - AH-64D Apache Longbow
       size: 4
@@ -93,13 +93,13 @@ squadrons:
         - H-6J Badger
       size: 16
     - primary: BAI
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - AH-1W SuperCobra
         - Su-25 Frogfoot
       size: 16
     - primary: CAS
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - OH-58D Kiowa Warrior
         - Mi-24P Hind-F

--- a/resources/campaigns/operation_vectrons_claw.yaml
+++ b/resources/campaigns/operation_vectrons_claw.yaml
@@ -57,7 +57,7 @@ squadrons:
       size: 20
   Squadrons from Incirlik:
     - primary: CAS
-      secondary: air-to-ground
+      secondary: any
       aircraft:
         - AH-64D Apache Longbow
       size: 4


### PR DESCRIPTION
1. Switches attack chopper secondary mission type from air-to-ground to any so that the autoplanner can use them for escort.
2. Add Apache squadron to Exercise Bright Star
3. Adds both name variants to squadrons using Hokum III so it works regardless of selected faction.