### PR TITLE
Autocreate package fix

### DIFF
--- a/game/commander/packagebuilder.py
+++ b/game/commander/packagebuilder.py
@@ -48,6 +48,7 @@ class PackageBuilder:
         using release_planned_aircraft.
         """
         target = self.package.target
+        heli = False
         pf = self.package.primary_flight
         if pf:
             target = (
@@ -56,11 +57,15 @@ class PackageBuilder:
                 in [FlightType.AEWC, FlightType.REFUELING, FlightType.RECOVERY]
                 else target
             )
+            if plan.preferred_type:
+                heli = plan.preferred_type.helicopter
+            else:
+                heli = pf.is_helo
         squadron = self.air_wing.best_squadron_for(
             target,
             plan.task,
             plan.num_aircraft,
-            plan.preferred_type.helicopter,
+            heli,
             this_turn=True,
             preferred_type=plan.preferred_type,
             ignore_range=ignore_range,

--- a/game/commander/packagebuilder.py
+++ b/game/commander/packagebuilder.py
@@ -48,7 +48,6 @@ class PackageBuilder:
         using release_planned_aircraft.
         """
         target = self.package.target
-        heli = False
         pf = self.package.primary_flight
         if pf:
             target = (
@@ -57,12 +56,11 @@ class PackageBuilder:
                 in [FlightType.AEWC, FlightType.REFUELING, FlightType.RECOVERY]
                 else target
             )
-            heli = pf.is_helo
         squadron = self.air_wing.best_squadron_for(
             target,
             plan.task,
             plan.num_aircraft,
-            heli,
+            plan.preferred_type.helicopter,
             this_turn=True,
             preferred_type=plan.preferred_type,
             ignore_range=ignore_range,


### PR DESCRIPTION
Bugfix WRT: https://discord.com/channels/1015931619187621999/1025759185511653387/1326666368799735808

Looks like this bug would occur any time you attempt to use the auto create feature and an air assault (or other primary task flight) was a helicopter. Helo would be set to true and all of the escorts, sead sweep, etc would fail to find a squadron because they are looking for only helo squadrons. Maybe this was preferred in the past to keep a flight package of only helos if a helo task is the primary flight? Unsure but this fixes the bug.

Fix: Use plan.perferred_type.helicopter instead of heli/primaryflight.is_helo

Please review, it's only a few lines changed but the affects might be farther reaching than I understand. I presume we were using the primary flight is helo attribute for some reason but I can't see why it would be better than plan.preferred_type.helicopter