### PR TITLE
Update package speed waypoints to use 'join' instead of 'ingress'

### DIFF
--- a/game/ato/flightplans/formationattack.py
+++ b/game/ato/flightplans/formationattack.py
@@ -29,7 +29,7 @@ class FormationAttackFlightPlan(FormationFlightPlan, ABC):
     @property
     def package_speed_waypoints(self) -> set[FlightWaypoint]:
         return {
-            self.layout.ingress,
+            self.layout.join,
             self.layout.split,
         } | set(self.layout.targets)
 


### PR DESCRIPTION
For some reason, escorts were only matching their primary flight's speed from the Ingress waypoint. 
I've changed this to 'join'.

