### PR TITLE
Fix airwing config not properly saving or loading

### DIFF
--- a/game/campaignloader/campaignairwingconfig.py
+++ b/game/campaignloader/campaignairwingconfig.py
@@ -71,9 +71,25 @@ class CampaignAirWingConfig:
         cls, data: dict[Union[str, int], Any], theater: ConflictTheater
     ) -> CampaignAirWingConfig:
         by_location: dict[ControlPoint, list[SquadronConfig]] = defaultdict(list)
+        carriers = theater.find_carriers()
+        lhas = theater.find_lhas()
         for base_id, squadron_configs in data.items():
             if isinstance(base_id, int):
                 base = theater.find_control_point_by_airport_id(base_id)
+            elif "CVN" in base_id:
+                if carriers:
+                    base = carriers.pop(0)
+                else:
+                    raise ValueError(
+                        f"Air wing config incompatible due to lack of carriers in theater"
+                    )
+            elif "LHA" in base_id:
+                if lhas:
+                    base = lhas.pop(0)
+                else:
+                    raise ValueError(
+                        f"Air wing config incompatible due to lack of LHAs in theater"
+                    )
             else:
                 base = theater.control_point_named(base_id)
 

--- a/game/campaignloader/campaignairwingconfig.py
+++ b/game/campaignloader/campaignairwingconfig.py
@@ -4,8 +4,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Optional, TYPE_CHECKING, Union
 
-from game.dcs.shipunittype import ShipUnitType
-
 from game.ato.flighttype import FlightType
 from game.theater.controlpoint import ControlPoint
 

--- a/game/campaignloader/campaignairwingconfig.py
+++ b/game/campaignloader/campaignairwingconfig.py
@@ -4,11 +4,14 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Optional, TYPE_CHECKING, Union
 
+from game.dcs.shipunittype import ShipUnitType
+
 from game.ato.flighttype import FlightType
 from game.theater.controlpoint import ControlPoint
 
 if TYPE_CHECKING:
     from game.theater import ConflictTheater
+    from game.factions import Faction
 
 
 DEFAULT_SQUADRON_SIZE = 12
@@ -74,24 +77,24 @@ class CampaignAirWingConfig:
         carriers = theater.find_carriers()
         lhas = theater.find_lhas()
         for base_id, squadron_configs in data.items():
+            base: Optional[ControlPoint] = None
             if isinstance(base_id, int):
                 base = theater.find_control_point_by_airport_id(base_id)
-            elif "CVN" in base_id:
-                if carriers:
-                    base = carriers.pop(0)
-                else:
-                    raise ValueError(
-                        f"Air wing config incompatible due to lack of carriers in theater"
-                    )
-            elif "LHA" in base_id:
-                if lhas:
-                    base = lhas.pop(0)
-                else:
-                    raise ValueError(
-                        f"Air wing config incompatible due to lack of LHAs in theater"
-                    )
             else:
-                base = theater.control_point_named(base_id)
+                try:
+                    base = theater.control_point_named(base_id)
+                except:
+                    if base_id == "Red CV":
+                        base = next((c for c in carriers if not c.captured), None)
+                    elif base_id == "Blue CV":
+                        base = next((c for c in carriers if c.captured), None)
+                    elif base_id == "Red LHA":
+                        base = next((l for l in lhas if not l.captured), None)
+                    elif base_id == "Blue LHA":
+                        base = next((l for l in lhas if l.captured), None)
+
+            if base is None:
+                raise ValueError(f"No valid control points found {base_id}")
 
             for squadron_data in squadron_configs:
                 by_location[base].append(SquadronConfig.from_data(squadron_data))

--- a/game/campaignloader/campaignairwingconfig.py
+++ b/game/campaignloader/campaignairwingconfig.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Optional, TYPE_CHECKING, Union
@@ -90,10 +92,12 @@ class CampaignAirWingConfig:
                     elif base_id == "Blue LHA":
                         base = next((l for l in lhas if l.captured), None)
 
-            if base is None:
-                raise ValueError(f"No valid control points found {base_id}")
-
             for squadron_data in squadron_configs:
