### PR TITLE
Ramon Airbase hack

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * **[Campaign Setup]** Allow adjustments to naval TGOs (except carriers) on turn 0
 * **[Campaign Design]** Ability to configure specific carrier names & types in campaign's yaml file 
 * **[Mission Generation]** Ability to inject custom kneeboards
+* **[Options]** Extend option (so it can be disabled when fixed in DCS) to force air-starts (except for the slots that work) at Ramon Airbase, similar to the Nevatim fix in Retribution 1.3.0
 
 ## Fixes
 * **[UI/UX]** A-10A flights can be edited again.

--- a/game/missiongenerator/aircraft/flightgroupspawner.py
+++ b/game/missiongenerator/aircraft/flightgroupspawner.py
@@ -137,7 +137,9 @@ class FlightGroupSpawner:
                     slot
                     for slot in cp.dcs_airport.free_parking_slots(ac_type)
                     if slot.slot_name
-                    in [str(n) for n in [1, 2, 3, 4, 5, 6, 13, 14, 15, 16, 17, 18, 61]]
+                    not in [
+                        str(n) for n in [1, 2, 3, 4, 5, 6, 13, 14, 15, 16, 17, 18, 61]
+                    ]
                 ]
             group = self._generate_at_airfield(
                 name=namegen.next_aircraft_name(self.country, self.flight),
@@ -230,7 +232,7 @@ class FlightGroupSpawner:
                             self.flight.squadron.aircraft.dcs_unit_type
                         )
                         if slot.slot_name
-                        in [
+                        not in [
                             str(n)
                             for n in [1, 2, 3, 4, 5, 6, 13, 14, 15, 16, 17, 18, 61]
                         ]

--- a/game/missiongenerator/aircraft/flightgroupspawner.py
+++ b/game/missiongenerator/aircraft/flightgroupspawner.py
@@ -19,7 +19,7 @@ from dcs.planes import (
 from dcs.point import PointAction
 from dcs.ships import KUZNECOW
 from dcs.terrain import NoParkingSlotError, Sinai, ParkingSlot
-from dcs.terrain.sinai.airports import Nevatim
+from dcs.terrain.sinai.airports import Nevatim, Ramon_Airbase
 from dcs.unitgroup import (
     FlyingGroup,
     ShipGroup,
@@ -131,6 +131,14 @@ class FlightGroupSpawner:
                     for slot in cp.dcs_airport.free_parking_slots(ac_type)
                     if slot.slot_name in [str(n) for n in range(55, 66)]
                 ]
+            elif self._check_ramon_airbase_hack(cp):
+                ac_type = self.flight.unit_type.dcs_unit_type
+                slots = [
+                    slot
+                    for slot in cp.dcs_airport.free_parking_slots(ac_type)
+                    if slot.slot_name
+                    in [str(n) for n in [1, 2, 3, 4, 5, 6, 13, 14, 15, 16, 17, 18, 61]]
+                ]
             group = self._generate_at_airfield(
                 name=namegen.next_aircraft_name(self.country, self.flight),
                 airfield=cp,
@@ -214,6 +222,20 @@ class FlightGroupSpawner:
                         if slot.slot_name in [str(n) for n in range(55, 66)]
                     ]
                     return self._generate_at_airfield(name, cp, slots)
+                elif self._check_ramon_airbase_hack(cp):
+                    # TODO: get rid of the ramon airbase hack once fixed in DCS...
+                    slots = [
+                        slot
+                        for slot in cp.dcs_airport.free_parking_slots(
+                            self.flight.squadron.aircraft.dcs_unit_type
+                        )
+                        if slot.slot_name
+                        in [
+                            str(n)
+                            for n in [1, 2, 3, 4, 5, 6, 13, 14, 15, 16, 17, 18, 61]
+                        ]
+                    ]
+                    return self._generate_at_airfield(name, cp, slots)
                 else:
                     return self._generate_at_airfield(name, cp)
             else:
@@ -235,6 +257,13 @@ class FlightGroupSpawner:
         nevatim_hack &= isinstance(self.mission.terrain, Sinai)
         nevatim_hack &= isinstance(cp.dcs_airport, Nevatim)
         return nevatim_hack
+
+    def _check_ramon_airbase_hack(self, cp: ControlPoint) -> bool:
+        # TODO: get rid of the ramon airbase hack once fixed in DCS...
+        ramon_airbase_hack = self.flight.coalition.game.settings.nevatim_parking_fix
+        ramon_airbase_hack &= isinstance(self.mission.terrain, Sinai)
+        ramon_airbase_hack &= isinstance(cp.dcs_airport, Ramon_Airbase)
+        return ramon_airbase_hack
 
     def generate_mid_mission(self) -> FlyingGroup[Any]:
         assert isinstance(self.flight.state, InFlight)

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -740,12 +740,12 @@ class Settings:
         ),
     )
     nevatim_parking_fix: bool = boolean_option(
-        "Force air-starts for all aircraft at Nevatim",
+        "Force air-starts for aircraft at Nevatim and Ramon Airbase inoperable parking slots",
         page=MISSION_GENERATOR_PAGE,
         section=GAMEPLAY_SECTION,
         default=True,  # TODO: set to False or remove this when DCS is fixed
         detail=(
-            "Air-starts forced for all aircraft at Nevatim except parking slots "
+            "Air-starts forced for all aircraft at Nevatim and Ramon Airbase except parking slots "
             "55 till 65, since those are the only ones that work."
         ),
     )

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -746,7 +746,7 @@ class Settings:
         default=True,  # TODO: set to False or remove this when DCS is fixed
         detail=(
             "Air-starts forced for all aircraft at Nevatim and Ramon Airbase except parking slots "
-            "55 till 65, since those are the only ones that work."
+            "which are known to work as of DCS World 2.9.4.53990."
         ),
     )
     # Mission specific


### PR DESCRIPTION
Extend option (so it can be disabled when fixed in DCS) to force air-starts (except for the slots that work) at Ramon Airbase, similar to the Nevatim fix in Retribution 1.3.0. Affected slots are: [1, 2, 3, 4, 5, 6, 13, 14, 15, 16, 17, 18, 61]

https://discordapp.com/channels/1015931619187621999/1025837223821705236/1237373245250994267