### PR TITLE
Add MiG-21 to Blufor Modern

### DIFF
--- a/resources/factions/bluefor_modern.json
+++ b/resources/factions/bluefor_modern.json
@@ -52,6 +52,7 @@
     "Mirage-F1M-EE",
     "Mi-24P Hind-F",
     "Mi-8MTV2 Hip",
+    "MiG-21bis Fishbed-N",
     "MiG-29S Fulcrum-C",
     "OH-58D(R) Kiowa Warrior",
     "SA 342L Gazelle",


### PR DESCRIPTION
Added MiG-21 to Blufor Modern because there are still NATO-aligned nations that fly the jet, albeit in limited numbers.