### PR TITLE
Revert "Fix issue 304: Waypoint numbers should start at 0 not 1 on map."

### DIFF
--- a/client/src/components/flightplan/FlightPlan.tsx
+++ b/client/src/components/flightplan/FlightPlan.tsx
@@ -81,7 +81,7 @@ const WaypointMarkers = (props: FlightPlanProps) => {
       markers.push(
         <WaypointMarker
           key={idx}
-          number={idx-1}
+          number={idx}
           waypoint={p}
           flight={props.flight}
         />


### PR DESCRIPTION
Reverts dcs-retribution/dcs-retribution#524

The fix creates a new problem when dragging the waypoint. We need another solution. Please roll back.