### PR TITLE
Add Growler and Raptor squadrons to some campaigns

### DIFF
--- a/resources/campaigns/exercise_bright_star.yaml
+++ b/resources/campaigns/exercise_bright_star.yaml
@@ -35,6 +35,8 @@ performance: 2
 recommended_start_date: 2025-09-01
 version: "10.7"
 settings:
+  fa_18efg: true
+  f22_raptor: true
   hercules: true
   squadron_start_full: true  
 squadrons:
@@ -43,7 +45,13 @@ squadrons:
       secondary: any
       aircraft:
         - F/A-18C Hornet (Lot 20)
-      size: 24
+      size: 16
+    - primary: SEAD Escort
+      secondary: any
+      aircraft:
+        - EA-18G Growler
+        - F/A-18C Hornet (Lot 20)
+      size: 16
     - primary: AEW&C
       aircraft:
         - E-2D Advanced Hawkeye
@@ -62,6 +70,12 @@ squadrons:
     - primary: Escort
       secondary: any
       aircraft:
+        - F-15C Eagle
+      size: 12
+    - primary: TARCAP
+      secondary: any
+      aircraft:
+        - F-22A Raptor
         - F-15C Eagle
       size: 12
     - primary: OCA/Runway

--- a/resources/campaigns/exercise_vegas_nerve.yaml
+++ b/resources/campaigns/exercise_vegas_nerve.yaml
@@ -20,6 +20,8 @@ recommended_start_date: 2011-02-24
 version: "10.7"
 settings:
   chinesemilitaryassetspack: true
+  fa_18efg: true
+  f22_raptor: true
   hercules: true
   squadron_start_full: true
 squadrons:
@@ -40,6 +42,7 @@ squadrons:
     - primary: TARCAP
       secondary: any
       aircraft:
+        - F-22A Raptor
         - F-15C Eagle
       size: 16
     - primary: Strike
@@ -64,16 +67,22 @@ squadrons:
       aircraft:
         - OH-58D(R) Kiowa Warrior
       size: 2
-    - primary: DEAD
-      secondary: air-to-ground
+    - primary: SEAD
+      secondary: any
       aircraft:
         - F/A-18C Hornet (Lot 20)
-      size: 24
-    - primary: SEAD
-      secondary: air-to-ground
+      size: 16
+    - primary: SEAD Escort
+      secondary: any
+      aircraft:
+        - EA-18G Growler
+        - F/A-18C Hornet (Lot 20)
+      size: 16
+    - primary: DEAD
+      secondary: any
       aircraft:
         - F-16CM Fighting Falcon (Block 50)
-      size: 24
+      size: 20
     - primary: AEW&C
       aircraft:
         - E-3A

--- a/resources/campaigns/operation_noisy_cricket.yaml
+++ b/resources/campaigns/operation_noisy_cricket.yaml
@@ -31,6 +31,8 @@ recommended_enemy_money: 0
 recommended_player_income_multiplier: 0.2
 recommended_enemy_income_multiplier: 0.2
 settings:
+  fa_18efg: true
+  f22_raptor: true
   hercules: true
   squadron_start_full: true
 version: "10.7"
@@ -40,7 +42,13 @@ squadrons:
       secondary: any
       aircraft:
         - F/A-18C Hornet (Lot 20)
-      size: 40
+      size: 24
+    - primary: SEAD Escort
+      secondary: any
+      aircraft:
+        - EA-18G Growler
+        - F/A-18C Hornet (Lot 20)
+      size: 16
     - primary: AEW&C
       aircraft:
         - E-2C Hawkeye
@@ -67,16 +75,17 @@ squadrons:
       aircraft:
         - CH-47F Block I
       size: 4
+    - primary: TARCAP
+      secondary: any
+      aircraft:
+        - F-22A Raptor
+        - F-15C Eagle
+      size: 12
     - primary: DEAD
       secondary: any
       aircraft:
         - F-16CM Fighting Falcon (Block 50)
-      size: 20
-    - primary: Escort
-      secondary: air-to-air
-      aircraft:
-        - F-15C Eagle
-      size: 20
+      size: 16
   #Al Dhafra AFB (251)
   4:
     - primary: Strike
@@ -93,6 +102,11 @@ squadrons:
       aircraft:
         - F-15E Strike Eagle (Suite 4+)
       size: 16
+    - primary: Escort
+      secondary: air-to-air
+      aircraft:
+        - F-15C Eagle
+      size: 12
     - primary: DEAD
       secondary: air-to-ground
       aircraft:

--- a/resources/campaigns/operation_peace_spring.yaml
+++ b/resources/campaigns/operation_peace_spring.yaml
@@ -19,6 +19,8 @@ performance: 2
 recommended_start_date: 2019-12-23
 version: "10.7"
 settings:
+  fa_18efg: true
+  f22_raptor: true
   hercules: true
   squadron_start_full: true
 squadrons:
@@ -27,7 +29,13 @@ squadrons:
       secondary: any
       aircraft:
         - F/A-18C Hornet (Lot 20)
-      size: 24
+      size: 16
+    - primary: SEAD Escort
+      secondary: any
+      aircraft:
+        - EA-18G Growler
+        - F/A-18C Hornet (Lot 20)
+      size: 16
     - primary: AEW&C
       aircraft:
         - E-2D Advanced Hawkeye
@@ -63,29 +71,35 @@ squadrons:
       aircraft:
         - F-15E Strike Eagle (Suite 4+)
       size: 12
-    - primary: TARCAP
+    - primary: Escort
       secondary: air-to-air
       aircraft:
         - F-15C Eagle
-      size: 20
+      size: 16
    # Ramat David
   30:
