### PR TITLE
Fix state writing on mission end event

### DIFF
--- a/resources/plugins/base/dcs_retribution.lua
+++ b/resources/plugins/base/dcs_retribution.lua
@@ -185,8 +185,9 @@ local function onEvent(event)
     end
 
     if event.id == world.event.S_EVENT_MISSION_END then
-        write_state()
         mission_ended = true
+        dirty_state = true
+        write_state()
     end
 
 end


### PR DESCRIPTION
Changes the order that saving is done on mission end.
This fixed my "mission_ended:true" bug.