### PR TITLE
AI Helo RTB Settings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 * **[Package Planning]** Ability to plan recovery tanker flights
 * **[Modding]** Support for Bandit's cloud presets mod (v15)
 * **[UX]** Reduce size of save-file by loading landmap data on the fly, which also implies no new campaign needs to be started to benefit from an updated landmap
+* **[Options]** New option to make AI helos RTB when winchester on rockets and guided munitions
 
 ## Fixes
 * **[UI/UX]** A-10A flights can be edited again

--- a/game/missiongenerator/aircraft/aircraftbehavior.py
+++ b/game/missiongenerator/aircraft/aircraftbehavior.py
@@ -114,15 +114,15 @@ class AircraftBehavior:
         mission_uses_gun: bool = True,
         rtb_on_bingo: bool = True,
         ai_unlimited_fuel: Optional[bool] = None,
-        ai_no_gun: Optional[bool] = None,
+        ai_dont_use_gun: Optional[bool] = None,
     ) -> None:
         group.points[0].tasks.clear()
         if ai_unlimited_fuel is None:
             ai_unlimited_fuel = (
                 flight.squadron.coalition.game.settings.ai_unlimited_fuel
             )
-        if ai_no_gun is None:
-            ai_no_gun = flight.squadron.coalition.game.settings.ai_no_gun
+        if ai_dont_use_gun is None:
+            ai_dont_use_gun = flight.squadron.coalition.game.settings.ai_dont_use_gun
         # at IP, insert waypoint to orient aircraft in correct direction
         layout = flight.flight_plan.layout
         at_ip_or_combat = flight.state.is_at_ip or flight.state.in_combat
@@ -150,7 +150,7 @@ class AircraftBehavior:
         if restrict_jettison is not None:
             group.points[0].tasks.append(OptRestrictJettison(restrict_jettison))
         if rtb_winchester is not None:
-            if ai_no_gun and flight.is_helo and flight.client_count == 0:
+            if ai_dont_use_gun and flight.is_helo:
                 group.points[0].tasks.append(
                     OptRTBOnOutOfAmmo(OptRTBOnOutOfAmmo.Values.Rockets)
                 )
@@ -212,13 +212,6 @@ class AircraftBehavior:
             ammo_type = OptRTBOnOutOfAmmo.Values.Cannon
 
         self.configure_behavior(flight, group, rtb_winchester=ammo_type)
-
-    def configure_ai_no_gun(
-        self, group: FlyingGroup[Any], flight: Flight, ai_no_gun: bool = False
-    ) -> None:
-        if ai_no_gun and flight.is_helo and flight.client_count == 0:
-            for unit in group.units:
-                unit.gun = 0
 
     def configure_cas(self, group: FlyingGroup[Any], flight: Flight) -> None:
         self.configure_task(flight, group, CAS, [AFAC, AntishipStrike])

--- a/game/missiongenerator/aircraft/aircraftbehavior.py
+++ b/game/missiongenerator/aircraft/aircraftbehavior.py
@@ -114,15 +114,17 @@ class AircraftBehavior:
         mission_uses_gun: bool = True,
         rtb_on_bingo: bool = True,
         ai_unlimited_fuel: Optional[bool] = None,
-        ai_dont_use_gun: Optional[bool] = None,
+        ai_helo_rtb_on_winchester: Optional[bool] = None,
     ) -> None:
         group.points[0].tasks.clear()
         if ai_unlimited_fuel is None:
             ai_unlimited_fuel = (
                 flight.squadron.coalition.game.settings.ai_unlimited_fuel
             )
-        if ai_dont_use_gun is None:
-            ai_dont_use_gun = flight.squadron.coalition.game.settings.ai_dont_use_gun
+        if ai_helo_rtb_on_winchester is None:
+            ai_helo_rtb_on_winchester = (
+                flight.squadron.coalition.game.settings.ai_helo_rtb_on_winchester
+            )
         # at IP, insert waypoint to orient aircraft in correct direction
         layout = flight.flight_plan.layout
         at_ip_or_combat = flight.state.is_at_ip or flight.state.in_combat
@@ -150,7 +152,7 @@ class AircraftBehavior:
         if restrict_jettison is not None:
             group.points[0].tasks.append(OptRestrictJettison(restrict_jettison))
         if rtb_winchester is not None:
-            if ai_dont_use_gun and flight.is_helo:
+            if ai_helo_rtb_on_winchester and flight.is_helo:
                 group.points[0].tasks.append(
                     OptRTBOnOutOfAmmo(OptRTBOnOutOfAmmo.Values.Rockets)
                 )

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -333,12 +333,12 @@ class Settings:
         detail="AI will jettison their fuel tanks as soon as they're empty.",
     )
 
-    ai_no_gun: bool = boolean_option(
-        "AI helos will not use guns",
+    ai_rtb_on_rockets_and_guided: bool = boolean_option(
+        "Enable AI RTB without emptying guns",
         page=CAMPAIGN_DOCTRINE_PAGE,
         section=GENERAL_SECTION,
         default=False,
-        detail="AI helos will spawn without ammo for their guns.",
+        detail="AI helos will rtb when winchester on rockets and guided missiles.",
     )
 
     max_plane_altitude_offset: int = bounded_int_option(

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -333,12 +333,12 @@ class Settings:
         detail="AI will jettison their fuel tanks as soon as they're empty.",
     )
 
-    ai_rtb_on_rockets_and_guided: bool = boolean_option(
+    ai_helo_rtb_on_winchester: bool = boolean_option(
         "Enable AI RTB without emptying guns",
         page=CAMPAIGN_DOCTRINE_PAGE,
         section=GENERAL_SECTION,
         default=False,
-        detail="AI helos will rtb when winchester on rockets and guided missiles.",
+        detail="AI helos will RTB when winchester on rockets and guided missiles.",
     )
 
     max_plane_altitude_offset: int = bounded_int_option(

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -332,6 +332,15 @@ class Settings:
         default=False,
         detail="AI will jettison their fuel tanks as soon as they're empty.",
     )
+
+    ai_no_gun: bool = boolean_option(
+        "AI helos will not use guns",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=False,
+        detail="AI helos will spawn without ammo for their guns.",
+    )
+
     max_plane_altitude_offset: int = bounded_int_option(
         "Maximum randomized altitude offset (x1000 ft) for airplanes.",
         page=CAMPAIGN_DOCTRINE_PAGE,


### PR DESCRIPTION
New setting added to adjust AI helo RTB when winchester on rockets and guns, this will make AI helos not engage with guns which often results in their untimely death https://github.com/dcs-retribution/dcs-retribution/issues/241