### PR TITLE
F-4E-45MC squadrons fix

### DIFF
--- a/resources/squadrons/F-4E-45MC/EAF 222-FG-GG.yaml
+++ b/resources/squadrons/F-4E-45MC/EAF 222-FG-GG.yaml
@@ -4,7 +4,7 @@ nickname: Pharaoh's Ghosts
 country: Egypt
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - EAF - 60366 - Ghost Grey by Kerbo
+livery: EAF-60366_Ghost
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/EAF 222-FG-SEA.yaml
+++ b/resources/squadrons/F-4E-45MC/EAF 222-FG-SEA.yaml
@@ -4,7 +4,7 @@ nickname: Pharaoh's Ghosts
 country: Egypt
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - EAF - 70373 - SEA by Kerbo
+livery: EAF-70373_SEAW
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/GAF JG-72.yaml
+++ b/resources/squadrons/F-4E-45MC/GAF JG-72.yaml
@@ -4,7 +4,7 @@ nickname: Westphalen
 country: Germany
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4F - 37+24 - Norm 81 B - JG 72 Westphalen
+livery: 37+24_N81B_JG72
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/GAF JG-74.yaml
+++ b/resources/squadrons/F-4E-45MC/GAF JG-74.yaml
@@ -4,7 +4,7 @@ nickname: Moelders
 country: Germany
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4F - 37+36 - Norm 72 - JG 74 - Moelders
+livery: 37+36_N72_JG74
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/HAF 338-FS.yaml
+++ b/resources/squadrons/F-4E-45MC/HAF 338-FS.yaml
@@ -4,7 +4,7 @@ nickname: Ares
 country: Greece
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - HAF - 01507 - Aegean Ghost
+livery: HAF-01507_AG
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/IAF 119-FS.yaml
+++ b/resources/squadrons/F-4E-45MC/IAF 119-FS.yaml
@@ -4,7 +4,7 @@ nickname: Bat Squadron
 country: Israel
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - IAF - Kurnass 114 - 119 SQN
+livery: IAF-Kurnass-114-119SQN
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/IAF-69-FS.yaml
+++ b/resources/squadrons/F-4E-45MC/IAF-69-FS.yaml
@@ -4,7 +4,7 @@ nickname: Hammers
 country: Israel
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - IAF - Kurnass 175 - 69 SQN
+livery: IAF-Kurnass-175-69SQN
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/IRIAF 69-TFS.yaml
+++ b/resources/squadrons/F-4E-45MC/IRIAF 69-TFS.yaml
@@ -4,7 +4,7 @@ nickname: Panthers
 country: Iran
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - IRIAF - 3-6643 - 61st TFS by ISAAC
+livery: IRIAF-3-6643
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/JASDF 8-TFS.yaml
+++ b/resources/squadrons/F-4E-45MC/JASDF 8-TFS.yaml
@@ -4,7 +4,7 @@ nickname: Black Panthers
 country: Japan
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4EJ - JASDF - 87-8312 - 3WG by Fish
+livery: JASDF-87-8312-3WG
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/RAAF 1-SQN.yaml
+++ b/resources/squadrons/F-4E-45MC/RAAF 1-SQN.yaml
@@ -4,7 +4,7 @@ nickname: Fighting First
 country: Australia
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - RAAF - 97203 - SEA
+livery: RAAF-97203_SEA
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/RAF 43-SQN.yaml
+++ b/resources/squadrons/F-4E-45MC/RAF 43-SQN.yaml
@@ -4,7 +4,7 @@ nickname: Fighting Cocks
 country: UK
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: Fictional Royal Air Force 43(F) Sqn FG.1 by Fish
+livery: RAF-43-Sqn-FG.1
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/ROKAF 153-SQN.yaml
+++ b/resources/squadrons/F-4E-45MC/ROKAF 153-SQN.yaml
@@ -1,9 +1,10 @@
 ---
 name: ROKAF 153rd FS
