### PR TITLE
fix kneeboard generation wrt neutral base changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 * **[Engine]** Fixed a bug wrt pretense generation and moose script conflicts
 * **[Engine]** Fixed a bug where frontline debriefing was not properly calculated
 * **[Mission Generation]** Fixed an issue where blue and red units spawned next to each other on frontlines
+* **[Mission Generation]** Fixed an issue where kneeboards showed both opfor and ownfor support aircraft
 
 # Retribution v1.4.1 (hotfix)
 

--- a/game/missiongenerator/missiongenerator.py
+++ b/game/missiongenerator/missiongenerator.py
@@ -351,15 +351,15 @@ class MissionGenerator:
                 gen.add_dynamic_runway(dynamic_runway)
 
             for tanker in mission_data.tankers:
-                if tanker.blue:
+                if tanker.blue.is_blue:
                     gen.add_tanker(tanker)
 
             for aewc in mission_data.awacs:
-                if aewc.blue:
+                if aewc.blue.is_blue:
                     gen.add_awacs(aewc)
 
             for jtac in mission_data.jtacs:
-                if jtac.blue:
+                if jtac.blue.is_blue:
                     gen.add_jtac(jtac)
 
             for flight in mission_data.flights:


### PR DESCRIPTION
Properly check if a support aircraft (awacs, tanker, etc) is blue before adding it to the kneeboard