### PR TITLE
Fix issue 304: Waypoint numbers should start at 0 not 1 on map.

### DIFF
--- a/client/src/components/flightplan/FlightPlan.tsx
+++ b/client/src/components/flightplan/FlightPlan.tsx
@@ -81,7 +81,7 @@ const WaypointMarkers = (props: FlightPlanProps) => {
       markers.push(
         <WaypointMarker
           key={idx}
-          number={idx}
+          number={idx-1}
           waypoint={p}
           flight={props.flight}
         />


### PR DESCRIPTION
Subtract 1 from the index to match the waypoint numbering of the waypoint list. Hope this is a good way of fixing this.
See screenshot showing that the numbering is now identical.
<img width="860" alt="Screenshot 2025-06-09 123154" src="https://github.com/user-attachments/assets/0a0f9e22-6918-47e6-8f56-765f9929697b" />

