### PR TITLE
Fix to exclude Moose plugins from Pretense injection

### DIFF
--- a/game/pretense/pretenseluagenerator.py
+++ b/game/pretense/pretenseluagenerator.py
@@ -1725,7 +1725,9 @@ class PretenseLuaGenerator(LuaGenerator):
     ) -> None:
         # Hard block MOOSE injection for Pretense missions
         if script_mnemonic.lower() == "moose" or "moose" in script.lower():
-            logging.info("PretenseLuaGenerator: Skipping hard-blocked Moose.lua injection")
+            logging.info(
+                "PretenseLuaGenerator: Skipping hard-blocked Moose.lua injection"
+            )
             return
 
         if script_mnemonic in self.plugin_scripts:
@@ -1745,7 +1747,6 @@ class PretenseLuaGenerator(LuaGenerator):
         fileref = self.mission.map_resource.add_resource_file(filename)
         trigger.add_action(DoScriptFile(fileref))
         self.mission.triggerrules.triggers.append(trigger)
-
 
     def inject_plugins(self) -> None:
         for plugin in LuaPluginManager.plugins():

--- a/game/pretense/pretenseluagenerator.py
+++ b/game/pretense/pretenseluagenerator.py
@@ -1723,6 +1723,11 @@ class PretenseLuaGenerator(LuaGenerator):
     def inject_plugin_script(
         self, plugin_mnemonic: str, script: str, script_mnemonic: str
     ) -> None:
+        # Hard block MOOSE injection for Pretense missions
+        if script_mnemonic.lower() == "moose" or "moose" in script.lower():
+            logging.info("PretenseLuaGenerator: Skipping hard-blocked Moose.lua injection")
+            return
+
         if script_mnemonic in self.plugin_scripts:
             logging.debug(f"Skipping already loaded {script} for {plugin_mnemonic}")
             return
@@ -1730,7 +1735,6 @@ class PretenseLuaGenerator(LuaGenerator):
         self.plugin_scripts.append(script_mnemonic)
 
         plugin_path = Path("./resources/plugins", plugin_mnemonic)
-
         script_path = Path(plugin_path, script)
         if not script_path.exists():
             logging.error(f"Cannot find {script_path} for plugin {plugin_mnemonic}")
@@ -1741,6 +1745,7 @@ class PretenseLuaGenerator(LuaGenerator):
         fileref = self.mission.map_resource.add_resource_file(filename)
         trigger.add_action(DoScriptFile(fileref))
         self.mission.triggerrules.triggers.append(trigger)
+
 
     def inject_plugins(self) -> None:
         for plugin in LuaPluginManager.plugins():


### PR DESCRIPTION
This is a quick fix to exclude Moose plugins (including base plugin) from being injected into Pretense missions.

    def inject_plugin_script(
        self, plugin_mnemonic: str, script: str, script_mnemonic: str
    ) -> None:
        # Hard block MOOSE injection for Pretense missions
        if script_mnemonic.lower() == "moose" or "moose" in script.lower():
            logging.info("PretenseLuaGenerator: Skipping hard-blocked Moose.lua injection")
            return

        if script_mnemonic in self.plugin_scripts:
            logging.debug(f"Skipping already loaded {script} for {plugin_mnemonic}")
            return

        self.plugin_scripts.append(script_mnemonic)

        plugin_path = Path("./resources/plugins", plugin_mnemonic)
        script_path = Path(plugin_path, script)
        if not script_path.exists():
            logging.error(f"Cannot find {script_path} for plugin {plugin_mnemonic}")
            return

        trigger = TriggerStart(comment=f"Load {script_mnemonic}")
        filename = script_path.resolve()
        fileref = self.mission.map_resource.add_resource_file(filename)
        trigger.add_action(DoScriptFile(fileref))
        self.mission.triggerrules.triggers.append(trigger)

This will only effect Pretense generated missions, and fixes the issue with no missions being generated for players.