### PR TITLE
Fixed bugs wrt planning escort flights

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,7 @@
 * **[AirWing]** Use aircraft display names for easier differentiation between modules
 
 ## Fixes
-* **[Flight Plans]** Fixed a bug when a package was created with only escort flights
+* **[Flight Plans]** Fixed bugs wrt planning escort flights
 * **[Flight Plans]** Added AntiShipStrike as a fallback task for OCA/Aircraft to fix a bug where the S-3B could not do OCA/Aircraft
 * **[Squadrons]** Fixed a bug where loading an air wing config would not properly load all squadrons
 * **[Flight Plans]** Fixed a bug where SEAD flights would fire one ARM and RTB

--- a/game/ato/flightplans/escort.py
+++ b/game/ato/flightplans/escort.py
@@ -23,7 +23,13 @@ class EscortFlightPlan(FormationAttackFlightPlan):
 
     @property
     def split_time(self) -> datetime:
-        if self.package.primary_flight and self.package.primary_flight.flight_plan:
+        # Avoid infinite recursion when this escort flight is itself the primary flight
+        # This can happen when only escort flights remain in a package
+        if (
+            self.package.primary_flight
+            and self.package.primary_flight != self.flight
+            and self.package.primary_flight.flight_plan
+        ):
             return self.package.primary_flight.flight_plan.mission_departure_time
         else:
             return super().split_time

--- a/qt_ui/windows/mission/QPackageDialog.py
+++ b/qt_ui/windows/mission/QPackageDialog.py
@@ -298,6 +298,8 @@ class QPackageDialog(QDialog):
         ):
             return True
         else:
+            for flight in list(self.package_model.package.flights):
+                self.package_model.cancel_or_abort_flight(flight)
             QMessageBox.critical(
                 self,
                 "Invalid Package",


### PR DESCRIPTION
Fixes infinite recursion mentioned here: https://discord.com/channels/1015931619187621999/1025835702111445112/1435991888439279727

Also fixes deleting flights not recreating the package, this should happen since deleting a flight can change the primary flight.

Also fixes package validation not properly deleting the flights when the package gets marked as invalid.