### PR TITLE
Add ability to select loadout on flight creation

### DIFF
--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -1,6 +1,6 @@
 from typing import Optional, Type
 
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, Signal, QEvent
 from PySide6.QtWidgets import (
     QComboBox,
     QDialog,
@@ -10,6 +10,9 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QLineEdit,
     QHBoxLayout,
+    # QTextEdit,
+    QStyledItemDelegate,
+    QToolTip,
 )
 from dcs.unittype import FlyingType
 
@@ -88,8 +91,16 @@ class QFlightCreator(QDialog):
 
         layout.addWidget(QLabel("Loadout:"))
         self.loadout_selector = QComboBox()
+        self.loadout_selector.setItemDelegate(LoadoutDelegate(self.loadout_selector))
         for loadout in Loadout.iter_for_aircraft(self.aircraft_selector.currentData()):
             self.loadout_selector.addItem(loadout.name, loadout)
+        for loadout in Loadout.default_loadout_names_for(
+            self.task_selector.currentData()
+        ):
+            index = self.loadout_selector.findText(loadout)
+            if index != -1:
+                self.loadout_selector.setCurrentIndex(index)
+                break
         layout.addWidget(self.loadout_selector)
 
         required_start_type = None
@@ -225,11 +236,20 @@ class QFlightCreator(QDialog):
             self.task_selector.currentData(), new_aircraft
         )
         self.divert.change_aircraft(new_aircraft)
-
-        self.loadout_selector.clear()
-        for loadout in Loadout.iter_for_aircraft(new_aircraft):
-            self.loadout_selector.addItem(loadout.name, loadout)
         self.roster_editor.pilots_changed.emit()
+        if self.aircraft_selector.currentData() is not None:
+            self.loadout_selector.clear()
+            for loadout in Loadout.iter_for_aircraft(
+                self.aircraft_selector.currentData()
+            ):
+                self.loadout_selector.addItem(loadout.name, loadout)
+            for loadout in Loadout.default_loadout_names_for(
+                self.task_selector.currentData()
+            ):
+                index = self.loadout_selector.findText(loadout)
+                if index != -1:
+                    self.loadout_selector.setCurrentIndex(index)
+                    break
 
     def on_departure_changed(self, departure: ControlPoint) -> None:
         if isinstance(departure, OffMapSpawn):
@@ -307,3 +327,18 @@ class QFlightCreator(QDialog):
         if loadout is None:
             return Loadout.empty_loadout()
         return loadout
+
+
+class LoadoutDelegate(QStyledItemDelegate):
+    def helpEvent(self, event, view, option, index):
+        if event.type() == QEvent.ToolTip:
+            loadout = index.data(Qt.UserRole)
+            if loadout:
+                max_pylon = max(loadout.pylons.keys(), default=0)
+                pylons_info = "\n".join(
+                    f"Pylon {pylon}: {loadout.pylons.get(pylon, 'Empty')}"
+                    for pylon in range(1, max_pylon + 1)
+                )
+                QToolTip.showText(event.globalPos(), pylons_info, view)
+                return True
+        return helpEvent(event, view, option, index)

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -16,6 +16,7 @@ from dcs.unittype import FlyingType
 from game import Game
 from game.ato.flight import Flight
 from game.ato.flightroster import FlightRoster
+from game.ato.loadouts import Loadout
 from game.ato.package import Package
 from game.ato.starttype import StartType
 from game.squadrons.squadron import Squadron
@@ -84,6 +85,12 @@ class QFlightCreator(QDialog):
         self.flight_size_spinner = QFlightSizeSpinner()
         self.update_max_size(self.squadron_selector.aircraft_available)
         layout.addLayout(QLabeledWidget("Size:", self.flight_size_spinner))
+
+        layout.addWidget(QLabel("Loadout:"))
+        self.loadout_selector = QComboBox()
+        for loadout in Loadout.iter_for_aircraft(self.aircraft_selector.currentData()):
+            self.loadout_selector.addItem(loadout.name, loadout)
+        layout.addWidget(self.loadout_selector)
 
         required_start_type = None
         squadron = self.squadron_selector.currentData()
@@ -206,6 +213,7 @@ class QFlightCreator(QDialog):
                 member.assign_tgp_laser_code(
                     self.game.laser_code_registry.alloc_laser_code()
                 )
