### PR TITLE
fix ownfor being set to UN Peacekeepers regardless of campaign

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -4,6 +4,7 @@ import itertools
 import logging
 import math
 from collections.abc import Iterator
+from copy import deepcopy
 from datetime import date, datetime, time, timedelta
 from enum import Enum
 from typing import Any, List, TYPE_CHECKING, Union, cast
@@ -140,7 +141,7 @@ class Game:
         self.sanitize_sides(player_faction, enemy_faction)
         self.blue = Coalition(self, player_faction, player_budget, player=Player.BLUE)
         self.red = Coalition(self, enemy_faction, enemy_budget, player=Player.RED)
-        neutral_faction = player_faction
+        neutral_faction = deepcopy(player_faction)
         neutral_faction.country = self.neutral_country
         self.neutral = Coalition(self, neutral_faction, 0, player=Player.NEUTRAL)
         self.blue.set_opponent(self.red)

--- a/game/theater/start_generator.py
+++ b/game/theater/start_generator.py
@@ -175,9 +175,10 @@ class GameGenerator:
         # Remove carrier and lha, invert situation if needed
         for cp in self.theater.controlpoints:
             if self.generator_settings.inverted:
-                cp.starting_coalition = (
-                    Player.RED if not cp.captured_invert else Player.BLUE
-                )
+                if not cp.starting_coalition.is_neutral:
+                    cp.starting_coalition = (
+                        Player.RED if not cp.captured_invert else Player.BLUE
+                    )
 
             if cp.is_carrier and self.should_remove_carrier(cp.starting_coalition):
                 to_remove.append(cp)


### PR DESCRIPTION
Because I wasn't making a deep copy, when I edited the neutral faction country it also edited the ownfor faction country.