### PR TITLE
Loadout Selector Bugfix

### DIFF
--- a/qt_ui/windows/mission/flight/QFlightCreator.py
+++ b/qt_ui/windows/mission/flight/QFlightCreator.py
@@ -318,6 +318,8 @@ class QFlightCreator(QDialog):
             self.loadout_selector.addItem("No loadouts available", None)
             self.loadout_selector.setDisabled(True)
             return
+        else:
+            self.loadout_selector.setDisabled(False)
         for loadout in Loadout.iter_for_aircraft(ac_type):
             self.loadout_selector.addItem(loadout.name, loadout)
         for loadout in Loadout.default_loadout_names_for(


### PR DESCRIPTION
There is currently a bug where if a user selects a flight type with no loadouts available it would disable the loadout selector and then if they changed the task or aircraft to ones that have loadouts the loadout selector would stay disabled