### PR TITLE
Improve B-52 mission types and update B-52 and B-1 loadouts

### DIFF
--- a/resources/customized_payloads/B-1B.lua
+++ b/resources/customized_payloads/B-1B.lua
@@ -2,88 +2,8 @@ local unitPayloads = {
 	["name"] = "B-1B",
 	["payloads"] = {
 		[1] = {
-			["name"] = "CAS",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "GBU-38*16",
-					["num"] = 2,
-				},
-				[2] = {
-					["CLSID"] = "CBU87*10",
-					["num"] = 1,
-				},
-				[3] = {
-					["CLSID"] = "CBU97*10",
-					["num"] = 3,
-				},
-			},
-			["tasks"] = {
-				[1] = 33,
-			},
-		},
-		[2] = {
-			["name"] = "ANTISHIP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
-					["num"] = 3,
-				},
-			},
-			["tasks"] = {
-				[1] = 33,
-			},
-		},
-		[3] = {
-			["name"] = "SEAD",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
-					["num"] = 3,
-				},
-			},
-			["tasks"] = {
-				[1] = 33,
-			},
-		},
-		[4] = {
-			["displayName"] = "Retribution DEAD",
-			["name"] = "Retribution DEAD",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
-					["num"] = 1,
-				},
-				[2] = {
-					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
-					["num"] = 3,
-				},
-			},
-			["tasks"] = {
-				[1] = 33,
-			},
-		},
-		[5] = {
-			["name"] = "STRIKE",
+			["displayName"] = "Retribution CAS",
+			["name"] = "Retribution CAS",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "GBU-31*8",
@@ -103,12 +23,121 @@ local unitPayloads = {
 				[2] = 32,
 			},
 		},
-		[6] = {
+		[2] = {
+			["displayName"] = "Retribution Strike",
+			["name"] = "Retribution Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "GBU-31V3B*8",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "GBU-31V3B*8",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "GBU-31V3B*8",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+				[1] = 34,
+				[2] = 32,
+			},
+		},
+		[3] = {
+			["displayName"] = "Retribution OCA/Aircraft",
+			["name"] = "Retribution OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "GBU-31V3B*8",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "GBU-31V3B*8",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "GBU-31V3B*8",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+				[1] = 34,
+				[2] = 32,
+			},
+		},
+		[4] = {
 			["name"] = "CAP",
 			["pylons"] = {
 			},
 			["tasks"] = {
 				[1] = 33,
+			},
+		},
+		[5] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+				[1] = 34,
+				[2] = 32,
+			},
+		},
+		[6] = {
+			["displayName"] = "Retribution BAI",
+			["name"] = "Retribution BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{SECBM_CBU105}",
+					["num"] = 1,
+					["settings"] = {
+						["NFP_PRESID"] = "MDRN_CC_A_SUU65Plus_SFW",
+						["NFP_PRESVER"] = 1,
+						["NFP_fuze_type_nose"] = "FZU39",
+						["function_altitude_ctrl_FZU39_SUU65_SFW"] = 457.2,
+						["function_delay_ctrl_FZU39_SUU65_SFW"] = 2.23,
+					},
+				},
+				[2] = {
+					["CLSID"] = "{SECBM_CBU105}",
+					["num"] = 2,
+					["settings"] = {
+						["NFP_PRESID"] = "MDRN_CC_A_SUU65Plus_SFW",
+						["NFP_PRESVER"] = 1,
+						["NFP_fuze_type_nose"] = "FZU39",
+						["function_altitude_ctrl_FZU39_SUU65_SFW"] = 457.2,
+						["function_delay_ctrl_FZU39_SUU65_SFW"] = 2.23,
+					},
+				},
+				[3] = {
+					["CLSID"] = "{SECBM_CBU105}",
+					["num"] = 3,
+					["settings"] = {
+						["NFP_PRESID"] = "MDRN_CC_A_SUU65Plus_SFW",
+						["NFP_PRESVER"] = 1,
+						["NFP_fuze_type_nose"] = "FZU39",
+						["function_altitude_ctrl_FZU39_SUU65_SFW"] = 457.2,
+						["function_delay_ctrl_FZU39_SUU65_SFW"] = 2.23,
+					},
+				},
+			},
+			["tasks"] = {
+				[1] = 34,
+				[2] = 32,
 			},
 		},
 		[7] = {
@@ -131,6 +160,66 @@ local unitPayloads = {
 			["tasks"] = {
 				[1] = 34,
 				[2] = 32,
+			},
+		},
+		[8] = {
+			["name"] = "SEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+				[1] = 33,
+			},
+		},
+		[9] = {
+			["name"] = "CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "CBU97*10",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "CBU97*10",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "CBU97*10",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 33,
+			},
+		},
+		[10] = {
+			["name"] = "ANTISHIP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{AABA1A14-78A1-4E85-94DD-463CF75BD9E4}",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+				[1] = 33,
 			},
 		},
 	},

