### PR TITLE
Add SA-6 to Russia 2010

### DIFF
--- a/resources/factions/russia_2010.json
+++ b/resources/factions/russia_2010.json
@@ -63,6 +63,7 @@
   ],
   "missiles": [],
   "preset_groups": [
+    "SA-6",
     "SA-11",
     "SA-10/S-300PS",
     "SA-10B/S-300PS",


### PR DESCRIPTION
As it is, Russia 2010 only has one MERAD; the SA-11 Buk. This is problematic because the SA-11 Buk is a particularly resource-heavy SAM site because every single launcher vehicle has its own radar. So, having every MERAD in a campaign spawning as a Buk causes a noticeable degradation to performance (this is particularly a problem on Black Sea, but is also noticeable on Vectron's Claw and Grabthar's Hammer, for example).

I am adding in the SA-6 Kub to the faction. It still saw active use in the 2000s and while no longer in frontline use in the 2010s, it was still used by reserve forces. I think adding this will add some variety to Russian MERAD distribution as well as reduce the significant performance degradation caused by having multiple Buk sites 