### PR TITLE
Fix304 2

### DIFF
--- a/client/src/components/waypointmarker/WaypointMarker.tsx
+++ b/client/src/components/waypointmarker/WaypointMarker.tsx
@@ -60,7 +60,7 @@ const WaypointMarker = (props: WaypointMarkerProps) => {
   useEffect(() => {
     const waypoint = props.waypoint;
     marker.current?.setTooltipContent(
-      `${props.number} ${waypoint.name}<br />` +
+      `${props.number-1} ${waypoint.name}<br />` +
         `${waypoint.altitude_ft.toFixed()} ft ${waypoint.altitude_reference}<br />` +
         waypoint.timing
     );


### PR DESCRIPTION
Second try to fix issue 304. This time only the displayed number is modified, not the underlying index. This resolves the issue of duplicate markers when a waypoint is dragged.