### PR TITLE
Update Su-24 loadout

### DIFF
--- a/resources/customized_payloads/Su-24M.lua
+++ b/resources/customized_payloads/Su-24M.lua
@@ -2,46 +2,146 @@ local unitPayloads = {
 	["name"] = "Su-24M",
 	["payloads"] = {
 		[1] = {
-			["name"] = "CAP",
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{7D7EC917-05F6-49D4-8045-61FC587DD019}",
+					["CLSID"] = "{R-60M 2R}",
+					["num"] = 8,
+				},
+				[2] = {
+					["CLSID"] = "{40AB87E8-BEFB-4D85-90D9-B2753ACF9514}",
+					["num"] = 7,
+				},
+				[3] = {
+					["CLSID"] = "{40AB87E8-BEFB-4D85-90D9-B2753ACF9514}",
+					["num"] = 2,
+				},
+				[4] = {
+					["CLSID"] = "{R-60M 2L}",
+					["num"] = 1,
+				},
+				[5] = {
+					["CLSID"] = "{APK_9}",
+					["num"] = 4,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[2] = {
+			["displayName"] = "Retribution SEAD Escort",
+			["name"] = "Retribution SEAD Escort",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{292960BB-6518-41AC-BADA-210D65D5073C}",
+					["num"] = 8,
+				},
+				[2] = {
+					["CLSID"] = "{E86C5AA5-6D49-4F00-AD2E-79A62D6DDE26}",
+					["num"] = 7,
+				},
+				[3] = {
+					["CLSID"] = "{E86C5AA5-6D49-4F00-AD2E-79A62D6DDE26}",
+					["num"] = 2,
+				},
+				[4] = {
+					["CLSID"] = "{292960BB-6518-41AC-BADA-210D65D5073C}",
+					["num"] = 1,
+				},
+				[5] = {
+					["CLSID"] = "{0519A264-0AB6-11d6-9193-00A0249B6F00}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[3] = {
+			["name"] = "Retribution CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}",
+					["num"] = 8,
+				},
+				[2] = {
+					["CLSID"] = "{BA565F89-2373-4A84-9502-A0E017D3A44A}",
+					["num"] = 7,
+				},
+				[3] = {
+					["CLSID"] = "{BA565F89-2373-4A84-9502-A0E017D3A44A}",
+					["num"] = 2,
+				},
+				[4] = {
+					["CLSID"] = "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}",
+					["num"] = 1,
+				},
+				[5] = {
+					["CLSID"] = "{16602053-4A12-40A2-B214-AB60D481B20E}",
+					["num"] = 5,
+				},
+				[6] = {
+					["CLSID"] = "{BA565F89-2373-4A84-9502-A0E017D3A44A}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{BA565F89-2373-4A84-9502-A0E017D3A44A}",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[4] = {
+			["displayName"] = "Retribution SEAD",
+			["name"] = "Retribution SEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{R-60M 2R}",
+					["num"] = 8,
+				},
+				[2] = {
+					["CLSID"] = "{FE382A68-8620-4AC0-BDF5-709BFE3977D7}",
+					["num"] = 7,
+				},
+				[3] = {
+					["CLSID"] = "{FE382A68-8620-4AC0-BDF5-709BFE3977D7}",
+					["num"] = 2,
+				},
+				[4] = {
+					["CLSID"] = "{R-60M 2L}",
+					["num"] = 1,
+				},
+				[5] = {
+					["CLSID"] = "{0519A264-0AB6-11d6-9193-00A0249B6F00}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[5] = {
+			["name"] = "Retribution Anti-ship",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{4D13E282-DF46-4B23-864A-A9423DFDE504}",
 					["num"] = 7,
 				},
 				[2] = {
-					["CLSID"] = "{275A2855-4A79-4B2D-B082-91EA2ADF4691}",
-					["num"] = 8,
+					["CLSID"] = "{4D13E282-DF46-4B23-864A-A9423DFDE504}",
+					["num"] = 2,
 				},
 				[3] = {
 					["CLSID"] = "{B0DBC591-0F52-4F7D-AD7B-51E67725FB81}",
 					["num"] = 1,
 				},
 				[4] = {
-					["CLSID"] = "{7D7EC917-05F6-49D4-8045-61FC587DD019}",
-					["num"] = 2,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[2] = {
-			["name"] = "SEAD",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{FE382A68-8620-4AC0-BDF5-709BFE3977D7}",
-					["num"] = 7,
-				},
-				[2] = {
-					["CLSID"] = "{E86C5AA5-6D49-4F00-AD2E-79A62D6DDE26}",
+					["CLSID"] = "{275A2855-4A79-4B2D-B082-91EA2ADF4691}",
 					["num"] = 8,
-				},
-				[3] = {
-					["CLSID"] = "{E86C5AA5-6D49-4F00-AD2E-79A62D6DDE26}",
-					["num"] = 1,
-				},
-				[4] = {
-					["CLSID"] = "{FE382A68-8620-4AC0-BDF5-709BFE3977D7}",
-					["num"] = 2,
 				},
 				[5] = {
 					["CLSID"] = "{16602053-4A12-40A2-B214-AB60D481B20E}",
@@ -49,104 +149,48 @@ local unitPayloads = {
 				},
 			},
 			["tasks"] = {
-			},
-		},
-		[3] = {
-			["name"] = "STRIKE",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{KAB_1500LG_LOADOUT}",
-					["num"] = 7,
-				},
-				[2] = {
-					["CLSID"] = "{APU-60-1_R_60M}",
-					["num"] = 8,
-				},
-				[3] = {
-					["CLSID"] = "{APU-60-1_R_60M}",
-					["num"] = 1,
-				},
-				[4] = {
-					["CLSID"] = "{KAB_1500LG_LOADOUT}",
-					["num"] = 2,
-				},
-				[5] = {
-					["CLSID"] = "{16602053-4A12-40A2-B214-AB60D481B20E}",
-					["num"] = 5,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[4] = {
-			["name"] = "ANTISHIP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{D8F2C90B-887B-4B9E-9FE2-996BC9E9AF03}",
-					["num"] = 7,
-				},
-				[2] = {
-					["CLSID"] = "{E86C5AA5-6D49-4F00-AD2E-79A62D6DDE26}",
-					["num"] = 8,
-				},
-				[3] = {
-					["CLSID"] = "{E86C5AA5-6D49-4F00-AD2E-79A62D6DDE26}",
-					["num"] = 1,
-				},
-				[4] = {
-					["CLSID"] = "{D8F2C90B-887B-4B9E-9FE2-996BC9E9AF03}",
-					["num"] = 2,
-				},
-				[5] = {
-					["CLSID"] = "{16602053-4A12-40A2-B214-AB60D481B20E}",
-					["num"] = 5,
-				},
-			},
-			["tasks"] = {
-			},
-		},
-		[5] = {
-			["name"] = "CAS",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}",
-					["num"] = 8,
-				},
-				[2] = {
-					["CLSID"] = "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}",
-					["num"] = 1,
-				},
-				[3] = {
-					["CLSID"] = "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}",
-					["num"] = 2,
-				},
-				[4] = {
-					["CLSID"] = "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}",
-					["num"] = 7,
-				},
-				[5] = {
-					["CLSID"] = "{E2C426E3-8B10-4E09-B733-9CDC26520F48}",
-					["num"] = 6,
-				},
-				[6] = {
-					["CLSID"] = "{E2C426E3-8B10-4E09-B733-9CDC26520F48}",
-					["num"] = 3,
-				},
-			},
-			["tasks"] = {
+				[1] = 32,
 			},
 		},
 		[6] = {
-			["displayName"] = "Retribution OCA/Runway",
+			["displayName"] = "Retribution BAI",
+			["name"] = "Retribution BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}",
+					["num"] = 8,
+				},
+				[2] = {
+					["CLSID"] = "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}",
+					["num"] = 7,
+				},
+				[3] = {
+					["CLSID"] = "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}",
+					["num"] = 2,
+				},
+				[4] = {
+					["CLSID"] = "{6DADF342-D4BA-4D8A-B081-BA928C4AF86D}",
+					["num"] = 1,
+				},
+				[5] = {
+					["CLSID"] = "{16602053-4A12-40A2-B214-AB60D481B20E}",
+					["num"] = 5,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[7] = {
 			["name"] = "Retribution OCA/Runway",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{APU-60-1_R_60M}",
-					["num"] = 1,
+					["CLSID"] = "{BD289E34-DF84-4C5E-9220-4B14C346E79D}",
+					["num"] = 7,
 				},
 				[2] = {
 					["CLSID"] = "{BD289E34-DF84-4C5E-9220-4B14C346E79D}",
-					["num"] = 2,
+					["num"] = 6,
 				},
 				[3] = {
 					["CLSID"] = "{BD289E34-DF84-4C5E-9220-4B14C346E79D}",
@@ -154,19 +198,88 @@ local unitPayloads = {
 				},
 				[4] = {
 					["CLSID"] = "{BD289E34-DF84-4C5E-9220-4B14C346E79D}",
-					["num"] = 6,
+					["num"] = 2,
 				},
 				[5] = {
-					["CLSID"] = "{BD289E34-DF84-4C5E-9220-4B14C346E79D}",
-					["num"] = 7,
+					["CLSID"] = "{B0DBC591-0F52-4F7D-AD7B-51E67725FB81}",
+					["num"] = 1,
 				},
 				[6] = {
-					["CLSID"] = "{APU-60-1_R_60M}",
+					["CLSID"] = "{275A2855-4A79-4B2D-B082-91EA2ADF4691}",
 					["num"] = 8,
+				},
+				[7] = {
+					["CLSID"] = "{16602053-4A12-40A2-B214-AB60D481B20E}",
+					["num"] = 5,
 				},
 			},
 			["tasks"] = {
-				[1] = 34,
+				[1] = 32,
+			},
+		},
+		[8] = {
+			["displayName"] = "Retribution Strike",
+			["name"] = "Retribution Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{KAB_1500LG_LOADOUT}",
+					["num"] = 7,
+				},
+				[2] = {
+					["CLSID"] = "{KAB_1500LG_LOADOUT}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{16602053-4A12-40A2-B214-AB60D481B20E}",
+					["num"] = 5,
+				},
+				[4] = {
+					["CLSID"] = "{R-60M 2R}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{R-60M 2L}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[9] = {
+			["name"] = "Retribution OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{16602053-4A12-40A2-B214-AB60D481B20E}",
+					["num"] = 5,
+				},
+				[2] = {
+					["CLSID"] = "{E2C426E3-8B10-4E09-B733-9CDC26520F48}",
+					["num"] = 6,
+				},
+				[3] = {
+					["CLSID"] = "{E2C426E3-8B10-4E09-B733-9CDC26520F48}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{E2C426E3-8B10-4E09-B733-9CDC26520F48}",
+					["num"] = 2,
+				},
+				[5] = {
+					["CLSID"] = "{E2C426E3-8B10-4E09-B733-9CDC26520F48}",
+					["num"] = 7,
+				},
+				[6] = {
+					["CLSID"] = "{275A2855-4A79-4B2D-B082-91EA2ADF4691}",
+					["num"] = 8,
+				},
+				[7] = {
+					["CLSID"] = "{B0DBC591-0F52-4F7D-AD7B-51E67725FB81}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
 			},
 		},
 	},


### PR DESCRIPTION
Any loadouts with ARMs were not loading in-mission due to the lack of the ELINT pod (which is mandatory for ARMs). Likewise, Kh-59 requires datalink pod. As the existing loadouts are very old, I have fully updated the loadouts for all mission types.