-                by_location[base].append(SquadronConfig.from_data(squadron_data))
+                if base is None:
+                    logging.warning(
+                        f"Skipping squadron config for unknown base: {base_id}"
+                    )
+                else:
+                    by_location[base].append(SquadronConfig.from_data(squadron_data))
 
         return CampaignAirWingConfig(by_location)

--- a/game/campaignloader/campaignairwingconfig.py
+++ b/game/campaignloader/campaignairwingconfig.py
@@ -9,7 +9,6 @@ from game.theater.controlpoint import ControlPoint
 
 if TYPE_CHECKING:
     from game.theater import ConflictTheater
-    from game.factions import Faction
 
 
 DEFAULT_SQUADRON_SIZE = 12

--- a/game/theater/conflicttheater.py
+++ b/game/theater/conflicttheater.py
@@ -271,6 +271,14 @@ class ConflictTheater:
                 return cp
         raise KeyError(f"Cannot find ControlPoint named {name}")
 
+    def find_carriers(self) -> List[ControlPoint]:
+        carriers = [cp for cp in self.controlpoints if cp.is_carrier]
+        return carriers
+
+    def find_lhas(self) -> List[ControlPoint]:
+        lhas = [cp for cp in self.controlpoints if cp.is_lha]
+        return lhas
+
     def heading_to_conflict_from(self, position: Point) -> Optional[Heading]:
         # Heading for a Group to the enemy.
         # Should be the point between the nearest and the most distant conflict

--- a/game/theater/conflicttheater.py
+++ b/game/theater/conflicttheater.py
@@ -272,12 +272,18 @@ class ConflictTheater:
         raise KeyError(f"Cannot find ControlPoint named {name}")
 
     def find_carriers(self) -> List[ControlPoint]:
-        carriers = [cp for cp in self.controlpoints if cp.is_carrier]
-        return carriers
+        try:
+            carriers = [cp for cp in self.controlpoints if cp.is_carrier]
+            return carriers
+        except:
+            return []
 
     def find_lhas(self) -> List[ControlPoint]:
-        lhas = [cp for cp in self.controlpoints if cp.is_lha]
-        return lhas
+        try:
+            lhas = [cp for cp in self.controlpoints if cp.is_lha]
+            return lhas
+        except:
+            return []
 
     def heading_to_conflict_from(self, position: Point) -> Optional[Heading]:
         # Heading for a Group to the enemy.

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -823,6 +823,8 @@ class AirWingConfigurationDialog(QDialog):
         )
         fd.setAcceptMode(QFileDialog.AcceptMode.AcceptSave)
         if fd.exec_():
+            for tab in self.tabs:
+                tab.apply()
             airwing = self._build_air_wing()
             filename = fd.selectedFiles()[0]
             with open(filename, "w") as f:

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -849,7 +849,7 @@ class AirWingConfigurationDialog(QDialog):
             for s in sqs:
                 cp = s.location.at
                 if isinstance(cp, Point):
-                    key = s.location.name
+                    key = s.location.full_name
                 else:
                     key = cp.id
                 name = (

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -817,6 +817,17 @@ class AirWingConfigurationDialog(QDialog):
         layout.addLayout(buttons_layout)
 
     def save_config(self) -> None:
+        result = QMessageBox.information(
+            None,
+            "Save Air Wing?",
+            "Revert will not be possible after saving a different Air Wing.<br />"
+            "Are you sure you want to continue?",
+            QMessageBox.StandardButton.Yes,
+            QMessageBox.StandardButton.No,
+        )
+        if result == QMessageBox.StandardButton.No:
+            return
+
         awd = airwing_dir()
         fd = QFileDialog(
             caption="Save Air Wing", directory=str(awd), filter="*.yaml;*.yml"


### PR DESCRIPTION
Previously, saving an airwing config would not actually save your exact air wing because the tabs were not being properly updated. You would end up with whatever squadrons you added but any that were removed would not be removed when the air wing was saved. That is now fixed. Additionally, loading an airwing config after starting a new campaign would throw errors due to carrier names not matching up, this is now fixed.