### PR TITLE
Fix Backslashes in Mission Start Dialog

### DIFF
--- a/resources/ui/templates/mission_start_EN.j2
+++ b/resources/ui/templates/mission_start_EN.j2
@@ -46,7 +46,7 @@
 
 <h2>Finishing</h2>
 
-<p>Once you have played the mission, click on the \"Accept Results\" button.</p>
+<p>Once you have played the mission, click on the "Accept Results" button.</p>
 
 <p>
   If DCS Retribution does not detect mission end, use the manually submit button,


### PR DESCRIPTION
Update the `mission_start` dialog's english template file to remove backslashes appearing before quotes in the UI.


Before:

<img width="721" height="184" alt="2025-11-16-170026_721x184_scrot" src="https://github.com/user-attachments/assets/3a248c42-fd96-4949-9326-d4b9b0f83b65" />


After:

<img width="601" height="145" alt="2025-11-16-170119_601x145_scrot" src="https://github.com/user-attachments/assets/767f630d-d686-4bd7-817a-f8dc0e03f925" />
