### PR TITLE
expend all ARMs for SEAD

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * **[Flight Plans]** Fixed a bug when a package was created with only escort flights
 * **[Flight Plans]** Added AntiShipStrike as a fallback task for OCA/Aircraft to fix a bug where the S-3B could not do OCA/Aircraft
 * **[Squadrons]** Fixed a bug where loading an air wing config would not properly load all squadrons
+* **[Flight Plans]** Fixed a bug where SEAD flights would fire one ARM and RTB
 
 # Retribution v1.4.1 (hotfix)
 

--- a/game/missiongenerator/aircraft/waypoints/seadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/seadingress.py
@@ -62,6 +62,7 @@ class SeadIngressBuilder(PydcsWaypointBuilder):
                 # into the SAM instead of waiting for it to come alive
                 engage_task = EngageGroup(miz_group.id)
                 engage_task.params["weaponType"] = DcsWeaponType.ARM.value
+                engage_task.params["expend"] = Expend.All.value
                 waypoint.tasks.append(engage_task)
 
             # Use other Air-to-Surface Missiles at last


### PR DESCRIPTION
Expend all ARMs during SEAD enroute task to fix flights firing one ARM and RTB

Ref: https://wiki.hoggitworld.com/view/DCS_task_engageGroup