### PR TITLE
add campaign name to retribution window name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 * **[AirWing]** Use aircraft display names for easier differentiation between modules
 * **[Plugins]** Added BigEye EWR Script
 * **[Modding]** Update CurrentHill Russia Assets Pack to 2.0.0
+* **[UI]** Add campaign name to retribution window name
 
 ## Fixes
 * **[Flight Plans]** Fixed bugs wrt planning escort flights

--- a/game/game.py
+++ b/game/game.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 from copy import deepcopy
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, List, TYPE_CHECKING, Union, cast
+from typing import Any, List, Optional, TYPE_CHECKING, Union, cast
 from uuid import UUID
 
 from dcs.countries import Switzerland, USAFAggressors, UnitedNationsPeacekeepers
@@ -106,9 +106,11 @@ class Game:
         settings: Settings,
         player_budget: float,
         enemy_budget: float,
+        campaign_name: Optional[str] = None,
     ) -> None:
         self.settings = settings
         self.theater = theater
+        self.campaign_name = campaign_name
         self.turn = 0
         # NB: This is the *start* date. It is never updated.
         self.date = date(start_date.year, start_date.month, start_date.day)

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -42,7 +42,8 @@ class Migrator:
         self._update_weather()
         self._update_tgos()
         self._reload_terrain()
-        self._update_theather()
+        self._update_theater()
+        self._update_campaign_name()
 
         # TODO: remove in due time as this is supposedly fixed
         self.game.settings.nevatim_parking_fix = False
@@ -259,6 +260,10 @@ class Migrator:
         if issubclass(t.__class__, Terrain):
             self.game.theater.terrain = type(t)()  # type: ignore
 
-    def _update_theather(self) -> None:
+    def _update_theater(self) -> None:
         if not hasattr(self.game.theater, "rebel_zones"):
             self.game.theater.rebel_zones = []
+
+    def _update_campaign_name(self) -> None:
+        if not hasattr(self.game, "campaign_name"):
+            self.game.campaign_name = None

--- a/game/theater/start_generator.py
+++ b/game/theater/start_generator.py
@@ -128,6 +128,7 @@ class GameGenerator:
         settings: Settings,
         generator_settings: GeneratorSettings,
         mod_settings: ModSettings,
+        campaign_name: Optional[str] = None,
     ) -> None:
         self.player = player
         self.enemy = enemy
@@ -135,6 +136,7 @@ class GameGenerator:
         self.air_wing_config = air_wing_config
         self.settings = settings
         self.generator_settings = generator_settings
+        self.campaign_name = campaign_name
         self.player.apply_mod_settings(mod_settings)
         self.enemy.apply_mod_settings(mod_settings)
 
@@ -153,6 +155,7 @@ class GameGenerator:
                 settings=self.settings,
                 player_budget=self.generator_settings.player_budget,
                 enemy_budget=self.generator_settings.enemy_budget,
+                campaign_name=self.campaign_name,
             )
 
             GroundObjectGenerator(game, self.generator_settings).generate()

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -415,18 +415,25 @@ class QLiberationWindow(QMainWindow):
 
     def updateWindowTitle(self, save_path: Optional[str] = None) -> None:
         """
-        to DCS Retribution - vX.X.X - file_name
+        Window title format: DCS Retribution - vX.X.X - campaign_name - file_name
+        Campaign name is shown if a game is loaded and has a campaign_name.
+        File name is appended only if save_path is provided.
         """
         window_title = f"DCS Retribution - v{VERSION}"
-        if save_path:  # appending the file name to title as it is updated
+
+        if self.game and self.game.campaign_name:
+            window_title += f" - {self.game.campaign_name}"
+
+        if save_path:
             file_name = save_path.split("/")[-1].rsplit(".", 1)[0]
-            window_title = f"{window_title} - {file_name}"
+            window_title += f" - {file_name}"
+
         self.setWindowTitle(window_title)
 
     def onGameGenerated(self, game: Game):
-        self.updateWindowTitle()
         logging.info("On Game generated")
         self.game = game
+        self.updateWindowTitle()
         GameUpdateSignal.get_instance().game_loaded.emit(self.game)
 
     def onEndGame(self, state: TurnState):

--- a/qt_ui/windows/newgame/QNewGameWizard.py
+++ b/qt_ui/windows/newgame/QNewGameWizard.py
@@ -155,6 +155,7 @@ class NewGameWizard(QtWidgets.QWizard):
             settings,
             generator_settings,
             mod_settings,
+            campaign_name=campaign.name,
         )
         self.generatedGame = generator.generate()
 


### PR DESCRIPTION
Add the name of the campaign to the name of the retribution window to make it easier for users to know what campaign they are using and make debugging easier.