### PR TITLE
Disables Hercules autoplanner tasks that AI can't perform

### DIFF
--- a/resources/units/aircraft/Hercules.yaml
+++ b/resources/units/aircraft/Hercules.yaml
@@ -25,7 +25,7 @@ radios:
     inter_flight_radio_index: 1
 tasks:
   Air Assault: 990
-  BAI: 810
-  CAS: 810
-  OCA/Aircraft: 810
+  BAI: 0
+  CAS: 0
+  OCA/Aircraft: 0
   Transport: 140


### PR DESCRIPTION
The AI cannot do BAI, CAS, and Armed Recon with the Hercules, so those tasks have been set to 0 so the autoplanner won't pick the Hercules for those missions.