### PR TITLE
correctly remove CH presets for russia

### DIFF
--- a/game/factions/faction.py
+++ b/game/factions/faction.py
@@ -754,9 +754,9 @@ class Faction:
             self.remove_aircraft("CH_Mi28N")
             self.remove_aircraft("CH_Ka52")
             self.remove_aircraft("CH_Ka52K")
-            self.remove_preset("BAL_LBASM")
-            self.remove_preset("BUK_M3")
-            self.remove_preset("Bastion-P_LBASM")
+            self.remove_preset("BAL LBASM")
+            self.remove_preset("BUK M3")
+            self.remove_preset("Bastion-P LBASM")
             self.remove_preset("S-350")
 
     def remove_aircraft(self, name: str) -> None:


### PR DESCRIPTION
Wrong names for the presets caused them to not be properly removed when the mod wasn't enabled, this is now fixed