--- a/resources/customized_payloads/B-52H.lua
+++ b/resources/customized_payloads/B-52H.lua
@@ -2,6 +2,84 @@ local unitPayloads = {
 	["name"] = "B-52H",
 	["payloads"] = {
 		[1] = {
+			["displayName"] = "Retribution BAI",
+			["name"] = "Retribution BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HSAB_8x_CBU105_R}",
+					["num"] = 3,
+					["settings"] = {
+						["NFP_fuze_type_nose"] = "FZU39",
+						["function_altitude_ctrl_FZU39_SUU65_SFW"] = 457.2,
+						["function_delay_ctrl_FZU39_SUU65_SFW"] = 2.23,
+					},
+				},
+				[2] = {
+					["CLSID"] = "{HSAB_8x_CBU105_L}",
+					["num"] = 1,
+					["settings"] = {
+						["NFP_PRESID"] = "MDRN_CC_A_SUU65Plus_SFW",
+						["NFP_PRESVER"] = 1,
+						["NFP_fuze_type_nose"] = "FZU39",
+						["function_altitude_ctrl_FZU39_SUU65_SFW"] = 457.2,
+						["function_delay_ctrl_FZU39_SUU65_SFW"] = 2.23,
+					},
+				},
+				[3] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 4,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[2] = {
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{45447F82-01B5-4029-A572-9AAD28AF0275}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{8DCAF3A3-7FCF-41B8-BB88-58DEDA878EDE}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{45447F82-01B5-4029-A572-9AAD28AF0275}",
+					["num"] = 1,
+				},
+				[4] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 4,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[3] = {
+			["displayName"] = "Retribution Anti-ship",
+			["name"] = "Retribution Anti-ship",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HSAB_4x_AGM84D_R}",
+					["num"] = 3,
+				},
+				[2] = {
+					["CLSID"] = "{HSAB_4x_AGM84D_L}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 4,
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[4] = {
 			["name"] = "Retribution OCA/Runway",
 			["pylons"] = {
 				[1] = {
@@ -35,49 +113,16 @@ local unitPayloads = {
 						["NFP_fuze_type_tail"] = "FMU143",
 					},
 				},
-			},
-			["tasks"] = {
-				[1] = 32,
-			},
-		},
-		[2] = {
-			["name"] = "Retribution DEAD",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{45447F82-01B5-4029-A572-9AAD28AF0275}",
-					["num"] = 3,
-				},
-				[2] = {
-					["CLSID"] = "{8DCAF3A3-7FCF-41B8-BB88-58DEDA878EDE}",
-					["num"] = 2,
-				},
-				[3] = {
-					["CLSID"] = "{45447F82-01B5-4029-A572-9AAD28AF0275}",
-					["num"] = 1,
+				[4] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {
 				[1] = 32,
 			},
 		},
-		[3] = {
-			["displayName"] = "Retribution Anti-ship",
-			["name"] = "Retribution Anti-ship",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{HSAB_4x_AGM84D_R}",
-					["num"] = 3,
-				},
-				[2] = {
-					["CLSID"] = "{HSAB_4x_AGM84D_L}",
-					["num"] = 1,
-				},
-			},
-			["tasks"] = {
-				[1] = 32,
-			},
-		},
-		[4] = {
+		[5] = {
 			["displayName"] = "Retribution Strike",
 			["name"] = "Retribution Strike",
 			["pylons"] = {
@@ -112,12 +157,16 @@ local unitPayloads = {
 						["NFP_fuze_type_tail"] = "FMU143",
 					},
 				},
+				[4] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 4,
+				},
 			},
 			["tasks"] = {
 				[1] = 32,
 			},
 		},
