### PR TITLE
Add OCA/Aircraft mission type to B-21

### DIFF
--- a/resources/units/aircraft/B-21.yaml
+++ b/resources/units/aircraft/B-21.yaml
@@ -19,4 +19,5 @@ tasks:
   SEAD: 210
   DEAD: 210
   OCA/Runway: 660
+  OCA/Aircraft: 770
   Strike: 690


### PR DESCRIPTION
OCA/Aircraft is missing from B-21 mission list.