### PR TITLE
Remove PDU from Kiowa

### DIFF
--- a/resources/units/aircraft/OH58D.yaml
+++ b/resources/units/aircraft/OH58D.yaml
@@ -29,7 +29,7 @@ radios:
 default_overrides:
   #NetCrewControlPriority: 0,
   #Remove_doors: true,
-  PDU: true,
+  #PDU: true,
   #Rifles: true,
   #MMS_removal: false,
   #Rapid_Deployment_Gear: false,


### PR DESCRIPTION
Removes the default on for the Kiowa's PDU as it is fugly, practically useless, and was not typically installed in real life.