### PR TITLE
Update F-4E-45MC loadouts

### DIFF
--- a/resources/customized_payloads/F-4E-45MC.lua
+++ b/resources/customized_payloads/F-4E-45MC.lua
@@ -2,6 +2,94 @@ local unitPayloads = {
 	["name"] = "F-4E-45MC",
 	["payloads"] = {
 		[1] = {
+			["displayName"] = "Retribution SEAD Escort",
+			["name"] = "Retribution SEAD Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[2] = {
+					["CLSID"] = "{AGM_12B}",
+					["num"] = 13,
+				},
+				[3] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[4] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 10,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[5] = {
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[7] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 4,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[8] = {
+					["CLSID"] = "{AGM_12B}",
+					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 5,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 8,
+				},
+				[11] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 9,
+				},
+				[12] = {
+					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
+					["num"] = 7,
+				},
+				[13] = {
+					["CLSID"] = "{AGM_12B}",
+					["num"] = 11,
+				},
+				[14] = {
+					["CLSID"] = "{AGM_12B}",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[2] = {
 			["name"] = "Retribution Anti-ship",
 			["pylons"] = {
 				[1] = {
@@ -60,60 +148,8 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
-		[2] = {
-			["name"] = "Retribution BARCAP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
-					["num"] = 13,
-				},
-				[3] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 12,
-				},
-				[4] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 10,
-				},
-				[5] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 6,
-				},
-				[6] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 2,
-				},
-				[7] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 4,
-				},
-				[8] = {
-					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
-					["num"] = 1,
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-			},
-			["tasks"] = {
-			},
-		},
 		[3] = {
-			["displayName"] = "Retribution TARCAP",
-			["name"] = "Retribution TARCAP",
+			["name"] = "Retribution BARCAP",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{HB_ALE_40_30_60}",
@@ -216,6 +252,182 @@ local unitPayloads = {
 			},
 		},
 		[5] = {
+			["displayName"] = "Retribution BAI",
+			["name"] = "Retribution BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[2] = {
+					["CLSID"] = "{AGM_62_I}",
+					["num"] = 13,
+				},
+				[3] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[4] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 10,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[5] = {
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[7] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 4,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[8] = {
+					["CLSID"] = "{AGM_62_I}",
+					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 5,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 8,
+				},
+				[11] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 9,
+				},
+				[12] = {
+					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
+					["num"] = 7,
+				},
+				[13] = {
+					["CLSID"] = "{AGM_62_I}",
+					["num"] = 11,
+				},
+				[14] = {
+					["CLSID"] = "{AGM_62_I}",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[6] = {
+			["displayName"] = "Retribution CAS",
+			["name"] = "Retribution CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[2] = {
+					["CLSID"] = "{AGM_62_I}",
+					["num"] = 13,
+				},
+				[3] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[4] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 10,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[5] = {
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[7] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 4,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[8] = {
+					["CLSID"] = "{AGM_62_I}",
+					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 5,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 8,
+				},
+				[11] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 9,
+				},
+				[12] = {
+					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
+					["num"] = 7,
+				},
+				[13] = {
+					["CLSID"] = "{AGM_62_I}",
+					["num"] = 11,
+				},
+				[14] = {
+					["CLSID"] = "{AGM_62_I}",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[7] = {
 			["displayName"] = "Retribution SEAD",
 			["name"] = "Retribution SEAD",
 			["pylons"] = {
@@ -327,7 +539,133 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
-		[6] = {
+		[8] = {
+			["displayName"] = "Retribution Strike",
+			["name"] = "Retribution Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[2] = {
+					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
+					["num"] = 13,
+					["settings"] = {
+						["NFP_VIS_DrawArgNo_57"] = 0,
+						["NFP_fuze_type_nose"] = "M904E4",
+						["NFP_fuze_type_tail"] = "M905",
+						["arm_delay_ctrl_M904E4"] = 2,
+						["arm_delay_ctrl_M905"] = 4,
+						["function_delay_ctrl_M904E4"] = 0,
+						["function_delay_ctrl_M905"] = 0,
+					},
+				},
+				[3] = {
+					["CLSID"] = "{AIM-9M}",
+					["num"] = 12,
+				},
+				[4] = {
+					["CLSID"] = "{AIM-9M}",
+					["num"] = 10,
+				},
+				[5] = {
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{AIM-9M}",
+					["num"] = 2,
+				},
+				[7] = {
+					["CLSID"] = "{AIM-9M}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{AB8B8299-F1CC-4359-89B5-2172E0CF4A5A}",
+					["num"] = 1,
+					["settings"] = {
+						["NFP_VIS_DrawArgNo_57"] = 0,
+						["NFP_fuze_type_nose"] = "M904E4",
+						["NFP_fuze_type_tail"] = "M905",
+						["arm_delay_ctrl_M904E4"] = 2,
+						["arm_delay_ctrl_M905"] = 4,
+						["function_delay_ctrl_M904E4"] = 0,
+						["function_delay_ctrl_M905"] = 0,
+					},
+				},
+				[9] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 5,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 8,
+				},
+				[11] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 9,
+				},
+				[12] = {
+					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
+					["num"] = 7,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[9] = {
+			["displayName"] = "Retribution TARCAP",
+			["name"] = "Retribution TARCAP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[2] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
+					["num"] = 13,
+				},
+				[3] = {
+					["CLSID"] = "{AIM-9M}",
+					["num"] = 12,
+				},
+				[4] = {
+					["CLSID"] = "{AIM-9M}",
+					["num"] = 10,
+				},
+				[5] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{AIM-9M}",
+					["num"] = 2,
+				},
+				[7] = {
+					["CLSID"] = "{AIM-9M}",
+					["num"] = 4,
+				},
+				[8] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
+					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 5,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 8,
+				},
+				[11] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 9,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[10] = {
 			["displayName"] = "Retribution DEAD",
 			["name"] = "Retribution DEAD",
 			["pylons"] = {
@@ -415,403 +753,95 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
-		[7] = {
-			["displayName"] = "Retribution SEAD Escort",
-			["name"] = "Retribution SEAD Escort",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 13,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[5] = {
-					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
-					["num"] = 6,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 1,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{AGM_12B}",
-					["num"] = 11,
-				},
-				[14] = {
-					["CLSID"] = "{AGM_12B}",
-					["num"] = 3,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[8] = {
-			["displayName"] = "Retribution BAI",
-			["name"] = "Retribution BAI",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{AGM_62_I}",
-					["num"] = 13,
-				},
-				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[5] = {
-					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
-					["num"] = 6,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{AGM_62_I}",
-					["num"] = 1,
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{AGM_62_I}",
-					["num"] = 11,
-				},
-				[14] = {
-					["CLSID"] = "{AGM_62_I}",
-					["num"] = 3,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[9] = {
-			["displayName"] = "Retribution CAS",
-			["name"] = "Retribution CAS",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{AGM_62_I}",
-					["num"] = 13,
-				},
-				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[5] = {
-					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
-					["num"] = 6,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{AGM_62_I}",
-					["num"] = 1,
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{AGM_62_I}",
-					["num"] = 11,
-				},
-				[14] = {
-					["CLSID"] = "{AGM_62_I}",
-					["num"] = 3,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[10] = {
-			["displayName"] = "Retribution Strike",
-			["name"] = "Retribution Strike",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{Mk_84AIR_GP}",
-					["num"] = 13,
-					["settings"] = {
-						["NFP_fuze_type_nose"] = "M904E4",
-						["NFP_fuze_type_tail"] = "M905",
-						["arm_delay_ctrl_M904E4"] = 2,
-						["arm_delay_ctrl_M905"] = 4,
-						["function_delay_ctrl_M904E4"] = 0,
-						["function_delay_ctrl_M905"] = 0,
-					},
-				},
-				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[5] = {
-					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
-					["num"] = 6,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{Mk_84AIR_GP}",
-					["num"] = 1,
-					["settings"] = {
-						["NFP_fuze_type_nose"] = "M904E4",
-						["NFP_fuze_type_tail"] = "M905",
-						["arm_delay_ctrl_M904E4"] = 2,
-						["arm_delay_ctrl_M905"] = 4,
-						["function_delay_ctrl_M904E4"] = 0,
-						["function_delay_ctrl_M905"] = 0,
-					},
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{Mk_84AIR_GP}",
-					["num"] = 11,
-					["settings"] = {
-						["NFP_fuze_type_nose"] = "M904E4",
-						["NFP_fuze_type_tail"] = "M905",
-						["arm_delay_ctrl_M904E4"] = 2,
-						["arm_delay_ctrl_M905"] = 4,
-						["function_delay_ctrl_M904E4"] = 0,
-						["function_delay_ctrl_M905"] = 0,
-					},
-				},
-				[14] = {
-					["CLSID"] = "{Mk_84AIR_GP}",
-					["num"] = 3,
-					["settings"] = {
-						["NFP_fuze_type_nose"] = "M904E4",
-						["NFP_fuze_type_tail"] = "M905",
-						["arm_delay_ctrl_M904E4"] = 2,
-						["arm_delay_ctrl_M905"] = 4,
-						["function_delay_ctrl_M904E4"] = 0,
-						["function_delay_ctrl_M905"] = 0,
-					},
-				},
-			},
-			["tasks"] = {
-			},
-		},
 		[11] = {
+			["displayName"] = "Retribution OCA/Runway",
+			["name"] = "Retribution OCA/Runway",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[2] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
+					["num"] = 13,
+				},
+				[3] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[4] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 10,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[5] = {
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[7] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 4,
+					["settings"] = {
+						["EAS_bypass_ctrl"] = 1,
+						["NFP_rfgu_type"] = 1,
+						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
+						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
+					},
+				},
+				[8] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
+					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 5,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 8,
+				},
+				[11] = {
+					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["num"] = 9,
+				},
+				[12] = {
+					["CLSID"] = "{HB_F4E_BLU-107B_6x}",
+					["num"] = 7,
+				},
+				[13] = {
+					["CLSID"] = "{HB_F4E_BLU-107B_3x}",
+					["num"] = 11,
+				},
+				[14] = {
+					["CLSID"] = "{HB_F4E_BLU-107B_3x}",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+			},
+		},
+		[12] = {
 			["displayName"] = "Retribution OCA/Aircraft",
 			["name"] = "Retribution OCA/Aircraft",
 			["pylons"] = {
@@ -930,94 +960,6 @@ local unitPayloads = {
 						["function_delay_ctrl_M904E4"] = 0,
 						["function_delay_ctrl_M905"] = 0,
 					},
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[12] = {
-			["displayName"] = "Retribution OCA/Runway",
-			["name"] = "Retribution OCA/Runway",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
-					["num"] = 13,
-				},
-				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[5] = {
-					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
-					["num"] = 6,
-				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
-					["num"] = 1,
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-				[12] = {
-					["CLSID"] = "{HB_F4E_BLU-107B_6x}",
-					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{HB_F4E_BLU-107B_3x}",
-					["num"] = 11,
-				},
-				[14] = {
-					["CLSID"] = "{HB_F4E_BLU-107B_3x}",
-					["num"] = 3,
 				},
 			},
 			["tasks"] = {


### PR DESCRIPTION
Changes:
Switched strike loadout from air ballute Mk-84S to regular Mk-84s because the AI is hopeless at using the air ballutes.
Converted SEAD Escort loadout to 100% bullpups instead of the previous 50%, for now at least until shrike guidance unit auto/manual selection is implemented in Retribution.