-		[5] = {
+		[6] = {
 			["displayName"] = "Retribution OCA/Aircraft",
 			["name"] = "Retribution OCA/Aircraft",
 			["pylons"] = {
@@ -152,34 +201,9 @@ local unitPayloads = {
 						["NFP_fuze_type_tail"] = "FMU143",
 					},
 				},
-			},
-			["tasks"] = {
-				[1] = 32,
-			},
-		},
-		[6] = {
-			["displayName"] = "Retribution BAI",
-			["name"] = "Retribution BAI",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{HSAB_8x_CBU105_R}",
-					["num"] = 3,
-					["settings"] = {
-						["NFP_fuze_type_nose"] = "FZU39",
-						["function_altitude_ctrl_FZU39_SUU65_SFW"] = 457.2,
-						["function_delay_ctrl_FZU39_SUU65_SFW"] = 2.23,
-					},
-				},
-				[2] = {
-					["CLSID"] = "{HSAB_8x_CBU105_L}",
-					["num"] = 1,
-					["settings"] = {
-						["NFP_PRESID"] = "MDRN_CC_A_SUU65Plus_SFW",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_nose"] = "FZU39",
-						["function_altitude_ctrl_FZU39_SUU65_SFW"] = 457.2,
-						["function_delay_ctrl_FZU39_SUU65_SFW"] = 2.23,
-					},
+				[4] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 4,
 				},
 			},
 			["tasks"] = {

--- a/resources/customized_payloads/B-52H.lua
+++ b/resources/customized_payloads/B-52H.lua
@@ -5,16 +5,35 @@ local unitPayloads = {
 			["name"] = "Retribution OCA/Runway",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{585D626E-7F42-4073-AB70-41E728C333E2}",
+					["CLSID"] = "{HSAB_6x_GBU31V3_R}",
 					["num"] = 3,
+					["settings"] = {
+						["01_prfx_arm_delay_ctrl_FMU143"] = 5.5,
+						["01_prfx_function_delay_ctrl_FMU143"] = 0.03,
+						["NFP_fuze_type_tail"] = "FMU143",
+					},
 				},
 				[2] = {
-					["CLSID"] = "{6C47D097-83FF-4FB2-9496-EAB36DDF0B05}",
-					["num"] = 2,
+					["CLSID"] = "{HSAB_6x_GBU31V3_L}",
+					["num"] = 1,
+					["settings"] = {
+						["01_prfx_arm_delay_ctrl_FMU143"] = 5.5,
+						["01_prfx_function_delay_ctrl_FMU143"] = 0.03,
+						["NFP_PRESID"] = "MDRN_B_A_PGM_HTP",
+						["NFP_PRESVER"] = 2,
+						["NFP_fuze_type_tail"] = "FMU143",
+					},
 				},
 				[3] = {
-					["CLSID"] = "{585D626E-7F42-4073-AB70-41E728C333E2}",
-					["num"] = 1,
+					["CLSID"] = "{CSRL_GBU31V3}",
+					["num"] = 2,
+					["settings"] = {
+						["01_prfx_arm_delay_ctrl_FMU143"] = 5.5,
+						["01_prfx_function_delay_ctrl_FMU143"] = 0.03,
+						["NFP_PRESID"] = "MDRN_B_A_PGM_HTP",
+						["NFP_PRESVER"] = 2,
+						["NFP_fuze_type_tail"] = "FMU143",
+					},
 				},
 			},
 			["tasks"] = {
@@ -46,11 +65,11 @@ local unitPayloads = {
 			["name"] = "Retribution Anti-ship",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HSAB-6xAGM-84}",
+					["CLSID"] = "{HSAB_4x_AGM84D_R}",
 					["num"] = 3,
 				},
 				[2] = {
-					["CLSID"] = "{HSAB-6xAGM-84}",
+					["CLSID"] = "{HSAB_4x_AGM84D_L}",
 					["num"] = 1,
 				},
 			},
