### PR TITLE
Change Black Sea performance indicator from 2/3 to 3/3

### DIFF
--- a/resources/campaigns/black_sea.yaml
+++ b/resources/campaigns/black_sea.yaml
@@ -3,12 +3,12 @@ name: Caucasus - Black Sea
 theater: Caucasus
 authors: Colonel Panic
 description:
-  <p>A medium sized theater with bases along the coast of the Black Sea.</p>
+  <p>A medium sized theater with bases along the coast of the Black Sea. Note that due to heavy SAM coverage, performance on this campaign can be noticeably worse than in many others.</p>
 recommended_player_faction: USA 2005
 recommended_enemy_faction: Russia 2010
 recommended_start_date: 2004-01-07
 miz: black_sea.miz
-performance: 2
+performance: 3
 version: "10.7"
 squadrons:
   # Anapa-Vityazevo


### PR DESCRIPTION
Also added in a warning message. Black Sea is often a first pick by new users due to its position near the top of the campaign list, and I think it's good they get some warning that the performance on this campaign is not typical of the standard experience.