### PR TITLE
Add in F-22A mod version number

### DIFF
--- a/qt_ui/windows/newgame/WizardPages/QGeneratorSettings.py
+++ b/qt_ui/windows/newgame/WizardPages/QGeneratorSettings.py
@@ -199,7 +199,7 @@ class GeneratorOptions(QtWidgets.QWizardPage):
             ("F-15D Baz (v1.0)", self.f15d_baz),
             ("F-15I Ra'am (v1.0 by IDF Mods Project)", self.f_15_idf),
             ("F-16I Sufa & F-16D (v3.6 by IDF Mods Project)", self.f_16_idf),
-            ("F-22A Raptor", self.f22_raptor),
+            ("F-22A Raptor (v3.0)", self.f22_raptor),
             ("F-4B/C Phantom II (2.8.7.204)", self.f4bc_phantom),
             ("F-84G Thunderjet (v2.5.7.01)", self.f84g_thunderjet),
             ("F9F Panther (v2.8.7.101)", self.f9f_panther),


### PR DESCRIPTION
The F-22A mod is missing its supported version information. Have verified that 3.0 (the latest version) is working in Retribution.