-    - primary: BAI
+    - primary: CAS
       secondary: air-to-ground
       aircraft:
         - A-10C Thunderbolt II (Suite 7)
       size: 8
+    - primary: TARCAP
+      secondary: any
+      aircraft:
+        - F-22A Raptor
+        - F-15C Eagle
+      size: 16
     - primary: DEAD
       secondary: any
       aircraft:
         - F-16CM Fighting Falcon (Block 50)
-      size: 28
-    - primary: CAS
+      size: 16
+    - primary: Armed Recon
       secondary: any
       aircraft:
         - AH-64D Apache Longbow
       size: 4
-    - primary: CAS
+    - primary: Armed Recon
       secondary: any
       aircraft:
         - OH-58D(R) Kiowa Warrior

--- a/resources/campaigns/operation_vectrons_claw.yaml
+++ b/resources/campaigns/operation_vectrons_claw.yaml
@@ -27,6 +27,8 @@ performance: 1
 recommended_start_date: 2008-08-08
 version: "10.7"
 settings:
+  fa_18efg: true
+  f22_raptor: true
   hercules: true
   squadron_start_full: true
 squadrons:
@@ -36,11 +38,17 @@ squadrons:
       aircraft:
         - F-14B Tomcat
       size: 16
+    - primary: SEAD Escort
+      secondary: any
+      aircraft:
+        - EA-18G Growler
+        - F/A-18C Hornet (Lot 20)
+      size: 16
     - primary: SEAD
       secondary: any
       aircraft:
         - F/A-18C Hornet (Lot 20)
-      size: 24
+      size: 16
     - primary: BAI
       secondary: air-to-ground
       aircraft:
@@ -108,6 +116,12 @@ squadrons:
       aircraft:
         - F-15E Strike Eagle (Suite 4+)
       size: 12
+    - primary: TARCAP
+      secondary: any
+      aircraft:
+        - F-22A Raptor
+        - F-15C Eagle
+      size: 16
     - primary: Escort
       secondary: any
       aircraft:

--- a/resources/campaigns/red_sea_rising.yaml
+++ b/resources/campaigns/red_sea_rising.yaml
@@ -23,11 +23,13 @@ description:
     but for the entire world, as the balance of power teeters on a knife's edge.</p>
 miz: red_sea_rising.miz
 performance: 1
-recommended_start_date: 2003-01-11
+recommended_start_date: 2005-01-11
 version: "10.7"
 settings:
   usamilitaryassetspack: true
   chinesemilitaryassetspack: true
+  fa_18efg: true
+  f22_raptor: true
   hercules: true
   squadron_start_full: true
 squadrons:
@@ -37,7 +39,13 @@ squadrons:
       secondary: any
       aircraft:
         - F/A-18C Hornet (Lot 20)
-      size: 24
+      size: 12
+    - primary: SEAD Escort
+      secondary: any
+      aircraft:
+        - EA-18G Growler
+        - F/A-18C Hornet (Lot 20)
+      size: 12
     - primary: AEW&C
       aircraft:
         - E-2D Advanced Hawkeye
@@ -51,7 +59,7 @@ squadrons:
       secondary: air-to-ground
       aircraft:
         - AV-8B Harrier II Night Attack
-      size: 16
+      size: 12
     - primary: Escort
       secondary: any
       aircraft:
@@ -84,12 +92,18 @@ squadrons:
       aircraft:
         - "[CH] B-21"
         - F-117A Nighthawk
-      size: 16
+      size: 12
   #Tel Nof
   23:
     - primary: Escort
       secondary: any
       aircraft:
+        - F-15C Eagle
+      size: 12
+    - primary: TARCAP
+      secondary: any
+      aircraft:
+        - F-22A Raptor
         - F-15C Eagle
       size: 12
     - primary: OCA/Runway
@@ -155,7 +169,7 @@ squadrons:
       secondary: air-to-air
       aircraft:
         - Su-27 Flanker-B
-      size: 8
+      size: 12
   #St Catherine
   25:
     - primary: CAS
@@ -215,7 +229,7 @@ squadrons:
       secondary: air-to-air
       aircraft:
         - MiG-29S Fulcrum-C
-      size: 8
+      size: 12
   #Opfor Carrier
   Red CV-1:
     - primary: BARCAP

--- a/resources/campaigns/the_anvil_of_war.yaml
+++ b/resources/campaigns/the_anvil_of_war.yaml
@@ -16,7 +16,7 @@ description:
   The fate of Europe hangs in the balance, as this new offensive threatens to forever alter the geopolitical map.</p>
 miz: the_anvil_of_war.miz
 performance: 2
-recommended_start_date: 2005-05-13
+recommended_start_date: 2007-05-13
 version: "10.7"
 settings:
   russianmilitaryassetspack: true
@@ -24,16 +24,23 @@ settings:
   usamilitaryassetspack: true
   swedishmilitaryassetspack: true
   f22_raptor: true
+  fa_18efg: true
   hercules: true
   squadron_start_full: true
 squadrons:
   #Ownfor Carrier
   Blue-CV:
+    - primary: SEAD Escort
+      secondary: any
+      aircraft:
+        - EA-18G Growler
+        - F/A-18C Hornet (Lot 20)
+      size: 16
     - primary: SEAD
       secondary: any
       aircraft:
         - F/A-18C Hornet (Lot 20)
-      size: 40
+      size: 24
     - primary: AEW&C
       aircraft:
         - E-2D Advanced Hawkeye


### PR DESCRIPTION
Add Raptor and Growler squadrons to the following campaigns:
Exercise Vegas Nerve
Operation Peace Spring
Exercise Bright Star
Operation Vectron's Claw
Graveyard of Empires
Red Sea Rising
The Anvil of War
Operation Noisy Cricket