+nickname: 153rd Fighter Squadron
 country: South Korea
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - ROKAF - 78740 - Compass Ghost - 153rd FS
+livery: ROKAF-80470-CG-153FS
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/TuAF 111-FILO.yaml
+++ b/resources/squadrons/F-4E-45MC/TuAF 111-FILO.yaml
@@ -4,7 +4,7 @@ nickname: Panter
 country: Turkey
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - TuAF - 67-0268 - Hill Two by Aqil
+livery: TUAF-67-0268-H2
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/USAF 110-ANG-BS.yaml
+++ b/resources/squadrons/F-4E-45MC/USAF 110-ANG-BS.yaml
@@ -4,7 +4,7 @@ nickname: Lindbergh's Own
 country: USA
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - USAF - SL68-303 - Hill One - 110th Missouri ANG by LanceCriminal86
+livery: SL68-303_H1_110ANG
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/USAF 141-TFS.yaml
+++ b/resources/squadrons/F-4E-45MC/USAF 141-TFS.yaml
@@ -4,7 +4,7 @@ nickname: Tigers
 country: USA
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - USAF - NJ68-357 - Hill Two - 141st TFS Tigers
+livery: NJ68-357_H1_141TFS
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/USAF 163-TFG.yaml
+++ b/resources/squadrons/F-4E-45MC/USAF 163-TFG.yaml
@@ -4,7 +4,7 @@ nickname: Grizzlys
 country: USA
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - USAF - CA68-426 - Hill Two - 163rd TFG
+livery: CA68-426_H2_163tfg
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/USAF 20-FS.yaml
+++ b/resources/squadrons/F-4E-45MC/USAF 20-FS.yaml
@@ -4,7 +4,7 @@ nickname: Silver Lobos
 country: USA
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - USAF - GA68-400 - Hill Two - 20th TFTS Silver Lobos
+livery: default
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/USAF 36-TFS.yaml
+++ b/resources/squadrons/F-4E-45MC/USAF 36-TFS.yaml
@@ -1,10 +1,10 @@
 ---
 name: USAF 36th TFS
-nickname: Flying Fiends
+nickname: The Flying Fiends
 country: USA
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - USAF - OS68-349 - SEA - 36th TFS The Flying Fiends
+livery: OS68-349_SEAW_36TFS
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/USAF 457-ANG-FS.yaml
+++ b/resources/squadrons/F-4E-45MC/USAF 457-ANG-FS.yaml
@@ -4,7 +4,7 @@ nickname: Spads
 country: USA
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - USAF - TH68-450 - Hill Two - 457th FS Spads
+livery: TH68-450_H1_457FS
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/USAF 469-FTS.yaml
+++ b/resources/squadrons/F-4E-45MC/USAF 469-FTS.yaml
@@ -4,7 +4,7 @@ nickname: Fighting Bulls
 country: USA
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - USAF - JV70-288 - SEA - 469th TFS Tigers
+livery: JV67-288_SEAW_469TFS
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/USAF 512-TFS.yaml
+++ b/resources/squadrons/F-4E-45MC/USAF 512-TFS.yaml
@@ -4,7 +4,7 @@ nickname: Dragons
 country: USA
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - USAF - RS68-480 - SEA Wrap Around - 512th TFS Dragons
+livery: RS68-480_SEA_512TFS
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/USAF 526-TFS.yaml
+++ b/resources/squadrons/F-4E-45MC/USAF 526-TFS.yaml
@@ -4,7 +4,7 @@ nickname: Black Knights
 country: USA
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - USAF - RS68-381 - Euro One - 526th TFS
+livery: RS68-381_E1_526TFS
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/USAF 57-FIS.yaml
+++ b/resources/squadrons/F-4E-45MC/USAF 57-FIS.yaml
@@ -4,7 +4,7 @@ nickname: Black Knights
 country: USA
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - USAF - AF66-300 - ADC - 57th FIS by Mach3DS
+livery: ADC AF66-300
 mission_types:
   - Anti-ship
   - BAI

--- a/resources/squadrons/F-4E-45MC/USAF 68-FS.yaml
+++ b/resources/squadrons/F-4E-45MC/USAF 68-FS.yaml
@@ -4,7 +4,7 @@ nickname: Lightning Lancers
 country: USA
 role: Fighter Bomber
 aircraft: F-4E-45MC Phantom II
-livery: F-4E - USAF - MY68-328 - Euro One - 68th FS Lightning Lancers
+livery: MY68-328_E1_68FS
 mission_types:
   - Anti-ship
   - BAI


### PR DESCRIPTION
Fixes all the F-4E squadrons as they had incorrect names for the liveries.