### PR TITLE
Update SplashDamage3 defaults and add new options - Take 2

### DIFF
--- a/resources/plugins/splashdamage3/plugin.json
+++ b/resources/plugins/splashdamage3/plugin.json
@@ -38,7 +38,7 @@
             "defaultValue": true
         },
         {
-            "nameInUI": "Dynamic Blast Radius Multiplier (%)",
+            "nameInUI": "Dynamic Blast Radius Multiplier",
             "mnemonic": "dynamic_blast_radius_modifier",
             "minimumValue": 1,
             "maximumValue": 5000,
@@ -52,16 +52,16 @@
         {
             "nameInUI": "Static Objects Damage Boost",
             "mnemonic": "static_damage_boost",
-            "minimumValue": 1000,
+            "minimumValue": 1,
             "maximumValue": 5000,
             "defaultValue": 2000
         },
         {
-            "nameInUI": "Overall Scaling (%)",
+            "nameInUI": "Overall Scaling Multiplier",
             "mnemonic": "overall_scaling",
             "minimumValue": 1,
-            "maximumValue": 5000,
-            "defaultValue": 100
+            "maximumValue": 100,
+            "defaultValue": 3
         },
         {
             "nameInUI": "Health Value Units Movements are Disabled (%)",
@@ -90,6 +90,18 @@
             "defaultValue": false
         },
         {
+            "nameInUI": "Cluster Munitions Bomblets Count Reduction Modifier",
+            "mnemonic": "cluster_bomblet_reductionmodifier",
+            "defaultValue": true
+        },
+        {
+            "nameInUI": "Global Bomblet Explosive Modifier",
+            "mnemonic": "cluster_bomblet_damage_modifier",
+            "minimumValue": 1,
+            "maximumValue": 100,
+            "defaultValue": 1
+        },
+        {
             "nameInUI": "Rockets damage multiplier (%)",
             "mnemonic": "rocket_multiplier",
             "minimumValue": 10,
@@ -107,6 +119,87 @@
             "minimumValue": 0,
             "maximumValue": 5000,
             "defaultValue": 3000
+        },
+        {
+            "nameInUI": "Enable Ordnance Protection",
+            "mnemonic": "ordnance_protection",
+            "defaultValue": true
+        },
+        {
+            "nameInUI": "Ordnance Protection Radius (m)",
+            "mnemonic": "ordnance_protection_radius",
+            "minimumValue": 100,
+            "maximumValue": 2000,
+            "defaultValue": 800
+        },
+        {
+            "nameInUI": "Detect Ordnance Destroyed by Large Explosions",
+            "mnemonic": "detect_ordnance_destruction",
+            "defaultValue": true
+        },
+        {
+            "nameInUI": "Snap Explosion to Ground if Destroyed by Large Explosion",
+            "mnemonic": "snap_to_ground_if_destroyed_by_large_explosion",
+            "defaultValue": false
+        },
+        {
+            "nameInUI": "Maximum Height to Snap Explosions to Ground",
+            "mnemonic": "max_snapped_height",
+            "minimumValue": 10,
+            "maximumValue": 5000,
+            "defaultValue": 80
+        },
+        {
+            "nameInUI": "Enable Detection of Recent Large Explosion",
+            "mnemonic": "recent_large_explosion_snap",
+            "defaultValue": true
+        },
+        {
+            "nameInUI": "Range of Recent Large Explosion Detection (m)",
+            "mnemonic": "recent_large_explosion_range",
+            "minimumValue": 10,
+            "maximumValue": 5000,
+            "defaultValue": 100
+        },
+        {
+            "nameInUI": "Time to Detect Recent Large Explosions (sec)",
+            "mnemonic": "recent_large_explosion_time",
+            "minimumValue": 1,
+            "maximumValue": 100,
+            "defaultValue": 4
+        },
+        {
+            "nameInUI": "Ground Ordnance Explosion Damage Multipler",
+            "mnemonic": "groundunitordnance_damage_modifier",
+            "minimumValue": 1,
+            "maximumValue": 100,
+            "defaultValue": 1
+        },
+        {
+            "nameInUI": "Ground Ordnance Explosion Blast Wave Multipler",
+            "mnemonic": "groundunitordnance_blastwave_modifier",
+            "minimumValue": 1,
+            "maximumValue": 100,
+            "defaultValue": 4
+        },
+        {
+            "nameInUI": "Critical Component Damage (Single Hit Failure)",
+            "mnemonic": "CriticalComponent",
+            "defaultValue": false
+        },
+        {
+            "nameInUI": "Chance of Critical Component Damage (%)",
+            "mnemonic": "CriticalComponent_Chance",
+            "minimumValue": 0.01,
+            "maximumValue": 100.00,
+            "defaultValue": 0.01
+        },
+        {
+            "nameInUI": "Critical Component Explosive Power",
+            "mnemonic": "CriticalComponent_Explosion_Power",
+            "minimumValue": 1,
+            "maximumValue": 100,
+            "defaultValue": 50
         }
     ],
     "scriptsWorkOrders": [

--- a/resources/plugins/splashdamage3/plugin.json
+++ b/resources/plugins/splashdamage3/plugin.json
@@ -91,7 +91,7 @@
         },
         {
             "nameInUI": "Cluster Munitions Bomblets Count Reduction Modifier",
-            "mnemonic": "cluster_bomblet_reductionmodifier",
+            "mnemonic": "cluster_bomblet_reduction_modifier",
             "defaultValue": true
         },
         {
@@ -169,14 +169,14 @@
             "defaultValue": 4
         },
         {
-            "nameInUI": "Ground Ordnance Explosion Damage Multipler",
+            "nameInUI": "Ground Unit Ordnance Explosion Damage Multiplier",
             "mnemonic": "groundunitordnance_damage_modifier",
             "minimumValue": 1,
             "maximumValue": 100,
             "defaultValue": 1
         },
         {
-            "nameInUI": "Ground Ordnance Explosion Blast Wave Multipler",
+            "nameInUI": "Ground Unit Ordnance Explosion Blast Wave Multiplier",
             "mnemonic": "groundunitordnance_blastwave_modifier",
             "minimumValue": 1,
             "maximumValue": 100,

--- a/resources/plugins/splashdamage3/sd3-config.lua
+++ b/resources/plugins/splashdamage3/sd3-config.lua
@@ -6,7 +6,7 @@
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 
--- SD2 plugin - configuration
+-- SD3 plugin - configuration
 if dcsRetribution then
     -- retrieve specific options values
     if dcsRetribution.plugins then
@@ -27,9 +27,22 @@ if dcsRetribution then
             splash_damage_options.unit_cant_fire_health = dcsRetribution.plugins.splashdamage3.unit_cant_fire_health
             splash_damage_options.infantry_cant_fire_health = dcsRetribution.plugins.splashdamage3.infantry_cant_fire_health
             splash_damage_options.cluster_enabled = dcsRetribution.plugins.splashdamage3.cluster_enabled
+            splash_damage_options.cluster_bomblet_reductionmodifier = dcsRetribution.plugins.splashdamage3.cluster_bomblet_reductionmodifier
+            splash_damage_options.cluster_bomblet_damage_modifier = dcsRetribution.plugins.splashdamage3.cluster_bomblet_damage_modifier
             splash_damage_options.rocket_multiplier = dcsRetribution.plugins.splashdamage3.rocket_multiplier
             splash_damage_options.shipRadarDamageEnable = dcsRetribution.plugins.splashdamage3.shipRadarDamageENable
             splash_damage_options.oca_aircraft_damage_boost = dcsRetribution.plugins.splashdamage3.oca_aircraft_damage_boost
+            splash_damage_options.ordnance_protection = dcsRetribution.plugins.splashdamage3.ordnance_protection
+            splash_damage_options.ordnance_protection_radius = dcsRetribution.plugins.splashdamage3.ordnance_protection_radius
+            splash_damage_options.snap_to_ground_if_destroyed_by_large_explosion = dcsRetribution.plugins.splashdamage3.snap_to_ground_if_destroyed_by_large_explosion
+            splash_damage_options.max_snapped_height = dcsRetribution.plugins.splashdamage3.max_snapped_height
+            splash_damage_options.recent_large_explosion_snap = dcsRetribution.plugins.splashdamage3.recent_large_explosion_snap
+            splash_damage_options.recent_large_explosion_range = dcsRetribution.plugins.splashdamage3.recent_large_explosion_range
+            splash_damage_options.recent_large_explosion_time = dcsRetribution.plugins.splashdamage3.recent_large_explosion_time
+            splash_damage_options.groundunitordnance_damage_modifier = dcsRetribution.plugins.splashdamage3.groundunitordnance_damage_modifier
+            splash_damage_options.groundunitordnance_blastwave_modifier = dcsRetribution.plugins.splashdamage3.groundunitordnance_blastwave_modifier
+            splash_damage_options.CriticalComponent = dcsRetribution.plugins.splashdamage3.CriticalComponent
+            splash_damage_options.CriticalComponent_Chance = dcsRetribution.plugins.splashdamage3.CriticalComponent_Chance
         end
     end
 end

--- a/resources/plugins/splashdamage3/sd3-config.lua
+++ b/resources/plugins/splashdamage3/sd3-config.lua
@@ -27,13 +27,14 @@ if dcsRetribution then
             splash_damage_options.unit_cant_fire_health = dcsRetribution.plugins.splashdamage3.unit_cant_fire_health
             splash_damage_options.infantry_cant_fire_health = dcsRetribution.plugins.splashdamage3.infantry_cant_fire_health
             splash_damage_options.cluster_enabled = dcsRetribution.plugins.splashdamage3.cluster_enabled
-            splash_damage_options.cluster_bomblet_reductionmodifier = dcsRetribution.plugins.splashdamage3.cluster_bomblet_reductionmodifier
+            splash_damage_options.cluster_bomblet_reduction_modifier = dcsRetribution.plugins.splashdamage3.cluster_bomblet_reduction_modifier
             splash_damage_options.cluster_bomblet_damage_modifier = dcsRetribution.plugins.splashdamage3.cluster_bomblet_damage_modifier
             splash_damage_options.rocket_multiplier = dcsRetribution.plugins.splashdamage3.rocket_multiplier
-            splash_damage_options.shipRadarDamageEnable = dcsRetribution.plugins.splashdamage3.shipRadarDamageENable
+            splash_damage_options.shipRadarDamageEnable = dcsRetribution.plugins.splashdamage3.shipRadarDamageEnable
             splash_damage_options.oca_aircraft_damage_boost = dcsRetribution.plugins.splashdamage3.oca_aircraft_damage_boost
             splash_damage_options.ordnance_protection = dcsRetribution.plugins.splashdamage3.ordnance_protection
             splash_damage_options.ordnance_protection_radius = dcsRetribution.plugins.splashdamage3.ordnance_protection_radius
+            splash_damage_options.detect_ordnance_destruction = dcsRetribution.plugins.splashdamage3.detect_ordnance_destruction
             splash_damage_options.snap_to_ground_if_destroyed_by_large_explosion = dcsRetribution.plugins.splashdamage3.snap_to_ground_if_destroyed_by_large_explosion
             splash_damage_options.max_snapped_height = dcsRetribution.plugins.splashdamage3.max_snapped_height
             splash_damage_options.recent_large_explosion_snap = dcsRetribution.plugins.splashdamage3.recent_large_explosion_snap
@@ -43,6 +44,7 @@ if dcsRetribution then
             splash_damage_options.groundunitordnance_blastwave_modifier = dcsRetribution.plugins.splashdamage3.groundunitordnance_blastwave_modifier
             splash_damage_options.CriticalComponent = dcsRetribution.plugins.splashdamage3.CriticalComponent
             splash_damage_options.CriticalComponent_Chance = dcsRetribution.plugins.splashdamage3.CriticalComponent_Chance
+            splash_damage_options.CriticalComponent_Explosion_Power = dcsRetribution.plugins.splashdamage3.CriticalComponent_Explosion_Power
         end
     end
 end


### PR DESCRIPTION
This PR brings SpashDamage3 defaults back to more realistic levels without reducing functionality.
Added additional options for ordnance protection and blast wave from large explosion multipliers among others.