### PR TITLE
Allow users to plan refueling and escort flights

### DIFF
--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1259,6 +1259,7 @@ class Airfield(ControlPoint, CTLD):
         if self.is_friendly(for_player):
             yield from [
                 FlightType.AEWC,
+                FlightType.ESCORT,
                 # TODO: FlightType.INTERCEPTION
                 # TODO: FlightType.LOGISTICS
             ]
@@ -1372,6 +1373,7 @@ class NavalControlPoint(
                 FlightType.AEWC,
                 FlightType.RECOVERY,
                 FlightType.REFUELING,
+                FlightType.ESCORT,
                 # TODO: FlightType.INTERCEPTION
                 # TODO: Buddy tanking for the A-4?
                 # TODO: Rescue chopper?
@@ -1655,8 +1657,11 @@ class Fob(ControlPoint, RadioFrequencyContainer, CTLD):
             if self.total_aircraft_parking(ParkingType(True, True, True)):
                 yield FlightType.OCA_AIRCRAFT
         else:
-            yield FlightType.AEWC
-
+            yield from [
+                FlightType.AEWC,
+                FlightType.ESCORT,
+                FlightType.REFUELING,
+            ]
         yield from super().mission_types(for_player)
 
     def total_aircraft_parking(self, parking_type: ParkingType) -> int:


### PR DESCRIPTION
Previously users could not plan refueling flights on FOBs. Additionally they could not create a refueling package on a friendly CP and add escorts because escort missions were only allowed vs enemy control points. This PR fixes all of that but may have implications for the autoplanner, please let me know if it does and how to mitigate it.

Longterm we should look to add some validation to the package creation so you can't plan an escort flight with nothing else in the package. Currently doing so will not throw a visual error to the user but it will bug out the campaign with this stack trace:

```
Traceback (most recent call last):
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\uvicorn\protocols\websockets\websockets_impl.py", line 244, in run_asgi
    result = await self.app(self.scope, self.asgi_receive, self.asgi_send)  # type: ignore[func-returns-value]
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\uvicorn\middleware\proxy_headers.py", line 70, in __call__
    return await self.app(scope, receive, send)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\fastapi\applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\middleware\errors.py", line 152, in __call__
    await self.app(scope, receive, send)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\middleware\cors.py", line 77, in __call__
    await self.app(scope, receive, send)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\middleware\exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\routing.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\routing.py", line 735, in app
    await route.handle(scope, receive, send)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\routing.py", line 362, in handle
    await self.app(scope, receive, send)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\routing.py", line 95, in app
    await wrap_app_handling_exceptions(app, session)(scope, receive, send)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\starlette\routing.py", line 93, in app
    await func(session)
  File "c:\Users\zagxc\git\dcs-retribution\env\lib\site-packages\fastapi\routing.py", line 383, in app
    await dependant.call(**solved_result.values)
  File "C:\Users\zagxc\git\dcs-retribution\game\server\eventstream\routes.py", line 52, in event_stream
    GameUpdateEventsJs.from_events(events, GameContext.get())
  File "C:\Users\zagxc\git\dcs-retribution\game\server\eventstream\models.py", line 100, in from_events
    new_flights=[
  File "C:\Users\zagxc\git\dcs-retribution\game\server\eventstream\models.py", line 101, in <listcomp>
    FlightJs.for_flight(f, with_waypoints=True) for f in events.new_flights
  File "C:\Users\zagxc\git\dcs-retribution\game\server\flights\models.py", line 43, in for_flight
    waypoints = waypoints_for_flight(flight)
  File "C:\Users\zagxc\git\dcs-retribution\game\server\waypoints\routes.py", line 32, in waypoints_for_flight
    return [departure] + [
  File "C:\Users\zagxc\git\dcs-retribution\game\server\waypoints\routes.py", line 33, in <listcomp>
    FlightWaypointJs.for_waypoint(w, flight, i)
  File "C:\Users\zagxc\git\dcs-retribution\game\server\waypoints\models.py", line 91, in for_waypoint
    timing=timing_info(flight, waypoint_idx),
  File "C:\Users\zagxc\git\dcs-retribution\game\server\waypoints\models.py", line 16, in timing_info
    time = flight.flight_plan.tot_for_waypoint(waypoint)
  File "C:\Users\zagxc\git\dcs-retribution\game\ato\flightplans\formationattack.py", line 131, in tot_for_waypoint
    return super().tot_for_waypoint(waypoint)
  File "C:\Users\zagxc\git\dcs-retribution\game\ato\flightplans\formation.py", line 89, in tot_for_waypoint
    return self.split_time
  File "C:\Users\zagxc\git\dcs-retribution\game\ato\flightplans\escort.py", line 27, in split_time
    return self.package.primary_flight.flight_plan.mission_departure_time
  File "C:\Users\zagxc\git\dcs-retribution\game\ato\flightplans\formation.py", line 110, in mission_departure_time
    return self.split_time
    ```