### PR TITLE
Remove OCA/Aircraft from S-3B

### DIFF
--- a/resources/units/aircraft/S-3B.yaml
+++ b/resources/units/aircraft/S-3B.yaml
@@ -23,5 +23,4 @@ tasks:
   BAI: 570
   CAS: 570
   DEAD: 200
-  OCA/Aircraft: 330
   Strike: 370


### PR DESCRIPTION
See: https://discord.com/channels/1015931619187621999/1025835702111445112/1392093966828179527

S-3B does not have task.RunwayAttack or task.CAS so it cannot generate an OCA/Aircraft mission