### PR TITLE
Update Tu-160 mission types

### DIFF
--- a/resources/units/aircraft/Tu-160.yaml
+++ b/resources/units/aircraft/Tu-160.yaml
@@ -17,4 +17,7 @@ max_range: 2000
 variants:
   Tu-160 Blackjack: {}
 tasks:
+  Anti-ship: 100
+  BAI: 370
+  DEAD: 210
   Strike: 680


### PR DESCRIPTION
I think the regular Tu-160 should have the same mission types available as the CurrentHill variant. They both carry cruise missiles, though different variants. The CurrentHill Tu-160 carries the older Kh-55 and the newer Kh-101, and the regular Tu-160 carries the Kh-65.