### PR TITLE
Bugfix for mission editor directory not found

### DIFF
--- a/game/persistency.py
+++ b/game/persistency.py
@@ -169,10 +169,6 @@ def kneeboards_dir() -> Path:
     return base_path() / "Retribution" / "Kneeboards"
 
 
-def mission_editor_dir() -> Path:
-    return base_path() / "MissionEditor"
-
-
 def payloads_dir(backup: bool = False) -> Path:
     payloads = base_path() / "MissionEditor" / "UnitPayloads"
     if backup:

--- a/game/persistency.py
+++ b/game/persistency.py
@@ -169,6 +169,10 @@ def kneeboards_dir() -> Path:
     return base_path() / "Retribution" / "Kneeboards"
 
 
+def mission_editor_dir() -> Path:
+    return base_path() / "MissionEditor"
+
+
 def payloads_dir(backup: bool = False) -> Path:
     payloads = base_path() / "MissionEditor" / "UnitPayloads"
     if backup:

--- a/qt_ui/windows/mission/flight/payload/QLoadoutEditor.py
+++ b/qt_ui/windows/mission/flight/payload/QLoadoutEditor.py
@@ -21,7 +21,10 @@ from game import Game
 from game.ato.flight import Flight
 from game.ato.flightmember import FlightMember
 from game.data.weapons import Pylon
-from game.persistency import payloads_dir
+from game.persistency import (
+    payloads_dir,
+    mission_editor_dir,
+)
 from qt_ui.blocksignals import block_signals
 from qt_ui.windows.mission.flight.payload.QPylonEditor import QPylonEditor
 
@@ -103,6 +106,9 @@ class QLoadoutEditor(QGroupBox):
         payload_name = payload_name_input.textValue()
         ac_type = self.flight.unit_type.dcs_unit_type
         ac_id = ac_type.id
+        mission_editor_folder = mission_editor_dir()
+        if not mission_editor_folder.exists():
+            mission_editor_folder.mkdir()
         payloads_folder = payloads_dir()
         payload_file = payloads_folder / f"{ac_id}.lua"
         if not payloads_folder.exists():

--- a/qt_ui/windows/mission/flight/payload/QLoadoutEditor.py
+++ b/qt_ui/windows/mission/flight/payload/QLoadoutEditor.py
@@ -21,10 +21,7 @@ from game import Game
 from game.ato.flight import Flight
 from game.ato.flightmember import FlightMember
 from game.data.weapons import Pylon
-from game.persistency import (
-    payloads_dir,
-    mission_editor_dir,
-)
+from game.persistency import payloads_dir
 from qt_ui.blocksignals import block_signals
 from qt_ui.windows.mission.flight.payload.QPylonEditor import QPylonEditor
 
@@ -106,13 +103,9 @@ class QLoadoutEditor(QGroupBox):
         payload_name = payload_name_input.textValue()
         ac_type = self.flight.unit_type.dcs_unit_type
         ac_id = ac_type.id
-        mission_editor_folder = mission_editor_dir()
-        if not mission_editor_folder.exists():
-            mission_editor_folder.mkdir()
         payloads_folder = payloads_dir()
         payload_file = payloads_folder / f"{ac_id}.lua"
-        if not payloads_folder.exists():
-            payloads_folder.mkdir()
+        payloads_folder.mkdir(parents=True, exist_ok=True)
         ac_type.payloads[payload_name] = DcsPayload.from_flight_member(
             self.flight_member, payload_name
         ).to_dict()


### PR DESCRIPTION
Fixes MissionEditorDir not found error. Tested by renaming the MissionEditor directory in my saved games folder, directory got created and loadout was saved