### PR TITLE
Better handling of flights with no loadouts ex. Tankers

### DIFF
--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -314,7 +314,9 @@ class QFlightCreator(QDialog):
     def _init_loadout_selector(self):
         self.loadout_selector.clear()
         ac_type = self.aircraft_selector.currentData()
-        if ac_type is None:
+        if ac_type is None or not any(list(Loadout.iter_for_aircraft(ac_type))):
+            self.loadout_selector.addItem("No loadouts available", None)
+            self.loadout_selector.setDisabled(True)
             return
         for loadout in Loadout.iter_for_aircraft(ac_type):
             self.loadout_selector.addItem(loadout.name, loadout)


### PR DESCRIPTION
Previously the loadout box would be empty and not disabled for tanker flights. This PR changes that behavior so that if there are no loadouts to select the box is disabled and says "No loadouts available"