### PR TITLE
Missile sites now fire at random times

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,11 @@
 * **[New Game Wizard]** Ability to save an edited faction during new game creation
 * **[Options]** New option to make AI helicopters prefer vertical takeoff and landing
 * **[Campaign Design/Mission Generation]** Introduction of "rebel zones" which randomly spawn units according to the campaign's definitions.
+* **[Mission Generation]** Missile sites now fire at random times instead of all at the beginning of the mission
+* **[Modding]** Support for CurrentHill's Chinese Asset Pack (v1.1.4)
+* **[Modding]** Updated support for CurrentHill's Swedish Asset Pack (v1.1.0)
+* **[Modding]** Support for CurrentHill's Russian Asset Pack (v1.2.0)
+* **[Modding]** Support for CurrentHill's USA Asset Pack (v1.1.5)
 
 ## Fixes
 * **[UI/UX]** A-10A flights can be edited again

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -35,6 +35,8 @@ from dcs.task import (
     ActivateICLSCommand,
     ActivateLink4Command,
     ActivateACLSCommand,
+    ControlledTask,
+    Hold,
     EPLRS,
     FireAtPoint,
     OptAlarmState,
@@ -488,7 +490,6 @@ class MissileSiteGenerator(GroundObjectGenerator):
 
         # Note : Only the SCUD missiles group can fire (V1 site cannot fire in game right now)
         # TODO : Should be pre-planned ?
-        # TODO : Add delay to task to spread fire task over mission duration ?
         for group in self.ground_object.groups:
             vg = self.m.find_group(group.group_name)
             if vg is not None:
@@ -498,6 +499,14 @@ class MissileSiteGenerator(GroundObjectGenerator):
                     real_target = target.point_from_heading(
                         Heading.random().degrees, random.randint(0, 2500)
                     )
+                    hold = ControlledTask(Hold())
+                    hold.stop_after_duration(
+                        random.randint(
+                            60,
+                            self.game.settings.desired_player_mission_duration.total_seconds(),
+                        )
+                    )
+                    vg.points[0].add_task(hold)
                     vg.points[0].add_task(FireAtPoint(real_target))
                     logging.info("Set up fire task for missile group.")
                 else:

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -503,7 +503,9 @@ class MissileSiteGenerator(GroundObjectGenerator):
                     hold.stop_after_duration(
                         random.randint(
                             60,
-                            self.game.settings.desired_player_mission_duration.total_seconds(),
+                            int(
+                                self.game.settings.desired_player_mission_duration.total_seconds()
+                            ),
                         )
                     )
                     vg.points[0].add_task(hold)


### PR DESCRIPTION
Previously SCUDs would all fire at the start of a mission causing massive lag, now SCUDs fire randomly during the mission by setting a hold task before the fire task. My only reservation is maybe this should be set to half the mission duration to make them more likely to fire while the player is flying the mission?