### PR TITLE
Add default liveries to some aircraft that don't have preset squadrons

### DIFF
--- a/resources/units/aircraft/CH-47D.yaml
+++ b/resources/units/aircraft/CH-47D.yaml
@@ -5,6 +5,7 @@ cabin_size: 24 # It should have 33 but we do not want so much for CTLD to be pos
 can_carry_crates: true
 description: The CH-47D is a transport helicopter.
 price: 6
+default_livery: standard
 variants:
   CH-47D: null
 tasks:

--- a/resources/units/aircraft/Ka-50.yaml
+++ b/resources/units/aircraft/Ka-50.yaml
@@ -15,6 +15,7 @@ manufacturer: Kamov
 origin: USSR/Russia
 price: 20
 role: Attack
+default_livery: Russia Standard Army
 variants:
   Ka-50 Hokum: {}
 radios:

--- a/resources/units/aircraft/Ka-50_3.yaml
+++ b/resources/units/aircraft/Ka-50_3.yaml
@@ -15,6 +15,7 @@ manufacturer: Kamov
 origin: USSR/Russia
 price: 20
 role: Attack
+default_livery: Ka-50_standart_black_RussianAirForce
 variants:
   Ka-50 Hokum III: {}
   Ka-50 Hokum (Blackshark 3): {}  # for compatibility with Liberation

--- a/resources/units/aircraft/Mi-24P.yaml
+++ b/resources/units/aircraft/Mi-24P.yaml
@@ -24,6 +24,7 @@ origin: USSR/Russia
 price: 14
 role: Attack/Transport
 kneeboard_units: "metric"
+default_livery: Russian Air Force
 variants:
   Mi-24P Hind-F: {}
 radios:

--- a/resources/units/aircraft/Mi-8MT.yaml
+++ b/resources/units/aircraft/Mi-8MT.yaml
@@ -12,6 +12,7 @@ manufacturer: Mil
 origin: USSR/Russia
 price: 5
 role: Transport/Light Attack
+default_livery: Russia_Army_Weather
 variants:
   Mi-8MTV2 Hip: {}
 kneeboard_units: "metric"

--- a/resources/units/aircraft/MiG-23MLD.yaml
+++ b/resources/units/aircraft/MiG-23MLD.yaml
@@ -15,6 +15,7 @@ manufacturer: Mikoyan-Gurevich
 origin: USSR/Russia
 price: 12
 role: Fighter
+default_livery: af standard-3 (worn-out)
 variants:
   MiG-23ML Flogger-G:
     introduced: 1981

--- a/resources/units/aircraft/MiG-31.yaml
+++ b/resources/units/aircraft/MiG-31.yaml
@@ -16,6 +16,7 @@ origin: USSR/Russia
 price: 24
 role: Interceptor
 max_range: 800
+default_livery: af standard
 variants:
   MiG-31 Foxhound: {}
 tasks:

--- a/resources/units/aircraft/Su-17M4.yaml
+++ b/resources/units/aircraft/Su-17M4.yaml
@@ -13,6 +13,7 @@ origin: USSR/Russia
 price: 10
 role: Fighter-Bomber
 max_range: 300
+default_livery: af standard (worn-out) (RUS)
 variants:
   Su-17M4 Fitter-K: {}
   Su-22M4 Fitter-K:

--- a/resources/units/aircraft/Su-24M.yaml
+++ b/resources/units/aircraft/Su-24M.yaml
@@ -12,6 +12,7 @@ origin: USSR/Russia
 price: 14
 role: Attack
 max_range: 200
+default_livery: af standard
 variants:
   Su-24M Fencer-D: {}
   Su-24MK Fencer-D:

--- a/resources/units/aircraft/Su-25.yaml
+++ b/resources/units/aircraft/Su-25.yaml
@@ -12,6 +12,7 @@ origin: USSR/Russia
 price: 11
 role: Close Air Support/Attack
 max_range: 200
+default_livery: forest camo scheme #1 (native)
 variants:
   Su-25 Frogfoot: {}
 kneeboard_units: "metric"

--- a/resources/units/aircraft/Su-25T.yaml
+++ b/resources/units/aircraft/Su-25T.yaml
@@ -12,6 +12,7 @@ origin: USSR/Russia
 price: 18
 role: Close Air Support/Attack
 max_range: 200
+default_livery: af standard 1
 variants:
   Su-25T Frogfoot: {}
 kneeboard_units: "metric"

--- a/resources/units/aircraft/Su-27.yaml
+++ b/resources/units/aircraft/Su-27.yaml
@@ -15,6 +15,7 @@ origin: USSR/Russia
 price: 18
 role: Air-Superiority Fighter
 max_range: 300
+default_livery: Air Force Standard
 variants:
   Su-27 Flanker-B: {}
 kneeboard_units: "metric"

--- a/resources/units/aircraft/Su-33.yaml
+++ b/resources/units/aircraft/Su-33.yaml
@@ -22,6 +22,7 @@ origin: USSR/Russia
 price: 22
 role: Carrier-based Multirole Fighter
 max_range: 300
+default_livery: t-10k-9 test paint scheme
 variants:
   J-15 Flanker X-2:
     introduced: 2013


### PR DESCRIPTION
This prevents Retribution from picking unsuitable liveries (typically from paid campaigns) by default.