### PR TITLE
Swap Currenthill Tu-95 squadrons for new DCS model

### DIFF
--- a/resources/campaigns/clash_of_the_titans.yaml
+++ b/resources/campaigns/clash_of_the_titans.yaml
@@ -139,7 +139,6 @@ squadrons:
     - primary: Strike
       secondary: any
       aircraft:
-        - "[CH] Tu-95MSM"
         - Tu-95MS Bear-H
       size: 8
     - primary: BAI

--- a/resources/campaigns/clash_of_the_titans.yaml
+++ b/resources/campaigns/clash_of_the_titans.yaml
@@ -189,7 +189,6 @@ squadrons:
     - primary: Escort
       secondary: any
       aircraft:
-         - "[CH] Mi-28N AH"
          - Mi-28N Havoc
       size: 4
   #Camp Bastion

--- a/resources/campaigns/slava_ukraini.yaml
+++ b/resources/campaigns/slava_ukraini.yaml
@@ -88,7 +88,7 @@ squadrons:
     - primary: CAS
       secondary: air-to-ground
       aircraft:
-        - "[CH] Mi-28N AH"
+        - Mi-28N Havoc
       size: 4
   #Mineralnye Vody
   26:

--- a/resources/campaigns/slava_ukraini.yaml
+++ b/resources/campaigns/slava_ukraini.yaml
@@ -115,6 +115,5 @@ squadrons:
     - primary: Strike
       secondary: any
       aircraft:
-        - "[CH] Tu-95MSM"
         - Tu-95MS Bear-H
       size: 12

--- a/resources/campaigns/the_anvil_of_war.yaml
+++ b/resources/campaigns/the_anvil_of_war.yaml
@@ -177,7 +177,6 @@ squadrons:
     - primary: Escort
       secondary: any
       aircraft:
-        - "[CH] Mi-28N AH"
         - Mi-28N Havoc
       size: 4
     - primary: CAS

--- a/resources/campaigns/the_anvil_of_war.yaml
+++ b/resources/campaigns/the_anvil_of_war.yaml
@@ -234,7 +234,6 @@ squadrons:
     - primary: Strike
       secondary: any
       aircraft:
-        - "[CH] Tu-95MSM"
         - Tu-95MS Bear-H
       size: 12
     - primary: OCA/Runway


### PR DESCRIPTION
The old low poly DCS Tu-95 has been replaced with the one from Currenthill's Russia asset pack. The Tu-95 has therefore been removed from the latest Russia asset pack. I have swapped out the Tu-95 squadrons in my campaigns that use them with the new base DCS Tu-95.

Edit: Also swapped out the CH Mi-28 for the new DCS Mi-28 as the new CH pack no longer has one.