@@ -63,16 +82,104 @@ local unitPayloads = {
 			["name"] = "Retribution Strike",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{585D626E-7F42-4073-AB70-41E728C333E2}",
+					["CLSID"] = "{HSAB_6x_GBU31V3_R}",
 					["num"] = 3,
+					["settings"] = {
+						["01_prfx_arm_delay_ctrl_FMU143"] = 5.5,
+						["01_prfx_function_delay_ctrl_FMU143"] = 0.03,
+						["NFP_fuze_type_tail"] = "FMU143",
+					},
 				},
 				[2] = {
-					["CLSID"] = "{6C47D097-83FF-4FB2-9496-EAB36DDF0B05}",
+					["CLSID"] = "{CSRL_GBU31V3}",
 					["num"] = 2,
+					["settings"] = {
+						["01_prfx_arm_delay_ctrl_FMU143"] = 5.5,
+						["01_prfx_function_delay_ctrl_FMU143"] = 0.03,
+						["NFP_PRESID"] = "MDRN_B_A_PGM_HTP",
+						["NFP_PRESVER"] = 2,
+						["NFP_fuze_type_tail"] = "FMU143",
+					},
 				},
 				[3] = {
-					["CLSID"] = "{585D626E-7F42-4073-AB70-41E728C333E2}",
+					["CLSID"] = "{HSAB_6x_GBU31V3_L}",
 					["num"] = 1,
+					["settings"] = {
+						["01_prfx_arm_delay_ctrl_FMU143"] = 5.5,
+						["01_prfx_function_delay_ctrl_FMU143"] = 0.03,
+						["NFP_PRESID"] = "MDRN_B_A_PGM_HTP",
+						["NFP_PRESVER"] = 2,
+						["NFP_fuze_type_tail"] = "FMU143",
+					},
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[5] = {
+			["displayName"] = "Retribution OCA/Aircraft",
+			["name"] = "Retribution OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HSAB_6x_GBU31V3_R}",
+					["num"] = 3,
+					["settings"] = {
+						["01_prfx_arm_delay_ctrl_FMU143"] = 5.5,
+						["01_prfx_function_delay_ctrl_FMU143"] = 0.03,
+						["NFP_fuze_type_tail"] = "FMU143",
+					},
+				},
+				[2] = {
+					["CLSID"] = "{HSAB_6x_GBU31V3_L}",
+					["num"] = 1,
+					["settings"] = {
+						["01_prfx_arm_delay_ctrl_FMU143"] = 5.5,
+						["01_prfx_function_delay_ctrl_FMU143"] = 0.03,
+						["NFP_PRESID"] = "MDRN_B_A_PGM_HTP",
+						["NFP_PRESVER"] = 2,
+						["NFP_fuze_type_tail"] = "FMU143",
+					},
+				},
+				[3] = {
+					["CLSID"] = "{CSRL_GBU31V3}",
+					["num"] = 2,
+					["settings"] = {
+						["01_prfx_arm_delay_ctrl_FMU143"] = 5.5,
+						["01_prfx_function_delay_ctrl_FMU143"] = 0.03,
+						["NFP_PRESID"] = "MDRN_B_A_PGM_HTP",
+						["NFP_PRESVER"] = 2,
+						["NFP_fuze_type_tail"] = "FMU143",
+					},
+				},
+			},
+			["tasks"] = {
+				[1] = 32,
+			},
+		},
+		[6] = {
+			["displayName"] = "Retribution BAI",
+			["name"] = "Retribution BAI",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{HSAB_8x_CBU105_R}",
+					["num"] = 3,
+					["settings"] = {
+						["NFP_fuze_type_nose"] = "FZU39",
+						["function_altitude_ctrl_FZU39_SUU65_SFW"] = 457.2,
+						["function_delay_ctrl_FZU39_SUU65_SFW"] = 2.23,
+					},
+				},
+				[2] = {
+					["CLSID"] = "{HSAB_8x_CBU105_L}",
+					["num"] = 1,
+					["settings"] = {
+						["NFP_PRESID"] = "MDRN_CC_A_SUU65Plus_SFW",
+						["NFP_PRESVER"] = 1,
+						["NFP_fuze_type_nose"] = "FZU39",
+						["function_altitude_ctrl_FZU39_SUU65_SFW"] = 457.2,
+						["function_delay_ctrl_FZU39_SUU65_SFW"] = 2.23,
+					},
 				},
 			},
 			["tasks"] = {

--- a/resources/units/aircraft/B-52H.yaml
+++ b/resources/units/aircraft/B-52H.yaml
@@ -14,6 +14,9 @@ variants:
   B-52H Stratofortress: {}
 tasks:
   Anti-ship: 100
+  BAI: 660
+  CAS: 660
   DEAD: 210
   OCA/Runway: 660
+  OCA/Aircraft: 660
   Strike: 690


### PR DESCRIPTION
Add CAS, BAI, and OCA/aircraft to mission types for B-52 now that it has access to JDAMs, LGBs, and CBUs.

Also updated B-52 and B-1 loadouts to use new weapon types and fix loadouts not showing up in Retribution.