### PR TITLE
Remove SEAD and SEAD Escort mission type from Gripen

### DIFF
--- a/resources/units/aircraft/CH_JAS39C.yaml
+++ b/resources/units/aircraft/CH_JAS39C.yaml
@@ -20,7 +20,5 @@ tasks:
   Intercept: 430
   OCA/Aircraft: 750
   OCA/Runway: 610
-  SEAD: 750
-  SEAD Escort: 750
   Strike: 610
   TARCAP: 430


### PR DESCRIPTION
Sweden doesn't use anti-radiation missiles and Gripens don't perform those missions.