### PR TITLE
Added implementation of Tiresias according to StillClock1 (Issue #561)

### DIFF
--- a/game/missiongenerator/flotgenerator.py
+++ b/game/missiongenerator/flotgenerator.py
@@ -158,7 +158,7 @@ class FlotGenerator:
             country = self.mission.country(self.game.blue.faction.country.name)
             jtac = self.mission.flight_group(
                 country=country,
-                name=namegen.next_jtac_name(),
+                name=namegen.next_jtac_name() + " FRONTLINE",
                 aircraft_type=utype.dcs_unit_type,
                 position=position[0],
                 airport=None,
@@ -240,7 +240,7 @@ class FlotGenerator:
                         )[0]
                         vg = self.mission.vehicle_group(
                             side,
-                            namegen.next_infantry_name(side, u),
+                            namegen.next_infantry_name(side, u) + " FRONTLINE",
                             u.dcs_unit_type,
                             position=infantry_position,
                             group_size=1,
@@ -268,7 +268,7 @@ class FlotGenerator:
         )
         vg = self.mission.vehicle_group(
             side,
-            namegen.next_infantry_name(side, units[0]),
+            namegen.next_infantry_name(side, units[0]) + " FRONTLINE",
             units[0].dcs_unit_type,
             position=infantry_position,
             group_size=1,
@@ -283,7 +283,7 @@ class FlotGenerator:
             position = infantry_position.random_point_within(55, 5)
             vg = self.mission.vehicle_group(
                 side,
-                namegen.next_infantry_name(side, unit),
+                namegen.next_infantry_name(side, unit) + " FRONTLINE",
                 unit.dcs_unit_type,
                 position=position,
                 group_size=1,
@@ -825,7 +825,7 @@ class FlotGenerator:
 
         group = self.mission.vehicle_group(
             side,
-            namegen.next_unit_name(side, unit_type),
+            namegen.next_unit_name(side, unit_type) + " FRONTLINE",
             unit_type.dcs_unit_type,
             position=at,
             group_size=count,

--- a/resources/plugins/MooseTiresias/MooseTiresias.lua
+++ b/resources/plugins/MooseTiresias/MooseTiresias.lua
@@ -1,0 +1,9 @@
+env.info("-----DCSRetribution|MOOSE Tiresias plugin - configuration start ------")
+
+local exceptionset = SET_GROUP:New():FilterPrefixes({ "Convoy", "convoy", "FRONTLINE" }):FilterStart()
+local blinder = TIRESIAS:New()
+-- Setup different radius for activation around helo and airplane groups (applies to AI and humans)
+blinder:SetActivationRanges(10, 25) -- defaults are 10, and 25
+-- Setup engagement ranges for AAA (non-advanced SAM units like Flaks etc) and if you want them to be AIOff
+blinder:SetAAARanges(60, true) -- defaults are 60, and true
+blinder:AddExceptionSet(exceptionset)

--- a/resources/plugins/MooseTiresias/plugin.json
+++ b/resources/plugins/MooseTiresias/plugin.json
@@ -1,0 +1,13 @@
+{
+    "nameInUI": "Moose's Tiresias",
+    "defaultValue": true,
+    "specificOptions": [],
+    "scriptsWorkOrders": [
+        {
+            "file": "MooseTiresias.lua",
+            "mnemonic": "MooseTiresias"
+        }
+    ],
+    "configurationWorkOrders": [],
+    "otherResourceFiles": []
+}

--- a/resources/plugins/plugins.json
+++ b/resources/plugins/plugins.json
@@ -11,5 +11,6 @@
     "skynetiads",
     "splashdamage2",
     "MooseAutolase",
-    "MooseMarkerOps"
+    "MooseMarkerOps",
+    "MooseTiresias"
 ]


### PR DESCRIPTION
Basic implementation of the idea by @StillClock1 (Issue #561).

I think the best way to do this would be to instead feed the unit names directly from Retribution to the LUA script via the plugin interface (a bit like how it is done for the artymbot plugin), but this should suffice for some testing (hence the draft PR).

I tested it, but there seems to be some issues with unresponsive AIs on the frontline nonetheless. I will be doing some more investigation, but in the meantime, feel free to test the performance difference.