### PR TITLE
Updated SU-30 weapon definitions to version v2.8.03 Beta + CWS 3.70

### DIFF
--- a/pydcs_extensions/su30/su30.py
+++ b/pydcs_extensions/su30/su30.py
@@ -10,7 +10,8 @@ from pydcs_extensions.weapon_injector import inject_weapons
 
 
 class WeaponsSu30:
-    ASTRA_Mk_1___Active_Rdr_AAM = {
+
+    Astra_Mk_1___Active_Rdr_AAM = {
         "clsid": "{Su30_ASTRA}",
         "name": "ASTRA Mk.1 - Active Rdr AAM",
         "weight": 154,
@@ -20,6 +21,8 @@ class WeaponsSu30:
 
     BRAHMOS_A_Ship = {"clsid": "{BRAHMOS_S}", "name": "BRAHMOS A-Ship", "weight": 2500}
     BRAHMOS_SEAD = {"clsid": "{BRAHMOS_SEAD}", "name": "BRAHMOS SEAD", "weight": 2500}
+
+    CMII__TV_Guided = {"clsid": "{SU30_CM2}", "name": "CMII, TV Guided", "weight": 1240}
 
     DAMOCLES___Targeting_Pod = {
         "clsid": "{DAMOCLES}",
@@ -103,16 +106,18 @@ class WeaponsSu30:
         "name": "Kh-35UE (AS-20 Kayak) - 520kg",
         "weight": 711,
     }
-    Kh_31AD__AS_17_Krypton____610kg = {
+    Kh_31AD__AS_17_Krypton____715kg = {
         "clsid": "{SU30_KH31AD}",
-        "name": "Kh-31AD (AS-17 Krypton) - 610kg",
-        "weight": 715,
+        "name": "Kh-31AD (AS-17 Krypton) - 715kg",
+        "weight": 901,
     }
-    Kh_31PD__AS_17_Krypton____600kg = {
+
+    Kh_31PD__AS_17_Krypton____710kg = {
         "clsid": "{SU30_KH31PD}",
-        "name": "Kh-31PD (AS-17 Krypton) - 600kg",
-        "weight": 707,
+        "name": "Kh-31PD (AS-17 Krypton) - 710kg",
+        "weight": 786,
     }
+
     Kh_59MK2__AS_22_Kazoo____700kg = {
         "clsid": "{SU30_KH59MK2}",
         "name": "Kh-59MK2 (AS-22 Kazoo) - 700kg",
@@ -244,10 +249,16 @@ class WeaponsSu30:
         "weight": 106,
     }
 
-    R_73M__AA_11_Archer_M____Infra_Red = {
+    R_74M2__AA_11_Archer_M2____Infra_Red = {
+        "clsid": "{Su30-R-74M2-AA}",
+        "name": "R-74M2 (AA-11 Archer M2) - Infra Red",
+        "weight": 117,
+    }
+
+    R_74M__AA_11_Archer_M____Infra_Red = {
         "clsid": "{Su30-R-73M-AA}",
-        "name": "R-73M (AA-11 Archer M) - Infra Red",
-        "weight": 110,
+        "name": "R-74M (AA-11 Archer M) - Infra Red",
+        "weight": 106,
     }
 
     R_77__AA_12_Adder_Early____Active_Rdr = {
@@ -318,6 +329,12 @@ class WeaponsSu30:
         "clsid": "{SMOKE-POD-BLACK}",
         "name": "Smoke Generator - Black",
         "weight": 220,
+    }
+
+    T220_FLIR_LDT_POD = {
+        "clsid": "{Su30SM_T220}",
+        "name": "T220 FLIR/LDT POD",
+        "weight": 295,
     }
 
 
@@ -514,13 +531,13 @@ class Su_30SM(PlaneType):
             1,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             1,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
+        R_74M2__AA_11_Archer_M2____Infra_Red = (
             1,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
+            WeaponsSu30.R_74M2__AA_11_Archer_M2____Infra_Red,
         )
         L005_Sorbtsiya_ECM_pod__left_ = (1, Weapons.L005_Sorbtsiya_ECM_pod__left_)
         SAP_518_ECM_Pod__Left_ = (1, WeaponsSu30.SAP_518_ECM_Pod__Left_)
@@ -538,13 +555,13 @@ class Su_30SM(PlaneType):
             2,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             2,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
+        R_74M2__AA_11_Archer_M2____Infra_Red = (
             2,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
+            WeaponsSu30.R_74M2__AA_11_Archer_M2____Infra_Red,
         )
         R_77__AA_12_Adder_Early____Active_Rdr = (
             2,
@@ -574,13 +591,13 @@ class Su_30SM(PlaneType):
             3,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             3,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
+        R_74M2__AA_11_Archer_M2____Infra_Red = (
             3,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
+            WeaponsSu30.R_74M2__AA_11_Archer_M2____Infra_Red,
         )
         R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
             3,
@@ -631,6 +648,10 @@ class Su_30SM(PlaneType):
             WeaponsSu30.R_37M__AA_13_Axehead____Active_Rdr,
         )
         Kh_31P__AS_17_Krypton____600kg = (3, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            3,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_36__AS_23____600kg_Grom_E1 = (3, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
         KH_38MTE__AS_23__IR_Guided = (3, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
         KH_38MLE__AS_23___Semi_Act_Laser = (
@@ -646,23 +667,26 @@ class Su_30SM(PlaneType):
             3,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            3,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             3,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
         # ERRR {JAS39_AGM_65K}
-        Kh_59M__AS_18_Kazoo___930kg = (3, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
         Kh_59MK__AS_18_Kazoo____930kg = (3, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (3, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_35__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
         Kh_35UE__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
+        Kh_31AD__AS_17_Krypton____715kg = (
             3,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
+            WeaponsSu30.Kh_31AD__AS_17_Krypton____715kg,
         )
-        Kh_31PD__AS_17_Krypton____600kg = (
+        Kh_31PD__AS_17_Krypton____710kg = (
             3,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
+            WeaponsSu30.Kh_31PD__AS_17_Krypton____710kg,
         )
         Kh_59MK2__AS_22_Kazoo____700kg = (3, WeaponsSu30.Kh_59MK2__AS_22_Kazoo____700kg)
         KAB_500Kr___500kg_TV_Guided_Bomb = (3, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
@@ -697,13 +721,12 @@ class Su_30SM(PlaneType):
             Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (3, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (3, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_500M62_UMPK__500kg_Glide_Bomb = (
             3,
             WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
         )
         FAB_250_M62___227kg__freefall = (3, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (3, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             3,
             WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
@@ -716,19 +739,19 @@ class Su_30SM(PlaneType):
             3,
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        _2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation = (
             3,
             Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
         )
@@ -785,22 +808,29 @@ class Su_30SM(PlaneType):
             4,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            4,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             4,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (4, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            4,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (4, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (4, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_35__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
         Kh_35UE__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
+        Kh_31AD__AS_17_Krypton____715kg = (
             4,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
+            WeaponsSu30.Kh_31AD__AS_17_Krypton____715kg,
         )
-        Kh_31PD__AS_17_Krypton____600kg = (
+        Kh_31PD__AS_17_Krypton____710kg = (
             4,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
+            WeaponsSu30.Kh_31PD__AS_17_Krypton____710kg,
         )
         Kh_59MK2__AS_22_Kazoo____700kg = (4, WeaponsSu30.Kh_59MK2__AS_22_Kazoo____700kg)
         KAB_500Kr___500kg_TV_Guided_Bomb = (4, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
@@ -841,13 +871,12 @@ class Su_30SM(PlaneType):
             Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (4, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (4, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_500M62_UMPK__500kg_Glide_Bomb = (
             4,
             WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
         )
         FAB_250_M62___227kg__freefall = (4, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (4, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
         RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
             4,
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
@@ -920,18 +949,22 @@ class Su_30SM(PlaneType):
             5,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            5,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             5,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
         Kh_31A__AS_17_Krypton____610kg = (5, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
+        Kh_31AD__AS_17_Krypton____715kg = (
             5,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
+            WeaponsSu30.Kh_31AD__AS_17_Krypton____715kg,
         )
-        Kh_31PD__AS_17_Krypton____600kg = (
+        Kh_31PD__AS_17_Krypton____710kg = (
             5,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
+            WeaponsSu30.Kh_31PD__AS_17_Krypton____710kg,
         )
         KAB_500Kr___500kg_TV_Guided_Bomb = (5, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg__GPS_Guided = (5, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
@@ -957,13 +990,12 @@ class Su_30SM(PlaneType):
             Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (5, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (5, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_500M62_UMPK__500kg_Glide_Bomb = (
             5,
             WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
         )
         FAB_250_M62___227kg__freefall = (5, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (5, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
         RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
             5,
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
@@ -1056,13 +1088,12 @@ class Su_30SM(PlaneType):
             Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (6, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (6, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_500M62_UMPK__500kg_Glide_Bomb = (
             6,
             WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
         )
         FAB_250_M62___227kg__freefall = (6, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (6, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
         RN_244___260kg__Tactic_Nuclear_bomb = (
             6,
             WeaponsSu30.RN_244___260kg__Tactic_Nuclear_bomb,
@@ -1151,13 +1182,12 @@ class Su_30SM(PlaneType):
             Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (7, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (7, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_500M62_UMPK__500kg_Glide_Bomb = (
             7,
             WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
         )
         FAB_250_M62___227kg__freefall = (7, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (7, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
         RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
             7,
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
@@ -1249,18 +1279,22 @@ class Su_30SM(PlaneType):
             8,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            8,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             8,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
         Kh_31A__AS_17_Krypton____610kg = (8, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
+        Kh_31AD__AS_17_Krypton____715kg = (
             8,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
+            WeaponsSu30.Kh_31AD__AS_17_Krypton____715kg,
         )
-        Kh_31PD__AS_17_Krypton____600kg = (
+        Kh_31PD__AS_17_Krypton____710kg = (
             8,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
+            WeaponsSu30.Kh_31PD__AS_17_Krypton____710kg,
         )
         KAB_500Kr___500kg_TV_Guided_Bomb = (8, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg__GPS_Guided = (8, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
@@ -1286,13 +1320,12 @@ class Su_30SM(PlaneType):
             Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (8, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (8, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_500M62_UMPK__500kg_Glide_Bomb = (
             8,
             WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
         )
         FAB_250_M62___227kg__freefall = (8, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (8, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
         RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
             8,
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
@@ -1309,6 +1342,7 @@ class Su_30SM(PlaneType):
             8,
             WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
         )
+        T220_FLIR_LDT_POD = (8, WeaponsSu30.T220_FLIR_LDT_POD)
 
     # ERRR <CLEAN>
 
@@ -1361,22 +1395,29 @@ class Su_30SM(PlaneType):
             9,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            9,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             9,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (9, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            9,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (9, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (9, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_35__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
         Kh_35UE__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
+        Kh_31AD__AS_17_Krypton____715kg = (
             9,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
+            WeaponsSu30.Kh_31AD__AS_17_Krypton____715kg,
         )
-        Kh_31PD__AS_17_Krypton____600kg = (
+        Kh_31PD__AS_17_Krypton____710kg = (
             9,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
+            WeaponsSu30.Kh_31PD__AS_17_Krypton____710kg,
         )
         Kh_59MK2__AS_22_Kazoo____700kg = (9, WeaponsSu30.Kh_59MK2__AS_22_Kazoo____700kg)
         KAB_500Kr___500kg_TV_Guided_Bomb = (9, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
@@ -1417,14 +1458,13 @@ class Su_30SM(PlaneType):
             Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (9, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (9, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (9, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_500M62_UMPK__500kg_Glide_Bomb = (
             9,
             WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
         )
         # ERRR {DIS_UMPK_FAB_5002}
         FAB_250_M62___227kg__freefall = (9, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (9, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
         RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
             9,
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
@@ -1454,13 +1494,13 @@ class Su_30SM(PlaneType):
             10,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             10,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
+        R_74M2__AA_11_Archer_M2____Infra_Red = (
             10,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
+            WeaponsSu30.R_74M2__AA_11_Archer_M2____Infra_Red,
         )
         R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
             10,
@@ -1529,12 +1569,19 @@ class Su_30SM(PlaneType):
             10,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            10,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             10,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
         # ERRR {JAS39_AGM_65H}
-        Kh_59M__AS_18_Kazoo___930kg = (10, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            10,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (10, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (
             10,
@@ -1542,13 +1589,13 @@ class Su_30SM(PlaneType):
         )
         Kh_35__AS_20_Kayak____520kg = (10, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
         Kh_35UE__AS_20_Kayak____520kg = (10, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
+        Kh_31AD__AS_17_Krypton____715kg = (
             10,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
+            WeaponsSu30.Kh_31AD__AS_17_Krypton____715kg,
         )
-        Kh_31PD__AS_17_Krypton____600kg = (
+        Kh_31PD__AS_17_Krypton____710kg = (
             10,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
+            WeaponsSu30.Kh_31PD__AS_17_Krypton____710kg,
         )
         Kh_59MK2__AS_22_Kazoo____700kg = (
             10,
@@ -1589,16 +1636,12 @@ class Su_30SM(PlaneType):
             Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (10, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (10, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (10, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_500M62_UMPK__500kg_Glide_Bomb = (
             10,
             WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
         )
         FAB_250_M62___227kg__freefall = (10, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (
-            10,
-            WeaponsSu30.FAB_500M62_NV__500kg_Parachute,
-        )
         RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
             10,
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
@@ -1619,19 +1662,19 @@ class Su_30SM(PlaneType):
             10,
             WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
         )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        _2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation = (
             10,
             Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
         )
@@ -1645,13 +1688,13 @@ class Su_30SM(PlaneType):
             11,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             11,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
+        R_74M2__AA_11_Archer_M2____Infra_Red = (
             11,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
+            WeaponsSu30.R_74M2__AA_11_Archer_M2____Infra_Red,
         )
         R_77__AA_12_Adder_Early____Active_Rdr = (
             11,
@@ -1681,13 +1724,13 @@ class Su_30SM(PlaneType):
             12,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             12,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
+        R_74M2__AA_11_Archer_M2____Infra_Red = (
             12,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
+            WeaponsSu30.R_74M2__AA_11_Archer_M2____Infra_Red,
         )
         L005_Sorbtsiya_ECM_pod__right_ = (12, Weapons.L005_Sorbtsiya_ECM_pod__right_)
         SAP_518_ECM_Pod__Right_ = (12, WeaponsSu30.SAP_518_ECM_Pod__Right_)
@@ -1907,14 +1950,6 @@ class Su_30MKA(PlaneType):
             1,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            1,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            1,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
         L005_Sorbtsiya_ECM_pod__left_ = (1, Weapons.L005_Sorbtsiya_ECM_pod__left_)
         SAP_518_ECM_Pod__Left_ = (1, WeaponsSu30.SAP_518_ECM_Pod__Left_)
         Smoke_Generator___red = (1, Weapons.Smoke_Generator___red)
@@ -1929,14 +1964,6 @@ class Su_30MKA(PlaneType):
         R_73L__AA_11_Archer_L____Infra_Red = (
             2,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            2,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            2,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
         )
         RVV_AE__AA_12_Adder____Active_Rdr = (
             2,
@@ -1960,14 +1987,6 @@ class Su_30MKA(PlaneType):
         R_73L__AA_11_Archer_L____Infra_Red = (
             3,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            3,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            3,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
         )
         R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
             3,
@@ -1997,35 +2016,21 @@ class Su_30MKA(PlaneType):
             3,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
         )
-        Kh_31P__AS_17_Krypton____600kg = (3, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (3, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (3, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
             3,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (3, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            3,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
         )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             3,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (3, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            3,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (3, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (3, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_35__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            3,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            3,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
         KAB_500Kr___500kg_TV_Guided_Bomb = (3, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg__GPS_Guided = (3, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
         KAB_500LG___500kg_Laser_Guided_Bomb = (
@@ -2062,7 +2067,7 @@ class Su_30MKA(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (3, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (3, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (3, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             3,
@@ -2072,23 +2077,22 @@ class Su_30MKA(PlaneType):
             3,
             WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
         )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        _2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation = (
             3,
             Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
         )
-        _2_x_S_25 = (3, Weapons._2_x_S_25)
 
     # ERRR <CLEAN>
 
@@ -2110,38 +2114,25 @@ class Su_30MKA(PlaneType):
             WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
         )
         Kh_31P__AS_17_Krypton____600kg = (4, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (4, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (4, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            4,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (4, WeaponsSu30.Kh_38MAE__AS_23____500kg)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
             4,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
         )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
             4,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
         )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             4,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (4, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            4,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (4, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (4, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_35__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            4,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            4,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
         KAB_500Kr___500kg_TV_Guided_Bomb = (4, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg__GPS_Guided = (4, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
         KAB_1500Kr___1500kg = (4, WeaponsSu30.KAB_1500Kr___1500kg)
@@ -2184,7 +2175,7 @@ class Su_30MKA(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (4, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (4, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (4, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             4,
@@ -2215,34 +2206,19 @@ class Su_30MKA(PlaneType):
             WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
         )
         Kh_31P__AS_17_Krypton____600kg = (5, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (5, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (5, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
             5,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
         )
-        Kh_38MAE__AS_23____500kg = (5, WeaponsSu30.Kh_38MAE__AS_23____500kg)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
             5,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            5,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             5,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
         Kh_31A__AS_17_Krypton____610kg = (5, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            5,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            5,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
         KAB_500Kr___500kg_TV_Guided_Bomb = (5, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg__GPS_Guided = (5, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
         KAB_500LG___500kg_Laser_Guided_Bomb = (
@@ -2271,7 +2247,7 @@ class Su_30MKA(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (5, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (5, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (5, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             5,
@@ -2311,14 +2287,6 @@ class Su_30MKA(PlaneType):
             6,
             Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
         )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            6,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            6,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
         KAB_500LG___500kg_Laser_Guided_Bomb = (
             6,
             Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
@@ -2326,6 +2294,14 @@ class Su_30MKA(PlaneType):
         SAB_100MN___100_kg_Illumination_Bomb = (
             6,
             Weapons.SAB_100MN___100_kg_Illumination_Bomb,
+        )
+        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
+            6,
+            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
+        )
+        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
+            6,
+            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
         )
         P_50T___50kg_Practice_Bomb_LD = (6, Weapons.P_50T___50kg_Practice_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
@@ -2345,7 +2321,7 @@ class Su_30MKA(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (6, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (6, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (6, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             6,
@@ -2385,14 +2361,6 @@ class Su_30MKA(PlaneType):
         )
         KAB_500Kr___500kg_TV_Guided_Bomb = (7, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg__GPS_Guided = (7, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            7,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            7,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
             7,
             Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
@@ -2400,6 +2368,14 @@ class Su_30MKA(PlaneType):
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
             7,
             Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
+        )
+        KAB_500LG___500kg_Laser_Guided_Bomb = (
+            7,
+            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
+        )
+        SAB_100MN___100_kg_Illumination_Bomb = (
+            7,
+            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
         )
         P_50T___50kg_Practice_Bomb_LD = (7, Weapons.P_50T___50kg_Practice_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
@@ -2419,7 +2395,7 @@ class Su_30MKA(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (7, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (7, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (7, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             7,
@@ -2464,34 +2440,19 @@ class Su_30MKA(PlaneType):
             WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
         )
         Kh_31P__AS_17_Krypton____600kg = (8, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (8, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (8, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            8,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (8, WeaponsSu30.Kh_38MAE__AS_23____500kg)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
             8,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
         )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
             8,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
         )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             8,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
         Kh_31A__AS_17_Krypton____610kg = (8, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            8,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            8,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
         KAB_500Kr___500kg_TV_Guided_Bomb = (8, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg__GPS_Guided = (8, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
         KAB_500LG___500kg_Laser_Guided_Bomb = (
@@ -2520,7 +2481,7 @@ class Su_30MKA(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (8, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (8, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (8, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             8,
@@ -2551,38 +2512,25 @@ class Su_30MKA(PlaneType):
             WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
         )
         Kh_31P__AS_17_Krypton____600kg = (9, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (9, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (9, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            9,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (9, WeaponsSu30.Kh_38MAE__AS_23____500kg)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
             9,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
         )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
             9,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
         )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             9,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (9, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            9,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (9, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (9, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_35__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            9,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            9,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
         KAB_500Kr___500kg_TV_Guided_Bomb = (9, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg__GPS_Guided = (9, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
         KAB_1500Kr___1500kg = (9, WeaponsSu30.KAB_1500Kr___1500kg)
@@ -2625,7 +2573,7 @@ class Su_30MKA(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (9, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (9, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (9, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (9, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             9,
@@ -2643,14 +2591,6 @@ class Su_30MKA(PlaneType):
         R_73L__AA_11_Archer_L____Infra_Red = (
             10,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            10,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            10,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
         )
         R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
             10,
@@ -2680,41 +2620,28 @@ class Su_30MKA(PlaneType):
             10,
             WeaponsSu30.Kh_31P__AS_17_Krypton____600kg,
         )
-        Kh_36__AS_23____600kg_Grom_E1 = (10, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (10, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            10,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (10, WeaponsSu30.Kh_38MAE__AS_23____500kg)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
             10,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
         )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
             10,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
         )
         KH_29TE__AS_14_Kedge___TV_Guided = (
             10,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (10, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            10,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (10, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (
             10,
             WeaponsSu30.Kh_31A__AS_17_Krypton____610kg,
         )
         Kh_35__AS_20_Kayak____520kg = (10, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (10, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            10,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            10,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
         KAB_500Kr___500kg_TV_Guided_Bomb = (
             10,
             Weapons.KAB_500Kr___500kg_TV_Guided_Bomb,
@@ -2754,7 +2681,7 @@ class Su_30MKA(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (10, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (10, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (10, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (10, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             10,
@@ -2764,19 +2691,19 @@ class Su_30MKA(PlaneType):
             10,
             WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
         )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        _2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation = (
             10,
             Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
         )
@@ -2789,14 +2716,6 @@ class Su_30MKA(PlaneType):
         R_73L__AA_11_Archer_L____Infra_Red = (
             11,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            11,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            11,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
         )
         RVV_AE__AA_12_Adder____Active_Rdr = (
             11,
@@ -2820,14 +2739,6 @@ class Su_30MKA(PlaneType):
         R_73L__AA_11_Archer_L____Infra_Red = (
             12,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            12,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            12,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
         )
         L005_Sorbtsiya_ECM_pod__right_ = (12, Weapons.L005_Sorbtsiya_ECM_pod__right_)
         SAP_518_ECM_Pod__Right_ = (12, WeaponsSu30.SAP_518_ECM_Pod__Right_)
@@ -3046,9 +2957,9 @@ class Su_30MKM(PlaneType):
             1,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             1,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             1,
@@ -3069,9 +2980,9 @@ class Su_30MKM(PlaneType):
             2,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             2,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             2,
@@ -3100,9 +3011,9 @@ class Su_30MKM(PlaneType):
             3,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             3,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             3,
@@ -3133,9 +3044,17 @@ class Su_30MKM(PlaneType):
             WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
         )
         Kh_31P__AS_17_Krypton____600kg = (3, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            3,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
             3,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
+        )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            3,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
         )
         KH_29L__AS_14_Kedge___Semi_Act_Laser = (
             3,
@@ -3145,7 +3064,6 @@ class Su_30MKM(PlaneType):
             3,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (3, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
         Kh_59MK__AS_18_Kazoo____930kg = (3, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (3, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_35__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
@@ -3194,19 +3112,19 @@ class Su_30MKM(PlaneType):
             3,
             Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
         )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        _2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation = (
             3,
             Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
         )
@@ -3242,6 +3160,10 @@ class Su_30MKM(PlaneType):
             4,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            4,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         KH_29L__AS_14_Kedge___Semi_Act_Laser = (
             4,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
@@ -3250,7 +3172,10 @@ class Su_30MKM(PlaneType):
             4,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (4, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            4,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (4, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (4, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_35__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
@@ -3331,6 +3256,10 @@ class Su_30MKM(PlaneType):
             WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
         )
         Kh_31P__AS_17_Krypton____600kg = (5, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            5,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         KH_29L__AS_14_Kedge___Semi_Act_Laser = (
             5,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
@@ -3568,6 +3497,10 @@ class Su_30MKM(PlaneType):
             8,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            8,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         KH_29L__AS_14_Kedge___Semi_Act_Laser = (
             8,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
@@ -3610,7 +3543,7 @@ class Su_30MKM(PlaneType):
             8,
             Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
         )
-        # ERRR {DAMOCLES}
+        DAMOCLES___Targeting_Pod = (8, WeaponsSu30.DAMOCLES___Targeting_Pod)
         # ERRR <CLEAN>
         Mk_82___500lb_GP_Bomb_LD = (8, Weapons.Mk_82___500lb_GP_Bomb_LD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
@@ -3641,6 +3574,10 @@ class Su_30MKM(PlaneType):
             9,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            9,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         KH_29L__AS_14_Kedge___Semi_Act_Laser = (
             9,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
@@ -3649,7 +3586,10 @@ class Su_30MKM(PlaneType):
             9,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (9, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            9,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (9, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (9, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_35__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
@@ -3718,9 +3658,9 @@ class Su_30MKM(PlaneType):
             10,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             10,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             10,
@@ -3758,6 +3698,10 @@ class Su_30MKM(PlaneType):
             10,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            10,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         KH_29L__AS_14_Kedge___Semi_Act_Laser = (
             10,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
@@ -3766,7 +3710,10 @@ class Su_30MKM(PlaneType):
             10,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (10, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            10,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (10, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (
             10,
@@ -3821,19 +3768,19 @@ class Su_30MKM(PlaneType):
             10,
             Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
         )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        _2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation = (
             10,
             Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
         )
@@ -3855,9 +3802,9 @@ class Su_30MKM(PlaneType):
             11,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             11,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             11,
@@ -3886,1074 +3833,9 @@ class Su_30MKM(PlaneType):
             12,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             12,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            12,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        L005_Sorbtsiya_ECM_pod__right_ = (12, Weapons.L005_Sorbtsiya_ECM_pod__right_)
-        SAP_518_ECM_Pod__Right_ = (12, WeaponsSu30.SAP_518_ECM_Pod__Right_)
-        Smoke_Generator___red = (12, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (12, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (12, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (12, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (12, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (12, Weapons.Smoke_Generator___orange)
-
-    pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
-
-    tasks = [
-        task.CAP,
-        task.Escort,
-        task.FighterSweep,
-        task.Intercept,
-        task.AFAC,
-        task.SEAD,
-        task.AntishipStrike,
-        task.CAS,
-        task.PinpointStrike,
-        task.GroundAttack,
-        task.RunwayAttack,
-    ]
-    task_default = task.CAP
-
-
-@planemod
-class Su_30MKM_AG(PlaneType):
-    id = "Su-30MKM-AG"
-    flyable = True
-    height = 5.932
-    width = 14.7
-    length = 21.935
-    fuel_max = 9500
-    max_speed = 2499.984
-    chaff = 96
-    flare = 96
-    charge_total = 192
-    chaff_charge_size = 1
-    flare_charge_size = 1
-    eplrs = True
-    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
-
-    panel_radio = {
-        1: {
-            "channels": {
-                1: 305,
-                2: 264,
-                4: 256,
-                8: 257,
-                16: 261,
-                17: 267,
-                9: 255,
-                18: 251,
-                5: 254,
-                10: 262,
-                20: 266,
-                11: 259,
-                3: 265,
-                6: 250,
-                12: 268,
-                13: 269,
-                7: 270,
-                14: 260,
-                19: 253,
-                15: 263,
-            },
-        },
-        2: {
-            "channels": {
-                1: 117,
-                2: 135,
-                4: 127,
-                8: 128,
-                16: 132,
-                17: 138,
-                9: 126,
-                18: 122,
-                5: 125,
-                10: 133,
-                20: 137,
-                11: 130,
-                3: 136,
-                6: 121,
-                12: 139,
-                13: 140,
-                7: 141,
-                14: 131,
-                19: 124,
-                15: 134,
-            },
-        },
-    }
-
-    property_defaults: Dict[str, Any] = {
-        "SoloFlight": False,
-        "NetCrewControlPriority": 0,
-        "HumanOrchestra": False,
-        "HelmetMountedDevice": 1,
-        "ShowLadders": True,
-        "su30Chaff": 96,
-        "su30Flare": 96,
-    }
-
-    class Properties:
-        class SoloFlight:
-            id = "SoloFlight"
-
-        class NetCrewControlPriority:
-            id = "NetCrewControlPriority"
-
-            class Values:
-                Pilot = 0
-                WSO = 1
-                Ask_Always = -1
-                Equally_Responsible = -2
-
-        class HumanOrchestra:
-            id = "HumanOrchestra"
-
-        class HelmetMountedDevice:
-            id = "HelmetMountedDevice"
-
-            class Values:
-                Not_installed = 0
-                SURA_Visor = 1
-                NVG = 2
-
-        class ShowLadders:
-            id = "ShowLadders"
-
-        class su30Chaff:
-            id = "su30Chaff"
-
-        class su30Flare:
-            id = "su30Flare"
-
-    properties = {
-        "SoloFlight": UnitPropertyDescription(
-            identifier="SoloFlight",
-            control="checkbox",
-            label="Solo Flight",
-            player_only=True,
-            default=False,
-            weight_when_on=-80,
-        ),
-        "NetCrewControlPriority": UnitPropertyDescription(
-            identifier="NetCrewControlPriority",
-            control="comboList",
-            label="Aircraft Control Priority",
-            player_only=True,
-            default=0,
-            w_ctrl=150,
-            values={
-                0: "Pilot",
-                1: "WSO",
-                -1: "Ask Always",
-                -2: "Equally Responsible",
-            },
-        ),
-        "HumanOrchestra": UnitPropertyDescription(
-            identifier="HumanOrchestra",
-            control="checkbox",
-            label="Disable Multicrew",
-            player_only=True,
-            default=False,
-        ),
-        "HelmetMountedDevice": UnitPropertyDescription(
-            identifier="HelmetMountedDevice",
-            control="comboList",
-            label="Helmet Mounted Device",
-            player_only=True,
-            default=1,
-            w_ctrl=150,
-            values={
-                0: "Not installed",
-                1: "SURA Visor",
-                2: "NVG",
-            },
-        ),
-        "ShowLadders": UnitPropertyDescription(
-            identifier="ShowLadders",
-            control="checkbox",
-            label="Show Ladders",
-            default=True,
-        ),
-        "su30Chaff": UnitPropertyDescription(
-            identifier="su30Chaff",
-            control="spinbox",
-            label="Chaff",
-            player_only=True,
-            minimum=0,
-            maximum=192,
-            default=96,
-            dimension=" ",
-        ),
-        "su30Flare": UnitPropertyDescription(
-            identifier="su30Flare",
-            control="spinbox",
-            label="Flare",
-            player_only=True,
-            minimum=0,
-            maximum=192,
-            default=96,
-            dimension=" ",
-        ),
-    }
-
-    livery_name = "SU-30MKM-AG"  # from type
-
-    class Pylon1:
-        R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            1,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            1,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            1,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        L005_Sorbtsiya_ECM_pod__left_ = (1, Weapons.L005_Sorbtsiya_ECM_pod__left_)
-        SAP_518_ECM_Pod__Left_ = (1, WeaponsSu30.SAP_518_ECM_Pod__Left_)
-        Smoke_Generator___red = (1, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (1, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (1, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (1, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (1, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (1, Weapons.Smoke_Generator___orange)
-
-    class Pylon2:
-        R_73__AA_11_Archer____Infra_Red = (2, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            2,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            2,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            2,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            2,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            2,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Smoke_Generator___red = (2, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (2, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (2, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (2, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (2, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (2, Weapons.Smoke_Generator___orange)
-
-    # ERRR <CLEAN>
-
-    class Pylon3:
-        R_73__AA_11_Archer____Infra_Red = (3, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            3,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            3,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            3,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            3,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27T1__AA_10_Alamo_B____Infra_Red = (
-            3,
-            WeaponsSu30.R_27T1__AA_10_Alamo_B____Infra_Red,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            3,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_27ET1__AA_10_Alamo_D____IR_Extended_Range = (
-            3,
-            WeaponsSu30.R_27ET1__AA_10_Alamo_D____IR_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            3,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            3,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (3, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            3,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            3,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            3,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (3, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (3, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (3, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_35__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (3, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (3, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            3,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            3,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            3,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            3,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (3, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            3,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            3,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            3,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            3,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            3,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (
-            3,
-            Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
-        )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
-            3,
-            Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
-        )
-        _2_x_S_25 = (3, Weapons._2_x_S_25)
-        Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
-            3,
-            WeaponsSu30.GBU_38___JDAM__500lb_GPS_Guided_Bomb,
-        )
-        GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-
-    # ERRR <CLEAN>
-
-    class Pylon4:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            4,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            4,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            4,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            4,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (4, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            4,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            4,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            4,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (4, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (4, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (4, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_35__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (4, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (4, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (4, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (4, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            4,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            4,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            4,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            4,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            4,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (4, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            4,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            4,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            4,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            4,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            4,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (
-            4,
-            Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
-        )
-        # ERRR <CLEAN>
-        Mk_82___500lb_GP_Bomb_LD = (4, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
-            4,
-            WeaponsSu30.GBU_38___JDAM__500lb_GPS_Guided_Bomb,
-        )
-        GBU_12___500lb_Laser_Guided_Bomb = (4, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-
-    class Pylon5:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            5,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            5,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            5,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            5,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (5, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            5,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            5,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            5,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_31A__AS_17_Krypton____610kg = (5, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (5, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (5, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            5,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            5,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (5, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            5,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            5,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            5,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            5,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            5,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        APK_9_POD = (5, WeaponsSu30.APK_9_POD)
-        # ERRR <CLEAN>
-        Mk_82___500lb_GP_Bomb_LD = (5, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
-            5,
-            WeaponsSu30.GBU_38___JDAM__500lb_GPS_Guided_Bomb,
-        )
-        GBU_12___500lb_Laser_Guided_Bomb = (5, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-
-    class Pylon6:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            6,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            6,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            6,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            6,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (6, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (6, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (6, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (6, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            6,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            6,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            6,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            6,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            6,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (6, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            6,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            6,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            6,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            6,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            6,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (
-            6,
-            Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag,
-        )
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
-            6,
-            Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP,
-        )
-        # ERRR <CLEAN>
-        Mk_82___500lb_GP_Bomb_LD = (6, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
-            6,
-            WeaponsSu30.GBU_38___JDAM__500lb_GPS_Guided_Bomb,
-        )
-        GBU_12___500lb_Laser_Guided_Bomb = (6, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-
-    class Pylon7:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            7,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            7,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            7,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            7,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (7, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (7, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            7,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            7,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            7,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            7,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (7, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            7,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            7,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        FAB_250___250kg_GP_Bomb_LD = (7, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            7,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            7,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            7,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (
-            7,
-            Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag,
-        )
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
-            7,
-            Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP,
-        )
-        # ERRR <CLEAN>
-        Smoke_Generator___red = (7, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (7, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (7, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (7, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (7, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (7, Weapons.Smoke_Generator___orange)
-        Mk_82___500lb_GP_Bomb_LD = (7, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
-            7,
-            WeaponsSu30.GBU_38___JDAM__500lb_GPS_Guided_Bomb,
-        )
-        GBU_12___500lb_Laser_Guided_Bomb = (7, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-
-    class Pylon8:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            8,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            8,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            8,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            8,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (8, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            8,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            8,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            8,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_31A__AS_17_Krypton____610kg = (8, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (8, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (8, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            8,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            8,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (8, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            8,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            8,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        FAB_250___250kg_GP_Bomb_LD = (8, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            8,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            8,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            8,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        # ERRR {DAMOCLES}
-        # ERRR <CLEAN>
-        Mk_82___500lb_GP_Bomb_LD = (8, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
-            8,
-            WeaponsSu30.GBU_38___JDAM__500lb_GPS_Guided_Bomb,
-        )
-        GBU_12___500lb_Laser_Guided_Bomb = (8, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-
-    class Pylon9:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            9,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            9,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            9,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            9,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (9, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            9,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            9,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            9,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (9, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (9, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (9, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_35__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (9, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (9, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (9, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (9, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            9,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            9,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            9,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            9,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            9,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (9, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            9,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            9,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        FAB_250___250kg_GP_Bomb_LD = (9, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            9,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M_62___500kg_GP_Bomb_LD = (9, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            9,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            9,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (
-            9,
-            Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
-        )
-        # ERRR <CLEAN>
-        Mk_82___500lb_GP_Bomb_LD = (9, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
-            9,
-            WeaponsSu30.GBU_38___JDAM__500lb_GPS_Guided_Bomb,
-        )
-        GBU_12___500lb_Laser_Guided_Bomb = (9, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-
-    class Pylon10:
-        R_73__AA_11_Archer____Infra_Red = (10, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            10,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            10,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            10,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            10,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27T1__AA_10_Alamo_B____Infra_Red = (
-            10,
-            WeaponsSu30.R_27T1__AA_10_Alamo_B____Infra_Red,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            10,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_27ET1__AA_10_Alamo_D____IR_Extended_Range = (
-            10,
-            WeaponsSu30.R_27ET1__AA_10_Alamo_D____IR_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            10,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            10,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (
-            10,
-            WeaponsSu30.Kh_31P__AS_17_Krypton____600kg,
-        )
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            10,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            10,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            10,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (10, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (10, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (
-            10,
-            WeaponsSu30.Kh_31A__AS_17_Krypton____610kg,
-        )
-        Kh_35__AS_20_Kayak____520kg = (10, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (
-            10,
-            Weapons.KAB_500Kr___500kg_TV_Guided_Bomb,
-        )
-        KAB_500S___500kg__GPS_Guided = (10, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            10,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            10,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            10,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            10,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (10, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            10,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            10,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        FAB_250___250kg_GP_Bomb_LD = (10, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            10,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M_62___500kg_GP_Bomb_LD = (10, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            10,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            10,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (
-            10,
-            Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
-        )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
-            10,
-            Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
-        )
-        _2_x_S_25 = (10, Weapons._2_x_S_25)
-        # ERRR <CLEAN>
-        Mk_82___500lb_GP_Bomb_LD = (10, Weapons.Mk_82___500lb_GP_Bomb_LD)
-        GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
-            10,
-            WeaponsSu30.GBU_38___JDAM__500lb_GPS_Guided_Bomb,
-        )
-        GBU_12___500lb_Laser_Guided_Bomb = (
-            10,
-            Weapons.GBU_12___500lb_Laser_Guided_Bomb,
-        )
-
-    class Pylon11:
-        R_73__AA_11_Archer____Infra_Red = (11, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            11,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            11,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            11,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            11,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            11,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Smoke_Generator___red = (11, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (11, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (11, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (11, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (11, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (11, Weapons.Smoke_Generator___orange)
-
-    # ERRR <CLEAN>
-
-    class Pylon12:
-        R_73__AA_11_Archer____Infra_Red = (12, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            12,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            12,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             12,
@@ -5176,9 +4058,9 @@ class Su_30MKI(PlaneType):
             1,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             1,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             1,
@@ -5199,15 +4081,15 @@ class Su_30MKI(PlaneType):
             2,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             2,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             2,
             WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
         )
-        ASTRA_Mk_1___Active_Rdr_AAM = (2, WeaponsSu30.ASTRA_Mk_1___Active_Rdr_AAM)
+        Astra_Mk_1___Active_Rdr_AAM = (2, WeaponsSu30.Astra_Mk_1___Active_Rdr_AAM)
         I_Derby_ER___Active_Rdr_AAM = (2, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
         RVV_AE__AA_12_Adder____Active_Rdr = (
             2,
@@ -5232,9 +4114,9 @@ class Su_30MKI(PlaneType):
             3,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             3,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             3,
@@ -5256,7 +4138,7 @@ class Su_30MKI(PlaneType):
             3,
             WeaponsSu30.R_27ET1__AA_10_Alamo_D____IR_Extended_Range,
         )
-        ASTRA_Mk_1___Active_Rdr_AAM = (3, WeaponsSu30.ASTRA_Mk_1___Active_Rdr_AAM)
+        Astra_Mk_1___Active_Rdr_AAM = (3, WeaponsSu30.Astra_Mk_1___Active_Rdr_AAM)
         I_Derby_ER___Active_Rdr_AAM = (3, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
         RVV_AE__AA_12_Adder____Active_Rdr = (
             3,
@@ -5270,6 +4152,10 @@ class Su_30MKI(PlaneType):
             3,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            3,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
             3,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
@@ -5278,11 +4164,15 @@ class Su_30MKI(PlaneType):
             3,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (3, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            3,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (3, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (3, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_31P__AS_17_Krypton____600kg = (3, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
         Kh_35__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
+        CMII__TV_Guided = (3, WeaponsSu30.CMII__TV_Guided)
         Rudra_M1 = (3, WeaponsSu30.Rudra_M1)
         SAAW_POD = (3, WeaponsSu30.SAAW_POD)
         KAB_500Kr___500kg_TV_Guided_Bomb = (3, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
@@ -5321,7 +4211,7 @@ class Su_30MKI(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (3, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (3, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (3, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             3,
@@ -5331,19 +4221,19 @@ class Su_30MKI(PlaneType):
             3,
             WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
         )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        _2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation = (
             3,
             Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
             3,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
         )
@@ -5373,6 +4263,10 @@ class Su_30MKI(PlaneType):
             4,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            4,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
             4,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
@@ -5381,11 +4275,15 @@ class Su_30MKI(PlaneType):
             4,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (4, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            4,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (4, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (4, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_31P__AS_17_Krypton____600kg = (4, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
         Kh_35__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
+        CMII__TV_Guided = (4, WeaponsSu30.CMII__TV_Guided)
         Rudra_M1 = (4, WeaponsSu30.Rudra_M1)
         SAAW_POD = (4, WeaponsSu30.SAAW_POD)
         KAB_500Kr___500kg_TV_Guided_Bomb = (4, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
@@ -5430,7 +4328,7 @@ class Su_30MKI(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (4, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (4, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (4, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             4,
@@ -5473,8 +4371,15 @@ class Su_30MKI(PlaneType):
             5,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            5,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         Kh_31A__AS_17_Krypton____610kg = (5, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31P__AS_17_Krypton____600kg = (5, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            5,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Rudra_M1 = (5, WeaponsSu30.Rudra_M1)
         KAB_500Kr___500kg_TV_Guided_Bomb = (5, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg__GPS_Guided = (5, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
@@ -5504,7 +4409,7 @@ class Su_30MKI(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (5, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (5, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (5, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             5,
@@ -5582,7 +4487,7 @@ class Su_30MKI(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (6, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (6, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (6, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             6,
@@ -5658,7 +4563,7 @@ class Su_30MKI(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (7, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (7, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (7, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             7,
@@ -5706,6 +4611,10 @@ class Su_30MKI(PlaneType):
             8,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            8,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
             8,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
@@ -5745,7 +4654,7 @@ class Su_30MKI(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (8, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (8, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (8, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             8,
@@ -5781,6 +4690,10 @@ class Su_30MKI(PlaneType):
             9,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            9,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
             9,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
@@ -5789,11 +4702,15 @@ class Su_30MKI(PlaneType):
             9,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (9, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            9,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (9, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (9, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
         Kh_31P__AS_17_Krypton____600kg = (9, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
         Kh_35__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
+        CMII__TV_Guided = (9, WeaponsSu30.CMII__TV_Guided)
         KAB_500LG___500kg_Laser_Guided_Bomb = (
             9,
             Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
@@ -5838,7 +4755,7 @@ class Su_30MKI(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (9, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (9, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (9, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (9, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             9,
@@ -5857,9 +4774,9 @@ class Su_30MKI(PlaneType):
             10,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             10,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             10,
@@ -5881,7 +4798,7 @@ class Su_30MKI(PlaneType):
             10,
             WeaponsSu30.R_27ET1__AA_10_Alamo_D____IR_Extended_Range,
         )
-        ASTRA_Mk_1___Active_Rdr_AAM = (10, WeaponsSu30.ASTRA_Mk_1___Active_Rdr_AAM)
+        Astra_Mk_1___Active_Rdr_AAM = (10, WeaponsSu30.Astra_Mk_1___Active_Rdr_AAM)
         I_Derby_ER___Active_Rdr_AAM = (10, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
         RVV_AE__AA_12_Adder____Active_Rdr = (
             10,
@@ -5895,6 +4812,10 @@ class Su_30MKI(PlaneType):
             10,
             WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
         )
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+            10,
+            Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__,
+        )
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
             10,
             Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
@@ -5903,7 +4824,10 @@ class Su_30MKI(PlaneType):
             10,
             WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
         )
-        Kh_59M__AS_18_Kazoo___930kg = (10, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
+        Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (
+            10,
+            Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN,
+        )
         Kh_59MK__AS_18_Kazoo____930kg = (10, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
         Kh_31A__AS_17_Krypton____610kg = (
             10,
@@ -5914,6 +4838,7 @@ class Su_30MKI(PlaneType):
             WeaponsSu30.Kh_31P__AS_17_Krypton____600kg,
         )
         Kh_35__AS_20_Kayak____520kg = (10, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
+        CMII__TV_Guided = (10, WeaponsSu30.CMII__TV_Guided)
         Rudra_M1 = (10, WeaponsSu30.Rudra_M1)
         SAAW_POD = (10, WeaponsSu30.SAAW_POD)
         KAB_500Kr___500kg_TV_Guided_Bomb = (
@@ -5955,7 +4880,7 @@ class Su_30MKI(PlaneType):
             Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
         )
         FAB_500_M54___474kg__freefall = (10, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (10, WeaponsSu30.FAB_500_M62___474kg__freefall)
+        FAB_500_M_62___500kg_GP_Bomb_LD = (10, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250_M62___227kg__freefall = (10, WeaponsSu30.FAB_250_M62___227kg__freefall)
         MBD3_U6_68_with_6_x_FAB_250___250kg = (
             10,
@@ -5965,19 +4890,19 @@ class Su_30MKI(PlaneType):
             10,
             WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
         )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        _2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation = (
             10,
             Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
         )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
+        _2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
             10,
             Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
         )
@@ -5991,15 +4916,15 @@ class Su_30MKI(PlaneType):
             11,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             11,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             11,
             WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
         )
-        ASTRA_Mk_1___Active_Rdr_AAM = (11, WeaponsSu30.ASTRA_Mk_1___Active_Rdr_AAM)
+        Astra_Mk_1___Active_Rdr_AAM = (11, WeaponsSu30.Astra_Mk_1___Active_Rdr_AAM)
         I_Derby_ER___Active_Rdr_AAM = (11, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
         RVV_AE__AA_12_Adder____Active_Rdr = (
             11,
@@ -6024,3614 +4949,9 @@ class Su_30MKI(PlaneType):
             12,
             WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
         )
-        R_73M__AA_11_Archer_M____Infra_Red = (
+        R_74M__AA_11_Archer_M____Infra_Red = (
             12,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            12,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        L005_Sorbtsiya_ECM_pod__right_ = (12, Weapons.L005_Sorbtsiya_ECM_pod__right_)
-        SAP_518_ECM_Pod__Right_ = (12, WeaponsSu30.SAP_518_ECM_Pod__Right_)
-        Smoke_Generator___red = (12, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (12, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (12, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (12, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (12, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (12, Weapons.Smoke_Generator___orange)
-
-    pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
-
-    tasks = [
-        task.CAP,
-        task.Escort,
-        task.FighterSweep,
-        task.Intercept,
-        task.AFAC,
-        task.SEAD,
-        task.AntishipStrike,
-        task.CAS,
-        task.PinpointStrike,
-        task.GroundAttack,
-        task.RunwayAttack,
-    ]
-    task_default = task.CAP
-
-
-@planemod
-class Su_30MKA_AG(PlaneType):
-    id = "Su-30MKA-AG"
-    flyable = True
-    height = 5.932
-    width = 14.7
-    length = 21.935
-    fuel_max = 9500
-    max_speed = 2499.984
-    chaff = 96
-    flare = 96
-    charge_total = 192
-    chaff_charge_size = 1
-    flare_charge_size = 1
-    eplrs = True
-    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
-
-    panel_radio = {
-        1: {
-            "channels": {
-                1: 305,
-                2: 264,
-                4: 256,
-                8: 257,
-                16: 261,
-                17: 267,
-                9: 255,
-                18: 251,
-                5: 254,
-                10: 262,
-                20: 266,
-                11: 259,
-                3: 265,
-                6: 250,
-                12: 268,
-                13: 269,
-                7: 270,
-                14: 260,
-                19: 253,
-                15: 263,
-            },
-        },
-        2: {
-            "channels": {
-                1: 117,
-                2: 135,
-                4: 127,
-                8: 128,
-                16: 132,
-                17: 138,
-                9: 126,
-                18: 122,
-                5: 125,
-                10: 133,
-                20: 137,
-                11: 130,
-                3: 136,
-                6: 121,
-                12: 139,
-                13: 140,
-                7: 141,
-                14: 131,
-                19: 124,
-                15: 134,
-            },
-        },
-    }
-
-    property_defaults: Dict[str, Any] = {
-        "SoloFlight": False,
-        "NetCrewControlPriority": 0,
-        "HumanOrchestra": False,
-        "HelmetMountedDevice": 1,
-        "ShowLadders": True,
-        "su30Chaff": 96,
-        "su30Flare": 96,
-    }
-
-    class Properties:
-        class SoloFlight:
-            id = "SoloFlight"
-
-        class NetCrewControlPriority:
-            id = "NetCrewControlPriority"
-
-            class Values:
-                Pilot = 0
-                WSO = 1
-                Ask_Always = -1
-                Equally_Responsible = -2
-
-        class HumanOrchestra:
-            id = "HumanOrchestra"
-
-        class HelmetMountedDevice:
-            id = "HelmetMountedDevice"
-
-            class Values:
-                Not_installed = 0
-                SURA_Visor = 1
-                NVG = 2
-
-        class ShowLadders:
-            id = "ShowLadders"
-
-        class su30Chaff:
-            id = "su30Chaff"
-
-        class su30Flare:
-            id = "su30Flare"
-
-    properties = {
-        "SoloFlight": UnitPropertyDescription(
-            identifier="SoloFlight",
-            control="checkbox",
-            label="Solo Flight",
-            player_only=True,
-            default=False,
-            weight_when_on=-80,
-        ),
-        "NetCrewControlPriority": UnitPropertyDescription(
-            identifier="NetCrewControlPriority",
-            control="comboList",
-            label="Aircraft Control Priority",
-            player_only=True,
-            default=0,
-            w_ctrl=150,
-            values={
-                0: "Pilot",
-                1: "WSO",
-                -1: "Ask Always",
-                -2: "Equally Responsible",
-            },
-        ),
-        "HumanOrchestra": UnitPropertyDescription(
-            identifier="HumanOrchestra",
-            control="checkbox",
-            label="Disable Multicrew",
-            player_only=True,
-            default=False,
-        ),
-        "HelmetMountedDevice": UnitPropertyDescription(
-            identifier="HelmetMountedDevice",
-            control="comboList",
-            label="Helmet Mounted Device",
-            player_only=True,
-            default=1,
-            w_ctrl=150,
-            values={
-                0: "Not installed",
-                1: "SURA Visor",
-                2: "NVG",
-            },
-        ),
-        "ShowLadders": UnitPropertyDescription(
-            identifier="ShowLadders",
-            control="checkbox",
-            label="Show Ladders",
-            default=True,
-        ),
-        "su30Chaff": UnitPropertyDescription(
-            identifier="su30Chaff",
-            control="spinbox",
-            label="Chaff",
-            player_only=True,
-            minimum=0,
-            maximum=192,
-            default=96,
-            dimension=" ",
-        ),
-        "su30Flare": UnitPropertyDescription(
-            identifier="su30Flare",
-            control="spinbox",
-            label="Flare",
-            player_only=True,
-            minimum=0,
-            maximum=192,
-            default=96,
-            dimension=" ",
-        ),
-    }
-
-    livery_name = "SU-30MKA-AG"  # from type
-
-    class Pylon1:
-        R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            1,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            1,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            1,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        L005_Sorbtsiya_ECM_pod__left_ = (1, Weapons.L005_Sorbtsiya_ECM_pod__left_)
-        SAP_518_ECM_Pod__Left_ = (1, WeaponsSu30.SAP_518_ECM_Pod__Left_)
-        Smoke_Generator___red = (1, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (1, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (1, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (1, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (1, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (1, Weapons.Smoke_Generator___orange)
-
-    class Pylon2:
-        R_73__AA_11_Archer____Infra_Red = (2, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            2,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            2,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            2,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            2,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            2,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Smoke_Generator___red = (2, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (2, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (2, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (2, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (2, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (2, Weapons.Smoke_Generator___orange)
-
-    # ERRR <CLEAN>
-
-    class Pylon3:
-        R_73__AA_11_Archer____Infra_Red = (3, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            3,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            3,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            3,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            3,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27T1__AA_10_Alamo_B____Infra_Red = (
-            3,
-            WeaponsSu30.R_27T1__AA_10_Alamo_B____Infra_Red,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            3,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_27ET1__AA_10_Alamo_D____IR_Extended_Range = (
-            3,
-            WeaponsSu30.R_27ET1__AA_10_Alamo_D____IR_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            3,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            3,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            3,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (3, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (3, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (3, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            3,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (3, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            3,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            3,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (3, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (3, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (3, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_35__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            3,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            3,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (3, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (3, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            3,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            3,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            3,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            3,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (3, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            3,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            3,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            3,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            3,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (3, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (3, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (3, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            3,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            3,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
-            3,
-            Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
-        )
-        _2_x_S_25 = (3, Weapons._2_x_S_25)
-
-    # ERRR <CLEAN>
-
-    class Pylon4:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            4,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            4,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            4,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            4,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (4, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (4, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (4, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            4,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (4, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            4,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            4,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            4,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (4, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (4, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (4, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_35__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            4,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            4,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (4, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (4, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (4, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (4, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            4,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            4,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            4,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            4,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            4,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (4, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            4,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            4,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            4,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            4,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (4, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (4, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (4, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            4,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            4,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon5:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            5,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            5,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            5,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            5,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (5, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (5, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (5, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            5,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (5, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            5,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            5,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            5,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_31A__AS_17_Krypton____610kg = (5, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            5,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            5,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (5, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (5, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            5,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            5,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (5, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            5,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            5,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            5,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            5,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (5, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (5, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (5, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            5,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            5,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        APK_9_POD = (5, WeaponsSu30.APK_9_POD)
-        L_081_Fantasmagoria_ELINT_pod = (5, Weapons.L_081_Fantasmagoria_ELINT_pod)
-
-    # ERRR <CLEAN>
-
-    class Pylon6:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            6,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            6,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            6,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            6,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (6, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (6, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (6, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (6, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            6,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            6,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            6,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            6,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            6,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (6, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            6,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            6,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            6,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            6,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (6, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (6, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (6, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            6,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            6,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (
-            6,
-            Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag,
-        )
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
-            6,
-            Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon7:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            7,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            7,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            7,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            7,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (7, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (7, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            7,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            7,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            7,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            7,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (7, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            7,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            7,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            7,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            7,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (7, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (7, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (7, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            7,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            7,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        Smoke_Generator___red = (7, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (7, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (7, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (7, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (7, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (7, Weapons.Smoke_Generator___orange)
-        RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (
-            7,
-            Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag,
-        )
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
-            7,
-            Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon8:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            8,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            8,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            8,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            8,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (8, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (8, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (8, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            8,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (8, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            8,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            8,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            8,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_31A__AS_17_Krypton____610kg = (8, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            8,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            8,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (8, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (8, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            8,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            8,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (8, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            8,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            8,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            8,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            8,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (8, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (8, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (8, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            8,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            8,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon9:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            9,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            9,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            9,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            9,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (9, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (9, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (9, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            9,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (9, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            9,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            9,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            9,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (9, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (9, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (9, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_35__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            9,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            9,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (9, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (9, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (9, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (9, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            9,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            9,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            9,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            9,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            9,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (9, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            9,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            9,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            9,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            9,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (9, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (9, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (9, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            9,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            9,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon10:
-        R_73__AA_11_Archer____Infra_Red = (10, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            10,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            10,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            10,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            10,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27T1__AA_10_Alamo_B____Infra_Red = (
-            10,
-            WeaponsSu30.R_27T1__AA_10_Alamo_B____Infra_Red,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            10,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_27ET1__AA_10_Alamo_D____IR_Extended_Range = (
-            10,
-            WeaponsSu30.R_27ET1__AA_10_Alamo_D____IR_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            10,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            10,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (
-            10,
-            WeaponsSu30.Kh_31P__AS_17_Krypton____600kg,
-        )
-        Kh_36__AS_23____600kg_Grom_E1 = (10, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (10, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            10,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (10, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            10,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            10,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            10,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (10, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (10, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (
-            10,
-            WeaponsSu30.Kh_31A__AS_17_Krypton____610kg,
-        )
-        Kh_35__AS_20_Kayak____520kg = (10, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (10, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            10,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            10,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (
-            10,
-            Weapons.KAB_500Kr___500kg_TV_Guided_Bomb,
-        )
-        KAB_500S___500kg__GPS_Guided = (10, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            10,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            10,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            10,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            10,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (10, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            10,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            10,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            10,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            10,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (10, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (10, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (10, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            10,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            10,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
-            10,
-            Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
-        )
-        _2_x_S_25 = (10, Weapons._2_x_S_25)
-
-    # ERRR <CLEAN>
-
-    class Pylon11:
-        R_73__AA_11_Archer____Infra_Red = (11, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            11,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            11,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            11,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            11,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            11,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Smoke_Generator___red = (11, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (11, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (11, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (11, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (11, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (11, Weapons.Smoke_Generator___orange)
-
-    # ERRR <CLEAN>
-
-    class Pylon12:
-        R_73__AA_11_Archer____Infra_Red = (12, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            12,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            12,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            12,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        L005_Sorbtsiya_ECM_pod__right_ = (12, Weapons.L005_Sorbtsiya_ECM_pod__right_)
-        SAP_518_ECM_Pod__Right_ = (12, WeaponsSu30.SAP_518_ECM_Pod__Right_)
-        Smoke_Generator___red = (12, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (12, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (12, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (12, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (12, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (12, Weapons.Smoke_Generator___orange)
-
-    pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
-
-    tasks = [
-        task.CAP,
-        task.Escort,
-        task.FighterSweep,
-        task.Intercept,
-        task.AFAC,
-        task.SEAD,
-        task.AntishipStrike,
-        task.CAS,
-        task.PinpointStrike,
-        task.GroundAttack,
-        task.RunwayAttack,
-    ]
-    task_default = task.CAP
-
-
-@planemod
-class Su_30SM_AG(PlaneType):
-    id = "Su-30SM-AG"
-    flyable = True
-    height = 5.932
-    width = 14.7
-    length = 21.935
-    fuel_max = 9500
-    max_speed = 2499.984
-    chaff = 96
-    flare = 96
-    charge_total = 192
-    chaff_charge_size = 1
-    flare_charge_size = 1
-    eplrs = True
-    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
-
-    panel_radio = {
-        1: {
-            "channels": {
-                1: 305,
-                2: 264,
-                4: 256,
-                8: 257,
-                16: 261,
-                17: 267,
-                9: 255,
-                18: 251,
-                5: 254,
-                10: 262,
-                20: 266,
-                11: 259,
-                3: 265,
-                6: 250,
-                12: 268,
-                13: 269,
-                7: 270,
-                14: 260,
-                19: 253,
-                15: 263,
-            },
-        },
-        2: {
-            "channels": {
-                1: 117,
-                2: 135,
-                4: 127,
-                8: 128,
-                16: 132,
-                17: 138,
-                9: 126,
-                18: 122,
-                5: 125,
-                10: 133,
-                20: 137,
-                11: 130,
-                3: 136,
-                6: 121,
-                12: 139,
-                13: 140,
-                7: 141,
-                14: 131,
-                19: 124,
-                15: 134,
-            },
-        },
-    }
-
-    property_defaults: Dict[str, Any] = {
-        "SoloFlight": False,
-        "NetCrewControlPriority": 0,
-        "HumanOrchestra": False,
-        "HelmetMountedDevice": 1,
-        "ShowLadders": True,
-        "su30Chaff": 96,
-        "su30Flare": 96,
-    }
-
-    class Properties:
-        class SoloFlight:
-            id = "SoloFlight"
-
-        class NetCrewControlPriority:
-            id = "NetCrewControlPriority"
-
-            class Values:
-                Pilot = 0
-                WSO = 1
-                Ask_Always = -1
-                Equally_Responsible = -2
-
-        class HumanOrchestra:
-            id = "HumanOrchestra"
-
-        class HelmetMountedDevice:
-            id = "HelmetMountedDevice"
-
-            class Values:
-                Not_installed = 0
-                SURA_Visor = 1
-                NVG = 2
-
-        class ShowLadders:
-            id = "ShowLadders"
-
-        class su30Chaff:
-            id = "su30Chaff"
-
-        class su30Flare:
-            id = "su30Flare"
-
-    properties = {
-        "SoloFlight": UnitPropertyDescription(
-            identifier="SoloFlight",
-            control="checkbox",
-            label="Solo Flight",
-            player_only=True,
-            default=False,
-            weight_when_on=-80,
-        ),
-        "NetCrewControlPriority": UnitPropertyDescription(
-            identifier="NetCrewControlPriority",
-            control="comboList",
-            label="Aircraft Control Priority",
-            player_only=True,
-            default=0,
-            w_ctrl=150,
-            values={
-                0: "Pilot",
-                1: "WSO",
-                -1: "Ask Always",
-                -2: "Equally Responsible",
-            },
-        ),
-        "HumanOrchestra": UnitPropertyDescription(
-            identifier="HumanOrchestra",
-            control="checkbox",
-            label="Disable Multicrew",
-            player_only=True,
-            default=False,
-        ),
-        "HelmetMountedDevice": UnitPropertyDescription(
-            identifier="HelmetMountedDevice",
-            control="comboList",
-            label="Helmet Mounted Device",
-            player_only=True,
-            default=1,
-            w_ctrl=150,
-            values={
-                0: "Not installed",
-                1: "SURA Visor",
-                2: "NVG",
-            },
-        ),
-        "ShowLadders": UnitPropertyDescription(
-            identifier="ShowLadders",
-            control="checkbox",
-            label="Show Ladders",
-            default=True,
-        ),
-        "su30Chaff": UnitPropertyDescription(
-            identifier="su30Chaff",
-            control="spinbox",
-            label="Chaff",
-            player_only=True,
-            minimum=0,
-            maximum=192,
-            default=96,
-            dimension=" ",
-        ),
-        "su30Flare": UnitPropertyDescription(
-            identifier="su30Flare",
-            control="spinbox",
-            label="Flare",
-            player_only=True,
-            minimum=0,
-            maximum=192,
-            default=96,
-            dimension=" ",
-        ),
-    }
-
-    livery_name = "SU-30SM-AG"  # from type
-
-    class Pylon1:
-        R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            1,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            1,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            1,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        L005_Sorbtsiya_ECM_pod__left_ = (1, Weapons.L005_Sorbtsiya_ECM_pod__left_)
-        SAP_518_ECM_Pod__Left_ = (1, WeaponsSu30.SAP_518_ECM_Pod__Left_)
-        Smoke_Generator___red = (1, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (1, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (1, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (1, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (1, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (1, Weapons.Smoke_Generator___orange)
-        Smoke_Generator___Black = (1, WeaponsSu30.Smoke_Generator___Black)
-
-    class Pylon2:
-        R_73__AA_11_Archer____Infra_Red = (2, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            2,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            2,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            2,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        R_77__AA_12_Adder_Early____Active_Rdr = (
-            2,
-            WeaponsSu30.R_77__AA_12_Adder_Early____Active_Rdr,
-        )
-        R_77_1__AA_12_Adder_B____Active_Rdr = (
-            2,
-            WeaponsSu30.R_77_1__AA_12_Adder_B____Active_Rdr,
-        )
-        R_77M__AA_12_Adder_C____Active_Rdr = (
-            2,
-            WeaponsSu30.R_77M__AA_12_Adder_C____Active_Rdr,
-        )
-        Smoke_Generator___red = (2, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (2, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (2, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (2, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (2, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (2, Weapons.Smoke_Generator___orange)
-        Smoke_Generator___Black = (2, WeaponsSu30.Smoke_Generator___Black)
-
-    # ERRR <CLEAN>
-
-    class Pylon3:
-        R_73__AA_11_Archer____Infra_Red = (3, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            3,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            3,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            3,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            3,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27T1__AA_10_Alamo_B____Infra_Red = (
-            3,
-            WeaponsSu30.R_27T1__AA_10_Alamo_B____Infra_Red,
-        )
-        R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range = (
-            3,
-            WeaponsSu30.R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            3,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_27ET1__AA_10_Alamo_D____IR_Extended_Range = (
-            3,
-            WeaponsSu30.R_27ET1__AA_10_Alamo_D____IR_Extended_Range,
-        )
-        R_27EP1__AA_10_Alamo_F____Passive_Rdr_Extended_Range = (
-            3,
-            WeaponsSu30.R_27EP1__AA_10_Alamo_F____Passive_Rdr_Extended_Range,
-        )
-        R_27P1__AA_10_Alamo_E____Passive_Rdr = (
-            3,
-            WeaponsSu30.R_27P1__AA_10_Alamo_E____Passive_Rdr,
-        )
-        R_77__AA_12_Adder_Early____Active_Rdr = (
-            3,
-            WeaponsSu30.R_77__AA_12_Adder_Early____Active_Rdr,
-        )
-        R_77_1__AA_12_Adder_B____Active_Rdr = (
-            3,
-            WeaponsSu30.R_77_1__AA_12_Adder_B____Active_Rdr,
-        )
-        R_77M__AA_12_Adder_C____Active_Rdr = (
-            3,
-            WeaponsSu30.R_77M__AA_12_Adder_C____Active_Rdr,
-        )
-        R_77PD__AA_12_Adder____Active_Rdr_Ramjet = (
-            3,
-            WeaponsSu30.R_77PD__AA_12_Adder____Active_Rdr_Ramjet,
-        )
-        R_37M__AA_13_Axehead____Active_Rdr = (
-            3,
-            WeaponsSu30.R_37M__AA_13_Axehead____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (3, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (3, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (3, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            3,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (3, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            3,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            3,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            3,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        # ERRR {JAS39_AGM_65K}
-        Kh_59M__AS_18_Kazoo___930kg = (3, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (3, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (3, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_35__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            3,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            3,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        Kh_59MK2__AS_22_Kazoo____700kg = (3, WeaponsSu30.Kh_59MK2__AS_22_Kazoo____700kg)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (3, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (3, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            3,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            3,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            3,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            3,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (3, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            3,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            3,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            3,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (3, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (3, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_500M62_UMPK__500kg_Glide_Bomb = (
-            3,
-            WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
-        )
-        FAB_250_M62___227kg__freefall = (3, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (3, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            3,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            3,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            3,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
-            3,
-            Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
-        )
-        _2_x_S_25 = (3, Weapons._2_x_S_25)
-
-    # ERRR <CLEAN>
-
-    class Pylon4:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            4,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range = (
-            4,
-            WeaponsSu30.R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            4,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_77__AA_12_Adder_Early____Active_Rdr = (
-            4,
-            WeaponsSu30.R_77__AA_12_Adder_Early____Active_Rdr,
-        )
-        R_77_1__AA_12_Adder_B____Active_Rdr = (
-            4,
-            WeaponsSu30.R_77_1__AA_12_Adder_B____Active_Rdr,
-        )
-        R_77M__AA_12_Adder_C____Active_Rdr = (
-            4,
-            WeaponsSu30.R_77M__AA_12_Adder_C____Active_Rdr,
-        )
-        R_77PD__AA_12_Adder____Active_Rdr_Ramjet = (
-            4,
-            WeaponsSu30.R_77PD__AA_12_Adder____Active_Rdr_Ramjet,
-        )
-        R_37M__AA_13_Axehead____Active_Rdr = (
-            4,
-            WeaponsSu30.R_37M__AA_13_Axehead____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (4, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (4, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (4, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            4,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (4, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            4,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            4,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            4,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (4, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (4, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (4, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_35__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            4,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            4,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        Kh_59MK2__AS_22_Kazoo____700kg = (4, WeaponsSu30.Kh_59MK2__AS_22_Kazoo____700kg)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (4, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (4, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (4, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (4, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            4,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            4,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            4,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            4,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            4,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (4, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            4,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            4,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            4,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (4, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (4, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_500M62_UMPK__500kg_Glide_Bomb = (
-            4,
-            WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
-        )
-        FAB_250_M62___227kg__freefall = (4, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (4, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            4,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            4,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            4,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (
-            4,
-            Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            4,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon5:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            5,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range = (
-            5,
-            WeaponsSu30.R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            5,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_77__AA_12_Adder_Early____Active_Rdr = (
-            5,
-            WeaponsSu30.R_77__AA_12_Adder_Early____Active_Rdr,
-        )
-        R_77_1__AA_12_Adder_B____Active_Rdr = (
-            5,
-            WeaponsSu30.R_77_1__AA_12_Adder_B____Active_Rdr,
-        )
-        R_77M__AA_12_Adder_C____Active_Rdr = (
-            5,
-            WeaponsSu30.R_77M__AA_12_Adder_C____Active_Rdr,
-        )
-        R_77PD__AA_12_Adder____Active_Rdr_Ramjet = (
-            5,
-            WeaponsSu30.R_77PD__AA_12_Adder____Active_Rdr_Ramjet,
-        )
-        R_37M__AA_13_Axehead____Active_Rdr = (
-            5,
-            WeaponsSu30.R_37M__AA_13_Axehead____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (5, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (5, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (5, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            5,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (5, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            5,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            5,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            5,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_31A__AS_17_Krypton____610kg = (5, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            5,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            5,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (5, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (5, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            5,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            5,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (5, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            5,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            5,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            5,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (5, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (5, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_500M62_UMPK__500kg_Glide_Bomb = (
-            5,
-            WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
-        )
-        FAB_250_M62___227kg__freefall = (5, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (5, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            5,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            5,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            5,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            5,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        APK_9_POD = (5, WeaponsSu30.APK_9_POD)
-        L_081_Fantasmagoria_ELINT_pod = (5, Weapons.L_081_Fantasmagoria_ELINT_pod)
-
-    # ERRR <CLEAN>
-
-    class Pylon6:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            6,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range = (
-            6,
-            WeaponsSu30.R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            6,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_77__AA_12_Adder_Early____Active_Rdr = (
-            6,
-            WeaponsSu30.R_77__AA_12_Adder_Early____Active_Rdr,
-        )
-        R_77_1__AA_12_Adder_B____Active_Rdr = (
-            6,
-            WeaponsSu30.R_77_1__AA_12_Adder_B____Active_Rdr,
-        )
-        R_77M__AA_12_Adder_C____Active_Rdr = (
-            6,
-            WeaponsSu30.R_77M__AA_12_Adder_C____Active_Rdr,
-        )
-        R_77PD__AA_12_Adder____Active_Rdr_Ramjet = (
-            6,
-            WeaponsSu30.R_77PD__AA_12_Adder____Active_Rdr_Ramjet,
-        )
-        R_37M__AA_13_Axehead____Active_Rdr = (
-            6,
-            WeaponsSu30.R_37M__AA_13_Axehead____Active_Rdr,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (6, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (6, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (6, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (6, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            6,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            6,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            6,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            6,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            6,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (6, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            6,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            6,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            6,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (6, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (6, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_500M62_UMPK__500kg_Glide_Bomb = (
-            6,
-            WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
-        )
-        FAB_250_M62___227kg__freefall = (6, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (6, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
-        RN_244___260kg__Tactic_Nuclear_bomb = (
-            6,
-            WeaponsSu30.RN_244___260kg__Tactic_Nuclear_bomb,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            6,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            6,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            6,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            6,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (
-            6,
-            Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag,
-        )
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
-            6,
-            Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon7:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            7,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range = (
-            7,
-            WeaponsSu30.R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            7,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_77__AA_12_Adder_Early____Active_Rdr = (
-            7,
-            WeaponsSu30.R_77__AA_12_Adder_Early____Active_Rdr,
-        )
-        R_77_1__AA_12_Adder_B____Active_Rdr = (
-            7,
-            WeaponsSu30.R_77_1__AA_12_Adder_B____Active_Rdr,
-        )
-        R_77M__AA_12_Adder_C____Active_Rdr = (
-            7,
-            WeaponsSu30.R_77M__AA_12_Adder_C____Active_Rdr,
-        )
-        R_77PD__AA_12_Adder____Active_Rdr_Ramjet = (
-            7,
-            WeaponsSu30.R_77PD__AA_12_Adder____Active_Rdr_Ramjet,
-        )
-        R_37M__AA_13_Axehead____Active_Rdr = (
-            7,
-            WeaponsSu30.R_37M__AA_13_Axehead____Active_Rdr,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (7, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (7, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            7,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            7,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (7, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            7,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            7,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            7,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (7, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (7, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_500M62_UMPK__500kg_Glide_Bomb = (
-            7,
-            WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
-        )
-        FAB_250_M62___227kg__freefall = (7, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (7, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            7,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            7,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            7,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            7,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            7,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            7,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        Smoke_Generator___red = (7, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (7, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (7, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (7, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (7, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (7, Weapons.Smoke_Generator___orange)
-        Smoke_Generator___Black = (7, WeaponsSu30.Smoke_Generator___Black)
-        RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (
-            7,
-            Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag,
-        )
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
-            7,
-            Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon8:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            8,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range = (
-            8,
-            WeaponsSu30.R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            8,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_77__AA_12_Adder_Early____Active_Rdr = (
-            8,
-            WeaponsSu30.R_77__AA_12_Adder_Early____Active_Rdr,
-        )
-        R_77_1__AA_12_Adder_B____Active_Rdr = (
-            8,
-            WeaponsSu30.R_77_1__AA_12_Adder_B____Active_Rdr,
-        )
-        R_77M__AA_12_Adder_C____Active_Rdr = (
-            8,
-            WeaponsSu30.R_77M__AA_12_Adder_C____Active_Rdr,
-        )
-        R_77PD__AA_12_Adder____Active_Rdr_Ramjet = (
-            8,
-            WeaponsSu30.R_77PD__AA_12_Adder____Active_Rdr_Ramjet,
-        )
-        R_37M__AA_13_Axehead____Active_Rdr = (
-            8,
-            WeaponsSu30.R_37M__AA_13_Axehead____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (8, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (8, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (8, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            8,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (8, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            8,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            8,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            8,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_31A__AS_17_Krypton____610kg = (8, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            8,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            8,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (8, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (8, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            8,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            8,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (8, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            8,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            8,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            8,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (8, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (8, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_500M62_UMPK__500kg_Glide_Bomb = (
-            8,
-            WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
-        )
-        FAB_250_M62___227kg__freefall = (8, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (8, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            8,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            8,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            8,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            8,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon9:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            9,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range = (
-            9,
-            WeaponsSu30.R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            9,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_77__AA_12_Adder_Early____Active_Rdr = (
-            9,
-            WeaponsSu30.R_77__AA_12_Adder_Early____Active_Rdr,
-        )
-        R_77_1__AA_12_Adder_B____Active_Rdr = (
-            9,
-            WeaponsSu30.R_77_1__AA_12_Adder_B____Active_Rdr,
-        )
-        R_77M__AA_12_Adder_C____Active_Rdr = (
-            9,
-            WeaponsSu30.R_77M__AA_12_Adder_C____Active_Rdr,
-        )
-        R_77PD__AA_12_Adder____Active_Rdr_Ramjet = (
-            9,
-            WeaponsSu30.R_77PD__AA_12_Adder____Active_Rdr_Ramjet,
-        )
-        R_37M__AA_13_Axehead____Active_Rdr = (
-            9,
-            WeaponsSu30.R_37M__AA_13_Axehead____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (9, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_36__AS_23____600kg_Grom_E1 = (9, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (9, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            9,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (9, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            9,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            9,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            9,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (9, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (9, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (9, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_35__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            9,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            9,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        Kh_59MK2__AS_22_Kazoo____700kg = (9, WeaponsSu30.Kh_59MK2__AS_22_Kazoo____700kg)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (9, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (9, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (9, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (9, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            9,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            9,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            9,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            9,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            9,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (9, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            9,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            9,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            9,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (9, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (9, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_500M62_UMPK__500kg_Glide_Bomb = (
-            9,
-            WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
-        )
-        # ERRR {DIS_UMPK_FAB_5002}
-        FAB_250_M62___227kg__freefall = (9, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (9, WeaponsSu30.FAB_500M62_NV__500kg_Parachute)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            9,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            9,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            9,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (
-            9,
-            Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            9,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon10:
-        R_73__AA_11_Archer____Infra_Red = (10, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            10,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            10,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            10,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            10,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27T1__AA_10_Alamo_B____Infra_Red = (
-            10,
-            WeaponsSu30.R_27T1__AA_10_Alamo_B____Infra_Red,
-        )
-        R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range = (
-            10,
-            WeaponsSu30.R_27EA__AA_10_Alamo____Active_Rdr_Extended_Range,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            10,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_27ET1__AA_10_Alamo_D____IR_Extended_Range = (
-            10,
-            WeaponsSu30.R_27ET1__AA_10_Alamo_D____IR_Extended_Range,
-        )
-        R_27EP1__AA_10_Alamo_F____Passive_Rdr_Extended_Range = (
-            10,
-            WeaponsSu30.R_27EP1__AA_10_Alamo_F____Passive_Rdr_Extended_Range,
-        )
-        R_27P1__AA_10_Alamo_E____Passive_Rdr = (
-            10,
-            WeaponsSu30.R_27P1__AA_10_Alamo_E____Passive_Rdr,
-        )
-        R_77__AA_12_Adder_Early____Active_Rdr = (
-            10,
-            WeaponsSu30.R_77__AA_12_Adder_Early____Active_Rdr,
-        )
-        R_77_1__AA_12_Adder_B____Active_Rdr = (
-            10,
-            WeaponsSu30.R_77_1__AA_12_Adder_B____Active_Rdr,
-        )
-        R_77M__AA_12_Adder_C____Active_Rdr = (
-            10,
-            WeaponsSu30.R_77M__AA_12_Adder_C____Active_Rdr,
-        )
-        R_77PD__AA_12_Adder____Active_Rdr_Ramjet = (
-            10,
-            WeaponsSu30.R_77PD__AA_12_Adder____Active_Rdr_Ramjet,
-        )
-        R_37M__AA_13_Axehead____Active_Rdr = (
-            10,
-            WeaponsSu30.R_37M__AA_13_Axehead____Active_Rdr,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (
-            10,
-            WeaponsSu30.Kh_31P__AS_17_Krypton____600kg,
-        )
-        Kh_36__AS_23____600kg_Grom_E1 = (10, WeaponsSu30.Kh_36__AS_23____600kg_Grom_E1)
-        KH_38MTE__AS_23__IR_Guided = (10, WeaponsSu30.KH_38MTE__AS_23__IR_Guided)
-        KH_38MLE__AS_23___Semi_Act_Laser = (
-            10,
-            WeaponsSu30.KH_38MLE__AS_23___Semi_Act_Laser,
-        )
-        Kh_38MAE__AS_23____500kg = (10, WeaponsSu30.Kh_38MAE__AS_23____500kg)
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            10,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            10,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            10,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        # ERRR {JAS39_AGM_65H}
-        Kh_59M__AS_18_Kazoo___930kg = (10, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (10, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (
-            10,
-            WeaponsSu30.Kh_31A__AS_17_Krypton____610kg,
-        )
-        Kh_35__AS_20_Kayak____520kg = (10, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Kh_35UE__AS_20_Kayak____520kg = (10, WeaponsSu30.Kh_35UE__AS_20_Kayak____520kg)
-        Kh_31AD__AS_17_Krypton____610kg = (
-            10,
-            WeaponsSu30.Kh_31AD__AS_17_Krypton____610kg,
-        )
-        Kh_31PD__AS_17_Krypton____600kg = (
-            10,
-            WeaponsSu30.Kh_31PD__AS_17_Krypton____600kg,
-        )
-        Kh_59MK2__AS_22_Kazoo____700kg = (
-            10,
-            WeaponsSu30.Kh_59MK2__AS_22_Kazoo____700kg,
-        )
-        KAB_500Kr___500kg_TV_Guided_Bomb = (
-            10,
-            Weapons.KAB_500Kr___500kg_TV_Guided_Bomb,
-        )
-        KAB_500S___500kg__GPS_Guided = (10, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            10,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            10,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            10,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            10,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (10, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            10,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            10,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            10,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (10, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (10, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_500M62_UMPK__500kg_Glide_Bomb = (
-            10,
-            WeaponsSu30.FAB_500M62_UMPK__500kg_Glide_Bomb,
-        )
-        FAB_250_M62___227kg__freefall = (10, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        FAB_500M62_NV__500kg_Parachute = (
-            10,
-            WeaponsSu30.FAB_500M62_NV__500kg_Parachute,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            10,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (
-            10,
-            Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            10,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (
-            10,
-            Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            10,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
-            10,
-            Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
-        )
-        _2_x_S_25 = (10, Weapons._2_x_S_25)
-
-    # ERRR <CLEAN>
-
-    class Pylon11:
-        R_73__AA_11_Archer____Infra_Red = (11, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            11,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            11,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            11,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        R_77__AA_12_Adder_Early____Active_Rdr = (
-            11,
-            WeaponsSu30.R_77__AA_12_Adder_Early____Active_Rdr,
-        )
-        R_77_1__AA_12_Adder_B____Active_Rdr = (
-            11,
-            WeaponsSu30.R_77_1__AA_12_Adder_B____Active_Rdr,
-        )
-        R_77M__AA_12_Adder_C____Active_Rdr = (
-            11,
-            WeaponsSu30.R_77M__AA_12_Adder_C____Active_Rdr,
-        )
-        Smoke_Generator___red = (11, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (11, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (11, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (11, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (11, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (11, Weapons.Smoke_Generator___orange)
-        Smoke_Generator___Black = (11, WeaponsSu30.Smoke_Generator___Black)
-
-    # ERRR <CLEAN>
-
-    class Pylon12:
-        R_73__AA_11_Archer____Infra_Red = (12, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            12,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            12,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            12,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        L005_Sorbtsiya_ECM_pod__right_ = (12, Weapons.L005_Sorbtsiya_ECM_pod__right_)
-        SAP_518_ECM_Pod__Right_ = (12, WeaponsSu30.SAP_518_ECM_Pod__Right_)
-        Smoke_Generator___red = (12, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (12, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (12, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (12, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (12, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (12, Weapons.Smoke_Generator___orange)
-        Smoke_Generator___Black = (12, WeaponsSu30.Smoke_Generator___Black)
-
-    pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
-
-    tasks = [
-        task.CAP,
-        task.Escort,
-        task.FighterSweep,
-        task.Intercept,
-        task.AFAC,
-        task.SEAD,
-        task.AntishipStrike,
-        task.CAS,
-        task.PinpointStrike,
-        task.GroundAttack,
-        task.RunwayAttack,
-    ]
-    task_default = task.CAP
-
-
-@planemod
-class Su_30MKI_AG(PlaneType):
-    id = "Su-30MKI-AG"
-    flyable = True
-    height = 5.932
-    width = 14.7
-    length = 21.935
-    fuel_max = 9500
-    max_speed = 2499.984
-    chaff = 96
-    flare = 96
-    charge_total = 192
-    chaff_charge_size = 1
-    flare_charge_size = 1
-    eplrs = True
-    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
-
-    panel_radio = {
-        1: {
-            "channels": {
-                1: 305,
-                2: 264,
-                4: 256,
-                8: 257,
-                16: 261,
-                17: 267,
-                9: 255,
-                18: 251,
-                5: 254,
-                10: 262,
-                20: 266,
-                11: 259,
-                3: 265,
-                6: 250,
-                12: 268,
-                13: 269,
-                7: 270,
-                14: 260,
-                19: 253,
-                15: 263,
-            },
-        },
-        2: {
-            "channels": {
-                1: 117,
-                2: 135,
-                4: 127,
-                8: 128,
-                16: 132,
-                17: 138,
-                9: 126,
-                18: 122,
-                5: 125,
-                10: 133,
-                20: 137,
-                11: 130,
-                3: 136,
-                6: 121,
-                12: 139,
-                13: 140,
-                7: 141,
-                14: 131,
-                19: 124,
-                15: 134,
-            },
-        },
-    }
-
-    property_defaults: Dict[str, Any] = {
-        "SoloFlight": False,
-        "NetCrewControlPriority": 0,
-        "HumanOrchestra": False,
-        "HelmetMountedDevice": 1,
-        "ShowLadders": True,
-        "su30Chaff": 96,
-        "su30Flare": 96,
-    }
-
-    class Properties:
-        class SoloFlight:
-            id = "SoloFlight"
-
-        class NetCrewControlPriority:
-            id = "NetCrewControlPriority"
-
-            class Values:
-                Pilot = 0
-                WSO = 1
-                Ask_Always = -1
-                Equally_Responsible = -2
-
-        class HumanOrchestra:
-            id = "HumanOrchestra"
-
-        class HelmetMountedDevice:
-            id = "HelmetMountedDevice"
-
-            class Values:
-                Not_installed = 0
-                SURA_Visor = 1
-                NVG = 2
-
-        class ShowLadders:
-            id = "ShowLadders"
-
-        class su30Chaff:
-            id = "su30Chaff"
-
-        class su30Flare:
-            id = "su30Flare"
-
-    properties = {
-        "SoloFlight": UnitPropertyDescription(
-            identifier="SoloFlight",
-            control="checkbox",
-            label="Solo Flight",
-            player_only=True,
-            default=False,
-            weight_when_on=-80,
-        ),
-        "NetCrewControlPriority": UnitPropertyDescription(
-            identifier="NetCrewControlPriority",
-            control="comboList",
-            label="Aircraft Control Priority",
-            player_only=True,
-            default=0,
-            w_ctrl=150,
-            values={
-                0: "Pilot",
-                1: "WSO",
-                -1: "Ask Always",
-                -2: "Equally Responsible",
-            },
-        ),
-        "HumanOrchestra": UnitPropertyDescription(
-            identifier="HumanOrchestra",
-            control="checkbox",
-            label="Disable Multicrew",
-            player_only=True,
-            default=False,
-        ),
-        "HelmetMountedDevice": UnitPropertyDescription(
-            identifier="HelmetMountedDevice",
-            control="comboList",
-            label="Helmet Mounted Device",
-            player_only=True,
-            default=1,
-            w_ctrl=150,
-            values={
-                0: "Not installed",
-                1: "SURA Visor",
-                2: "NVG",
-            },
-        ),
-        "ShowLadders": UnitPropertyDescription(
-            identifier="ShowLadders",
-            control="checkbox",
-            label="Show Ladders",
-            default=True,
-        ),
-        "su30Chaff": UnitPropertyDescription(
-            identifier="su30Chaff",
-            control="spinbox",
-            label="Chaff",
-            player_only=True,
-            minimum=0,
-            maximum=192,
-            default=96,
-            dimension=" ",
-        ),
-        "su30Flare": UnitPropertyDescription(
-            identifier="su30Flare",
-            control="spinbox",
-            label="Flare",
-            player_only=True,
-            minimum=0,
-            maximum=192,
-            default=96,
-            dimension=" ",
-        ),
-    }
-
-    livery_name = "SU-30MKI-AG"  # from type
-
-    class Pylon1:
-        R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            1,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            1,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            1,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        L005_Sorbtsiya_ECM_pod__left_ = (1, Weapons.L005_Sorbtsiya_ECM_pod__left_)
-        SAP_518_ECM_Pod__Left_ = (1, WeaponsSu30.SAP_518_ECM_Pod__Left_)
-        Smoke_Generator___red = (1, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (1, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (1, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (1, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (1, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (1, Weapons.Smoke_Generator___orange)
-
-    class Pylon2:
-        R_73__AA_11_Archer____Infra_Red = (2, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            2,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            2,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            2,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        ASTRA_Mk_1___Active_Rdr_AAM = (2, WeaponsSu30.ASTRA_Mk_1___Active_Rdr_AAM)
-        I_Derby_ER___Active_Rdr_AAM = (2, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            2,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            2,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Smoke_Generator___red = (2, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (2, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (2, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (2, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (2, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (2, Weapons.Smoke_Generator___orange)
-
-    # ERRR <CLEAN>
-
-    class Pylon3:
-        R_73__AA_11_Archer____Infra_Red = (3, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            3,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            3,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            3,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            3,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27T1__AA_10_Alamo_B____Infra_Red = (
-            3,
-            WeaponsSu30.R_27T1__AA_10_Alamo_B____Infra_Red,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            3,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_27ET1__AA_10_Alamo_D____IR_Extended_Range = (
-            3,
-            WeaponsSu30.R_27ET1__AA_10_Alamo_D____IR_Extended_Range,
-        )
-        ASTRA_Mk_1___Active_Rdr_AAM = (3, WeaponsSu30.ASTRA_Mk_1___Active_Rdr_AAM)
-        I_Derby_ER___Active_Rdr_AAM = (3, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            3,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            3,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            3,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            3,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            3,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (3, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (3, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (3, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31P__AS_17_Krypton____600kg = (3, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_35__AS_20_Kayak____520kg = (3, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Rudra_M1 = (3, WeaponsSu30.Rudra_M1)
-        SAAW_POD = (3, WeaponsSu30.SAAW_POD)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (3, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (3, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            3,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            3,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            3,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            3,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (3, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            3,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            3,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            3,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            3,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (3, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (3, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (3, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            3,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            3,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
-            3,
-            Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
-            3,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
-        )
-        _2_x_S_25 = (3, Weapons._2_x_S_25)
-
-    # ERRR <CLEAN>
-
-    class Pylon4:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            4,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            4,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        I_Derby_ER___Active_Rdr_AAM = (4, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            4,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            4,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            4,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            4,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            4,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (4, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (4, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (4, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31P__AS_17_Krypton____600kg = (4, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_35__AS_20_Kayak____520kg = (4, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Rudra_M1 = (4, WeaponsSu30.Rudra_M1)
-        SAAW_POD = (4, WeaponsSu30.SAAW_POD)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (4, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (4, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (4, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (4, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            4,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            4,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            4,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            4,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            4,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (4, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            4,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            4,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            4,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            4,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (4, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (4, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (4, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            4,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            4,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon5:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            5,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            5,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        I_Derby_ER___Active_Rdr_AAM = (5, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            5,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            5,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            5,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            5,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            5,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        Kh_31A__AS_17_Krypton____610kg = (5, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31P__AS_17_Krypton____600kg = (5, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Rudra_M1 = (5, WeaponsSu30.Rudra_M1)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (5, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (5, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            5,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            5,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (5, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            5,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            5,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            5,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            5,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (5, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (5, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (5, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            5,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            5,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        APK_9_POD = (5, WeaponsSu30.APK_9_POD)
-        L_081_Fantasmagoria_ELINT_pod = (5, Weapons.L_081_Fantasmagoria_ELINT_pod)
-
-    # ERRR <CLEAN>
-
-    class Pylon6:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            6,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            6,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            6,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            6,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        I_Derby_ER___Active_Rdr_AAM = (6, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
-        # ERRR {BRAHMOS_AG}
-        BRAHMOS_A_Ship = (6, WeaponsSu30.BRAHMOS_A_Ship)
-        BRAHMOS_SEAD = (6, WeaponsSu30.BRAHMOS_SEAD)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (6, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (6, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (6, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (6, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            6,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            6,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            6,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            6,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            6,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (6, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            6,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            6,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            6,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            6,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (6, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (6, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (6, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            6,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            6,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (
-            6,
-            Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag,
-        )
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
-            6,
-            Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP,
-        )
-        EL_M_2060 = (6, WeaponsSu30.EL_M_2060)
-
-    # ERRR <CLEAN>
-
-    class Pylon7:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            7,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            7,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            7,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            7,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        I_Derby_ER___Active_Rdr_AAM = (7, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (7, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (7, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            7,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            7,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            7,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            7,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (7, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            7,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            7,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            7,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            7,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (7, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (7, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (7, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            7,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            7,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        Smoke_Generator___red = (7, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (7, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (7, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (7, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (7, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (7, Weapons.Smoke_Generator___orange)
-        # ERRR <CLEAN>
-        RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (
-            7,
-            Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag,
-        )
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
-            7,
-            Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP,
-        )
-
-    class Pylon8:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            8,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            8,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            8,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            8,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        I_Derby_ER___Active_Rdr_AAM = (8, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            8,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            8,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            8,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_31A__AS_17_Krypton____610kg = (8, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31P__AS_17_Krypton____600kg = (8, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Rudra_M1 = (8, WeaponsSu30.Rudra_M1)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (8, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (8, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            8,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            8,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (8, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            8,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            8,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            8,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            8,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (8, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (8, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (8, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            8,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            8,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        LITENING___Targeting_Pod = (8, WeaponsSu30.LITENING___Targeting_Pod)
-
-    # ERRR <CLEAN>
-
-    class Pylon9:
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            9,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            9,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            9,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            9,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        I_Derby_ER___Active_Rdr_AAM = (9, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            9,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            9,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            9,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (9, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (9, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (9, WeaponsSu30.Kh_31A__AS_17_Krypton____610kg)
-        Kh_31P__AS_17_Krypton____600kg = (9, WeaponsSu30.Kh_31P__AS_17_Krypton____600kg)
-        Kh_35__AS_20_Kayak____520kg = (9, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            9,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            9,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        Rudra_M1 = (9, WeaponsSu30.Rudra_M1)
-        SAAW_POD = (9, WeaponsSu30.SAAW_POD)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (9, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        KAB_500S___500kg__GPS_Guided = (9, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_1500Kr___1500kg = (9, WeaponsSu30.KAB_1500Kr___1500kg)
-        KAB_1500LG_PR___1500kg = (9, WeaponsSu30.KAB_1500LG_PR___1500kg)
-        KAB_1500L___1500kg_Laser_Guided_Bomb = (
-            9,
-            Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            9,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            9,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (9, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            9,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            9,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            9,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            9,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (9, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (9, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (9, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            9,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            9,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-
-    # ERRR <CLEAN>
-
-    class Pylon10:
-        R_73__AA_11_Archer____Infra_Red = (10, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            10,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            10,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            10,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        R_27R1__AA_10_Alamo_A____Semi_Act_Rdr = (
-            10,
-            WeaponsSu30.R_27R1__AA_10_Alamo_A____Semi_Act_Rdr,
-        )
-        R_27T1__AA_10_Alamo_B____Infra_Red = (
-            10,
-            WeaponsSu30.R_27T1__AA_10_Alamo_B____Infra_Red,
-        )
-        R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range = (
-            10,
-            WeaponsSu30.R_27ER1__AA_10_Alamo_C____Semi_Act_Extended_Range,
-        )
-        R_27ET1__AA_10_Alamo_D____IR_Extended_Range = (
-            10,
-            WeaponsSu30.R_27ET1__AA_10_Alamo_D____IR_Extended_Range,
-        )
-        ASTRA_Mk_1___Active_Rdr_AAM = (10, WeaponsSu30.ASTRA_Mk_1___Active_Rdr_AAM)
-        I_Derby_ER___Active_Rdr_AAM = (10, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            10,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            10,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        KH_29L__AS_14_Kedge___Semi_Act_Laser = (
-            10,
-            WeaponsSu30.KH_29L__AS_14_Kedge___Semi_Act_Laser,
-        )
-        Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (
-            10,
-            Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__,
-        )
-        KH_29TE__AS_14_Kedge___TV_Guided = (
-            10,
-            WeaponsSu30.KH_29TE__AS_14_Kedge___TV_Guided,
-        )
-        Kh_59M__AS_18_Kazoo___930kg = (10, WeaponsSu30.Kh_59M__AS_18_Kazoo___930kg)
-        Kh_59MK__AS_18_Kazoo____930kg = (10, WeaponsSu30.Kh_59MK__AS_18_Kazoo____930kg)
-        Kh_31A__AS_17_Krypton____610kg = (
-            10,
-            WeaponsSu30.Kh_31A__AS_17_Krypton____610kg,
-        )
-        Kh_31P__AS_17_Krypton____600kg = (
-            10,
-            WeaponsSu30.Kh_31P__AS_17_Krypton____600kg,
-        )
-        Kh_35__AS_20_Kayak____520kg = (10, WeaponsSu30.Kh_35__AS_20_Kayak____520kg)
-        Rudra_M1 = (10, WeaponsSu30.Rudra_M1)
-        SAAW_POD = (10, WeaponsSu30.SAAW_POD)
-        KAB_500Kr___500kg_TV_Guided_Bomb = (
-            10,
-            Weapons.KAB_500Kr___500kg_TV_Guided_Bomb,
-        )
-        KAB_500S___500kg__GPS_Guided = (10, WeaponsSu30.KAB_500S___500kg__GPS_Guided)
-        KAB_500LG___500kg_Laser_Guided_Bomb = (
-            10,
-            Weapons.KAB_500LG___500kg_Laser_Guided_Bomb,
-        )
-        SAB_100MN___100_kg_Illumination_Bomb = (
-            10,
-            Weapons.SAB_100MN___100_kg_Illumination_Bomb,
-        )
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
-            10,
-            Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP,
-        )
-        KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (
-            10,
-            Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag,
-        )
-        P_50T___50kg_Practice_Bomb_LD = (10, Weapons.P_50T___50kg_Practice_Bomb_LD)
-        BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (
-            10,
-            Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD,
-        )
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
-            10,
-            Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb,
-        )
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
-            10,
-            Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP,
-        )
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
-            10,
-            Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP,
-        )
-        FAB_500_M54___474kg__freefall = (10, WeaponsSu30.FAB_500_M54___474kg__freefall)
-        FAB_500_M62___474kg__freefall = (10, WeaponsSu30.FAB_500_M62___474kg__freefall)
-        FAB_250_M62___227kg__freefall = (10, WeaponsSu30.FAB_250_M62___227kg__freefall)
-        MBD3_U6_68_with_6_x_FAB_250___250kg = (
-            10,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_250___250kg,
-        )
-        MBD3_U6_68_with_6_x_FAB_100___100kg = (
-            10,
-            WeaponsSu30.MBD3_U6_68_with_6_x_FAB_100___100kg,
-        )
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
-            10,
-            Weapons._2_x_B_13L___5_x_UnGd_Rkts__122_mm_S_13OF_Blast_Fragmentation,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8TsM_SM_Orange,
-        )
-        _2_x_B_8M1___40_x_UnGd_Rkts__80_mm_S_8OFP2_MPP = (
-            10,
-            Weapons._2_x_B_8M1___20_x_UnGd_Rkts__80_mm_S_8OFP2_MPP,
-        )
-        _2_x_S_25 = (10, Weapons._2_x_S_25)
-
-    # ERRR <CLEAN>
-
-    class Pylon11:
-        R_73__AA_11_Archer____Infra_Red = (11, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            11,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            11,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
-        )
-        RVV_MD2__AA_11_Archer_M2____Infra_Red = (
-            11,
-            WeaponsSu30.RVV_MD2__AA_11_Archer_M2____Infra_Red,
-        )
-        ASTRA_Mk_1___Active_Rdr_AAM = (11, WeaponsSu30.ASTRA_Mk_1___Active_Rdr_AAM)
-        I_Derby_ER___Active_Rdr_AAM = (11, WeaponsSu30.I_Derby_ER___Active_Rdr_AAM)
-        RVV_AE__AA_12_Adder____Active_Rdr = (
-            11,
-            WeaponsSu30.RVV_AE__AA_12_Adder____Active_Rdr,
-        )
-        RVV_SD__AA_12_Adder_B____Active_Rdr = (
-            11,
-            WeaponsSu30.RVV_SD__AA_12_Adder_B____Active_Rdr,
-        )
-        Smoke_Generator___red = (11, Weapons.Smoke_Generator___red)
-        Smoke_Generator___green = (11, Weapons.Smoke_Generator___green)
-        Smoke_Generator___blue = (11, Weapons.Smoke_Generator___blue)
-        Smoke_Generator___white = (11, Weapons.Smoke_Generator___white)
-        Smoke_Generator___yellow = (11, Weapons.Smoke_Generator___yellow)
-        Smoke_Generator___orange = (11, Weapons.Smoke_Generator___orange)
-
-    # ERRR <CLEAN>
-
-    class Pylon12:
-        R_73__AA_11_Archer____Infra_Red = (12, Weapons.R_73__AA_11_Archer____Infra_Red)
-        R_73L__AA_11_Archer_L____Infra_Red = (
-            12,
-            WeaponsSu30.R_73L__AA_11_Archer_L____Infra_Red,
-        )
-        R_73M__AA_11_Archer_M____Infra_Red = (
-            12,
-            WeaponsSu30.R_73M__AA_11_Archer_M____Infra_Red,
+            WeaponsSu30.R_74M__AA_11_Archer_M____Infra_Red,
         )
         RVV_MD2__AA_11_Archer_M2____Infra_Red = (
             12,


### PR DESCRIPTION
Updated weapon definitions to latest public mod version (v2.8.03 Beta) + CWS 3.70
Removed A2G plane classes as the default download includes CWS, which merges A2A and A2G versions of the plane into one