+            member.loadout = self.current_loadout()
 
         # noinspection PyUnresolvedReferences
         self.created.emit(flight)
@@ -218,6 +226,9 @@ class QFlightCreator(QDialog):
         )
         self.divert.change_aircraft(new_aircraft)
 
+        self.loadout_selector.clear()
+        for loadout in Loadout.iter_for_aircraft(new_aircraft):
+            self.loadout_selector.addItem(loadout.name, loadout)
         self.roster_editor.pilots_changed.emit()
 
     def on_departure_changed(self, departure: ControlPoint) -> None:
@@ -290,3 +301,9 @@ class QFlightCreator(QDialog):
             start_type = self.game.settings.default_start_type
 
         self.start_type.setCurrentText(start_type.value)
+
+    def current_loadout(self) -> Loadout:
+        loadout = self.loadout_selector.currentData()
+        if loadout is None:
+            return Loadout.empty_loadout()
+        return loadout

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -328,9 +328,8 @@ class LoadoutDelegate(QStyledItemDelegate):
             if loadout:
                 max_pylon = max(loadout.pylons.keys(), default=0)
                 pylons_info = "\n".join(
-                    f"Pylon {pylon}: {loadout.pylons.get(pylon, 'Empty')}"
+                    f"Pylon {pylon}: {loadout.pylons.get(pylon, 'Clean')}"
                     for pylon in range(1, max_pylon + 1)
                 )
                 QToolTip.showText(event.globalPos(), pylons_info, view)
                 return True
-        return helpEvent(event, view, option, index)

--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -10,7 +10,6 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QLineEdit,
     QHBoxLayout,
-    # QTextEdit,
     QStyledItemDelegate,
     QToolTip,
 )
@@ -92,15 +91,7 @@ class QFlightCreator(QDialog):
         layout.addWidget(QLabel("Loadout:"))
         self.loadout_selector = QComboBox()
         self.loadout_selector.setItemDelegate(LoadoutDelegate(self.loadout_selector))
-        for loadout in Loadout.iter_for_aircraft(self.aircraft_selector.currentData()):
-            self.loadout_selector.addItem(loadout.name, loadout)
-        for loadout in Loadout.default_loadout_names_for(
-            self.task_selector.currentData()
-        ):
-            index = self.loadout_selector.findText(loadout)
-            if index != -1:
-                self.loadout_selector.setCurrentIndex(index)
-                break
+        self._init_loadout_selector()
         layout.addWidget(self.loadout_selector)
 
         required_start_type = None
@@ -238,18 +229,7 @@ class QFlightCreator(QDialog):
         self.divert.change_aircraft(new_aircraft)
         self.roster_editor.pilots_changed.emit()
         if self.aircraft_selector.currentData() is not None:
-            self.loadout_selector.clear()
-            for loadout in Loadout.iter_for_aircraft(
-                self.aircraft_selector.currentData()
-            ):
-                self.loadout_selector.addItem(loadout.name, loadout)
-            for loadout in Loadout.default_loadout_names_for(
-                self.task_selector.currentData()
-            ):
-                index = self.loadout_selector.findText(loadout)
-                if index != -1:
-                    self.loadout_selector.setCurrentIndex(index)
-                    break
+            self._init_loadout_selector()
 
     def on_departure_changed(self, departure: ControlPoint) -> None:
         if isinstance(departure, OffMapSpawn):
@@ -327,6 +307,18 @@ class QFlightCreator(QDialog):
         if loadout is None:
             return Loadout.empty_loadout()
         return loadout
+
+    def _init_loadout_selector(self):
+        self.loadout_selector.clear()
+        for loadout in Loadout.iter_for_aircraft(self.aircraft_selector.currentData()):
+            self.loadout_selector.addItem(loadout.name, loadout)
+        for loadout in Loadout.default_loadout_names_for(
+            self.task_selector.currentData()
+        ):
+            index = self.loadout_selector.findText(loadout)
+            if index != -1:
+                self.loadout_selector.setCurrentIndex(index)
+                break
 
 
 class LoadoutDelegate(QStyledItemDelegate):


### PR DESCRIPTION
These changes allow for users to select a loadout for a flight during flight creation. Tested in retribution UI and checked the created mission to ensure loadouts were properly adjusted.