### PR TITLE
Add C-130J to Israel 1973

### DIFF
--- a/resources/factions/israel_1973.json
+++ b/resources/factions/israel_1973.json
@@ -10,7 +10,8 @@
     "A-4E Skyhawk",
     "F-4E Phantom II",
     "UH-1H Iroquois",
-    "C-130"
+    "C-130",
+    "C-130J-30 Super Hercules"
   ],
   "awacs": [
     "E-2C Hawkeye"


### PR DESCRIPTION
Adds the Anubis C-130 mod aircraft to the Israel 1973 faction in order to allow paratroop drops.