### PR TITLE
prevent ground objects from being owned by off map spawns

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 * **[Engine]** Fixed a bug where frontline debriefing was not properly calculated
 * **[Mission Generation]** Fixed an issue where blue and red units spawned next to each other on frontlines
 * **[Mission Generation]** Fixed an issue where kneeboards showed both opfor and ownfor support aircraft
+* **[Campaigns]** Fixed a bug where off map spawns could own ground objects, causing them not to spawn
 
 # Retribution v1.4.1 (hotfix)
 

--- a/game/campaignloader/mizcampaignloader.py
+++ b/game/campaignloader/mizcampaignloader.py
@@ -546,7 +546,12 @@ class MizCampaignLoader:
                 not in [
                     ControlPointType.AIRCRAFT_CARRIER_GROUP,
                     ControlPointType.LHA_GROUP,
+                    ControlPointType.OFF_MAP,
                 ]
+            ]
+        else:
+            candidates = [
+                cp for cp in candidates if cp.cptype != ControlPointType.OFF_MAP
             ]
 
         if candidates:
@@ -565,10 +570,15 @@ class MizCampaignLoader:
                 not in [
                     ControlPointType.AIRCRAFT_CARRIER_GROUP,
                     ControlPointType.LHA_GROUP,
+                    ControlPointType.OFF_MAP,
                 ]
             ]
         else:
-            fallback_candidates = self.theater.controlpoints
+            fallback_candidates = [
+                cp
+                for cp in self.theater.controlpoints
+                if cp.cptype != ControlPointType.OFF_MAP
+            ]
 
         fallback_candidates = [
             cp for cp in fallback_candidates if not cp.influence_radius


### PR DESCRIPTION
This fixes a bug where an off map spawn could have control over a TGO object which would cause the TGO to not spawn at all in the campaign