### PR TITLE
Revamp mission planning

### DIFF
--- a/game/commander/missionscheduler.py
+++ b/game/commander/missionscheduler.py
@@ -14,11 +14,54 @@ if TYPE_CHECKING:
     from game.coalition import Coalition
     from game.ato import Package
 
+logger = logging.getLogger(__name__)
+
 
 class MissionScheduler:
     def __init__(self, coalition: Coalition, desired_mission_length: timedelta) -> None:
         self.coalition = coalition
         self.desired_mission_length = desired_mission_length
+
+    def _cluster_packages_by_location(
+        self, packages: list[Package]
+    ) -> list[list[Package]]:
+        """Group packages by geographic proximity to optimize TOT scheduling.
+        
+        Packages attacking targets in the same area should have similar TOTs
+        to reduce overall mission time and allow better coordination.
+        """
+        if not packages:
+            return []
+        
+        # Distance threshold for clustering (in meters) - targets within 150km are considered "nearby"
+        CLUSTER_DISTANCE_THRESHOLD = 150000.0
+        
+        clusters: list[list[Package]] = []
+        remaining = packages.copy()
+        
+        while remaining:
+            # Start new cluster with first remaining package
+            seed = remaining.pop(0)
+            cluster = [seed]
+            
+            # Find all packages with targets close to this one
+            i = 0
+            while i < len(remaining):
+                pkg = remaining[i]
+                # Check distance to any package already in cluster
+                is_nearby = any(
+                    pkg.target.distance_to(c.target) < CLUSTER_DISTANCE_THRESHOLD
+                    for c in cluster
+                )
+                if is_nearby:
+                    cluster.append(remaining.pop(i))
+                else:
+                    i += 1
+            
+            clusters.append(cluster)
+        
+        # Logging moved to cluster processing loop below
+        return clusters
 
     def schedule_missions(self, now: datetime) -> None:
         """Identifies and plans mission for the turn."""
@@ -48,12 +91,79 @@ class MissionScheduler:
         max_carrier_simultaneous_barcaps = 2  # TODO: make configurable
         carrier_barcaps: dict[MissionTarget, int] = defaultdict(int)
 
-        start_time = start_time_generator(
-            count=len(non_dca_packages),
-            earliest=5 * 60,
-            latest=int(self.desired_mission_length.total_seconds()),
-            margin=5 * 60,
-        )
+        # Group packages by geographic proximity
+        package_clusters = self._cluster_packages_by_location(non_dca_packages)
+        
+        # Pre-calculate earliest TOT for each package to understand travel times
+        package_earliest_tots = {}
+        for pkg in non_dca_packages:
+            earliest = TotEstimator(pkg).earliest_tot(now)
+            package_earliest_tots[pkg] = earliest
+        
+        # Calculate time windows for each cluster based on TOT (not departure time)
+        # Ensure all TOTs fit within mission duration
+        cluster_tot_map = {}
+        if package_clusters:
+            logger.info(f"[Scheduler] Grouped {len(non_dca_packages)} packages into "
+                       f"{len(package_clusters)} geographic clusters")
+            
+            mission_end = now + self.desired_mission_length
+            
+            # Find the latest TOT we can accommodate (mission end minus some buffer)
+            latest_acceptable_tot = mission_end - timedelta(minutes=5)
+            
+            cluster_interval = max(
+                60,  # Minimum 1 minute between cluster TOT windows
+                int(self.desired_mission_length.total_seconds() - 10 * 60) // len(package_clusters)
+            )
+            
+            for i, cluster in enumerate(package_clusters):
+                # Log cluster details
+                target_names = ", ".join(p.target.name for p in cluster[:3])
+                if len(cluster) > 3:
+                    target_names += f" (+{len(cluster)-3} more)"
+                logger.info(f"[Scheduler]   Cluster {i+1}: {len(cluster)} packages near {target_names}")
+                
+                # Calculate TOT window for this cluster (these are absolute datetimes)
+                cluster_tot_start = now + timedelta(seconds=5 * 60 + i * cluster_interval)
+                cluster_tot_end = min(
+                    cluster_tot_start + timedelta(minutes=10),  # 10 minute TOT window per cluster
+                    latest_acceptable_tot
+                )
+                
+                # Convert to seconds for the generator
+                tot_start_sec = (cluster_tot_start - now).total_seconds()
+                tot_end_sec = (cluster_tot_end - now).total_seconds()
+                
+                logger.info(f"[Scheduler]   Cluster {i+1} TOT window: "
+                           f"{tot_start_sec//60:.0f}-{tot_end_sec//60:.0f} min")
+                
+                # Within each cluster, spread TOTs with small random variation
+                margin = min(2 * 60, (tot_end_sec - tot_start_sec) // 4)  # 2 min max variation
+                gen = start_time_generator(
+                    count=len(cluster),
+                    earliest=int(tot_start_sec),
+                    latest=int(tot_end_sec),
+                    margin=int(margin)
+                )
+                
+                for pkg in cluster:
+                    desired_tot_offset = next(gen)
+                    desired_tot = now + desired_tot_offset
+                    earliest_tot = package_earliest_tots.get(pkg, desired_tot)
+                    
+                    # Can't arrive before we can physically get there
+                    actual_tot = max(desired_tot, earliest_tot)
+                    
+                    # Warn if package TOT exceeds mission duration
+                    if actual_tot > mission_end:
+                        travel_time_min = (earliest_tot - now).total_seconds() / 60
+                        logger.warning(f"[Scheduler] Package to {pkg.target.name} TOT exceeds "
+                                     f"mission duration (travel time: {travel_time_min:.0f}min, "
+                                     f"TOT: {(actual_tot - now).total_seconds()/60:.0f}min)")
+                    
+                    cluster_tot_map[pkg] = actual_tot
+        
         for package in self.coalition.ato.packages:
             if package.primary_task is FlightType.RECOVERY:
                 continue
@@ -90,13 +200,12 @@ class MissionScheduler:
                     continue
                 previous_aewc_end_time[package.target] = departure_time
             else:
-                # But other packages should be spread out a bit. Note that take
-                # times are delayed, but all aircraft will become active at
-                # mission start. This makes it more worthwhile to attack enemy
-                # airfields to hit grounded aircraft, since they're more likely
-                # to be present. Runway and air started aircraft will be
-                # delayed until their takeoff time by AirConflictGenerator.
-                package.time_over_target = next(start_time) + tot
+                # Use clustered TOT if available, ensuring it's within mission duration
+                if package in cluster_tot_map:
+                    package.time_over_target = cluster_tot_map[package]
+                else:
+                    # Fallback for packages not in clusters (shouldn't happen)
+                    package.time_over_target = tot
             for f in package.flights:
                 if f.departure.is_fleet and not f.is_helo:
                     carrier_etas[f.departure].append(

--- a/game/commander/tasks/compound/attackbattlepositions.py
+++ b/game/commander/tasks/compound/attackbattlepositions.py
@@ -1,17 +1,83 @@
 from collections.abc import Iterator
+import logging
 
 from game.commander.tasks.primitive.armedrecon import PlanArmedRecon
 from game.commander.tasks.primitive.bai import PlanBai
 from game.commander.theaterstate import TheaterState
 from game.htn import CompoundTask, Method
 
+logger = logging.getLogger(__name__)
+
+# Maximum number of BAI packages to plan
+MAX_BAI_PACKAGES = 6
+# Maximum number of battle positions per enemy CP
+MAX_POSITIONS_PER_CP = 2
+# Maximum distance to consider enemy CP for BAI (in meters)
+MAX_BAI_DISTANCE = 300000  # 300km
+
 
 class AttackBattlePositions(CompoundTask[TheaterState]):
     def each_valid_method(self, state: TheaterState) -> Iterator[Method[TheaterState]]:
-        for battle_positions in state.enemy_battle_positions.values():
+        """Plan BAI missions against nearest enemy control points.
+        
+        Prioritizes enemy CPs that are closest to friendly CPs.
+        Limits total BAI packages to prevent spending all aircraft on ground attack.
+        """
+        # Get friendly control points for distance calculation
+        friendly_cps = list(state.context.theater.control_points_for(
+            state.context.coalition.player
+        ))
+        
+        if not friendly_cps:
+            return
+        
+        # Score and sort enemy CPs by distance to nearest friendly CP
+        enemy_cp_scores = []
+        for enemy_cp, battle_positions in state.enemy_battle_positions.items():
+            # Skip if no battle positions
+            if not list(battle_positions.in_priority_order):
+                continue
+            
+            # Find distance to closest friendly CP
+            min_distance = min(enemy_cp.distance_to(fcp) for fcp in friendly_cps)
+            
+            # Filter out CPs that are too far away
+            if min_distance > MAX_BAI_DISTANCE:
+                logger.debug(f"[BAI] Skipping {enemy_cp.name} - too far ({min_distance/1000:.0f}km)")
+                continue
+            
+            # Lower distance = higher priority (negate for sorting)
+            enemy_cp_scores.append((min_distance, enemy_cp, battle_positions))
+        
+        # Sort by distance (closest first)
+        enemy_cp_scores.sort(key=lambda x: x[0])
+        
+        logger.info(f"[BAI] Found {len(enemy_cp_scores)} enemy CPs within range")
+        
+        # Yield BAI targets from closest CPs, limited to MAX_BAI_PACKAGES total
+        packages_yielded = 0
+        for distance, enemy_cp, battle_positions in enemy_cp_scores:
+            if packages_yielded >= MAX_BAI_PACKAGES:
+                logger.info(f"[BAI] Reached max packages ({MAX_BAI_PACKAGES}), stopping")
+                break
+            
+            logger.info(f"[BAI] Planning against {enemy_cp.name} ({distance/1000:.0f}km away)")
+            
+            # Yield top battle positions from this CP
+            positions_from_cp = 0
             for battle_position in battle_positions.in_priority_order:
+                if positions_from_cp >= MAX_POSITIONS_PER_CP:
+                    break
+                
+                logger.debug(f"[BAI]   Yielding target: {battle_position.name}")
                 yield [PlanBai(battle_position)]
-        # Only plan against the 2 most important CPs
+                packages_yielded += 1
+                positions_from_cp += 1
+                
+                if packages_yielded >= MAX_BAI_PACKAGES:
+                    break
+        
+        # Plan armed recon against highest priority CPs
         for cp in state.control_point_priority_queue[:2]:
             if not cp.is_fleet:
                 yield [PlanArmedRecon(cp)]

--- a/game/commander/tasks/compound/attackinfrastructure.py
+++ b/game/commander/tasks/compound/attackinfrastructure.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from game.commander.tasks.primitive.strike import PlanStrike
+from game.commander.theaterstate import TheaterState
+from game.config import REWARDS
+from game.htn import CompoundTask, Method
+from game.theater.theatergroundobject import BuildingGroundObject
+
+
+# High-value infrastructure categories worth targeting
+HIGH_VALUE_CATEGORIES = ["oil", "derrick", "factory", "fuel"]
+
+
+@dataclass(frozen=True)
+class AttackInfrastructure(CompoundTask[TheaterState]):
+    """Plans attacks on high-value enemy infrastructure.
+    
+    Targets valuable buildings like fuel depots, oil facilities, and factories
+    that generate significant income for the enemy. Prioritizes targets that are:
+    1. High value (based on income generation)
+    2. Accessible (outside of threat zones)
+    3. Close to friendly bases
+    """
+
+    def _calculate_target_value(self, target: BuildingGroundObject) -> float:
+        """Calculate the total income value of a target."""
+        category = target.category
+        if category not in REWARDS:
+            return 0.0
+        
+        income_per_building = REWARDS[category]
+        alive_count = sum(1 for unit in target.statics if unit.alive)
+        return income_per_building * alive_count
+
+    def _get_closest_friendly_distance(
+        self, target: BuildingGroundObject, state: TheaterState
+    ) -> float:
+        """Get distance from target to closest friendly control point."""
+        min_distance = float("inf")
+        for cp in state.context.theater.control_points_for(state.context.coalition.player):
+            distance = cp.position.distance_to_point(target.position)
+            if distance < min_distance:
+                min_distance = distance
+        return min_distance
+
+    def each_valid_method(self, state: TheaterState) -> Iterator[Method[TheaterState]]:
+        """Yields strike missions for high-value infrastructure targets.
+        
+        Filters for buildings in high-value categories, calculates their worth,
+        and prioritizes by value-to-distance ratio to target the most valuable
+        and accessible infrastructure first.
+        """
+        # Collect and evaluate high-value targets
+        valuable_targets = []
+        
+        for target in state.strike_targets:
+            # Only consider building ground objects
+            if not isinstance(target, BuildingGroundObject):
+                continue
+            
+            # Skip if not a high-value category
+            if target.category not in HIGH_VALUE_CATEGORIES:
+                continue
+            
+            # Skip ammo depots (handled by other tasks)
+            if target.is_ammo_depot:
+                continue
+            
+            # Calculate value and distance
+            value = self._calculate_target_value(target)
+            if value <= 0:
+                continue
+            
+            distance = self._get_closest_friendly_distance(target, state)
+            if distance == float("inf"):
+                continue
+            
+            # Calculate priority (higher value / shorter distance = higher priority)
+            priority = value / (distance / 1000.0)  # Normalize distance to km
+            
+            valuable_targets.append((priority, value, distance, target))
+        
+        # Sort by priority (highest first)
+        valuable_targets.sort(key=lambda x: x[0], reverse=True)
+        
+        # Yield strike plans for targets in priority order
+        for priority, value, distance, target in valuable_targets:
+            yield [PlanStrike(target)]

--- a/game/commander/tasks/compound/degradeiads.py
+++ b/game/commander/tasks/compound/degradeiads.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterator
 from typing import Union
 
@@ -7,27 +8,236 @@ from game.commander.theaterstate import TheaterState
 from game.data.groups import GroupTask
 from game.htn import CompoundTask, Method
 from game.theater.theatergroundobject import IadsGroundObject, NavalGroundObject
+from game.utils import meters
+
+logger = logging.getLogger(__name__)
 
 
 class DegradeIads(CompoundTask[TheaterState]):
+    # Yield multiple DEAD targets as alternatives for HTN planner to try
+    # If first target fails planning, HTN will automatically try next alternative
+    
     def each_valid_method(self, state: TheaterState) -> Iterator[Method[TheaterState]]:
-        for air_defense in state.threatening_air_defenses:
-            yield [self.plan_against(air_defense)]
-
-        prioritized_air_defenses = sorted(
-            [
-                tgo
-                for tgo in state.enemy_air_defenses
-                if tgo.task in [GroupTask.LORAD, GroupTask.MERAD]
-            ],
-            key=lambda x: (state.priority_cp.distance_to(x) if state.priority_cp else 0)
-            - x.max_threat_range().meters,
+        logger.info(f"[DEAD] Iteration - threatening: {len(state.threatening_air_defenses)}, "
+                    f"enemy: {len(state.enemy_air_defenses)}, "
+                    f"detecting: {len(state.detecting_air_defenses)}")
+        
+        # Get all candidate targets in priority order
+        candidates = []
+        
+        # Priority 1: Strategic threats (based on threat circle proximity)
+        strategically_threatening_sams = self._assess_strategic_threats(
+            state.enemy_air_defenses, state
         )
-
-        for air_defense in prioritized_air_defenses:
-            yield [self.plan_against(air_defense)]
-        for detector in state.detecting_air_defenses:
-            yield [self.plan_against(detector)]
+        for sam in strategically_threatening_sams:
+            logger.info(f"[DEAD] Strategic candidate: {sam.name} at {sam.control_point.name}")
+            candidates.append(("strategic", sam))
+        
+        # Priority 2: Systems actively threatening planned missions
+        prioritized_threats = self._prioritize_threatening_systems(state.threatening_air_defenses)
+        for sam in prioritized_threats:
+            logger.info(f"[DEAD] Threatening candidate: {sam.name} at {sam.control_point.name}")
+            # Only add if not already in candidates
+            if not any(c[1] == sam for c in candidates):
+                candidates.append(("threatening", sam))
+        
+        # Priority 3: High-value detection systems (EWRs)
+        high_value_detectors = [
+            d for d in state.detecting_air_defenses 
+            if d.task == GroupTask.EARLY_WARNING_RADAR
+        ]
+        for ewr in high_value_detectors[:2]:  # Top 2 EWRs
+            logger.info(f"[DEAD] Detector candidate: {ewr.name} at {ewr.control_point.name}")
+            if not any(c[1] == ewr for c in candidates):
+                candidates.append(("detector", ewr))
+        
+        # Yield each candidate as a separate method
+        # HTN planner will try them in order until one succeeds
+        for priority_type, target in candidates:
+            logger.info(f"[DEAD] Yielding {priority_type}: {target.name}")
+            yield [self.plan_against(target)]
+    
+    def _prioritize_threatening_systems(
+        self, 
+        threatening: list[IadsGroundObject]
+    ) -> list[IadsGroundObject]:
+        """Prioritize threatening systems to avoid targeting every AAA/SHORAD.
+        
+        Focus on high-value threats: LORAD > MERAD > SHORAD.
+        AAA is only targeted if it's one of the very few threats.
+        """
+        if not threatening:
+            return []
+        
+        # Categorize by threat tier
+        lorad_threats = [t for t in threatening if t.task == GroupTask.LORAD]
+        merad_threats = [t for t in threatening if t.task == GroupTask.MERAD]
+        shorad_threats = [t for t in threatening if t.task == GroupTask.SHORAD]
+        
+        # Prioritize: top LORAD, top MERAD only (very selective)
+        prioritized = []
+        prioritized.extend(lorad_threats[:1])  # Top 1 long-range SAM only
+        if len(lorad_threats) == 0:
+            # Only if no LORAD, take top 1 MERAD
+            prioritized.extend(merad_threats[:1])
+        
+        return prioritized
+    
+    def _assess_strategic_threats(
+        self, 
+        air_defenses: list[IadsGroundObject],
+        state: TheaterState
+    ) -> list[Union[IadsGroundObject, NavalGroundObject]]:
+        """Assess and prioritize air defenses by strategic threat level.
+        
+        Prioritizes based on:
+        1. Capability tier (LORAD > MERAD, SHORAD/AAA generally ignored)
+        2. Range and coverage of friendly bases
+        3. Position relative to operations
+        
+        Includes both land-based SAMs and naval SAM systems.
+        
+        Returns sorted list with highest threats first (limited to top 2).
+        """
+        threats = []
+        
+        # Get all friendly control points for threat assessment
+        friendly_cps = list(state.context.theater.control_points_for(
+            state.context.coalition.player
+        ))
+        
+        # Assess land-based SAMs
+        for air_defense in air_defenses:
+            # Only consider SAM systems that are meaningful threats
+            if air_defense.task not in [GroupTask.LORAD, GroupTask.MERAD]:
+                continue
+            
+            threat_range = air_defense.max_threat_range()
+            
+            # Calculate threat value based on multiple factors
+            threat_score = self._calculate_threat_score(
+                air_defense, 
+                threat_range, 
+                friendly_cps, 
+                state
+            )
+            
+            # Only consider systems that pose actual strategic threat
+            if threat_score > 0:
+                logger.debug(f"[DEAD Score] {air_defense.name} at {air_defense.control_point.name} "
+                            f"- Task: {air_defense.task}, Score: {threat_score:.0f}")
+                threats.append((threat_score, air_defense))
+        
+        # Assess naval SAM threats (ships with air defense capabilities)
+        for ship in state.enemy_ships:
+            threat_range = ship.max_threat_range()
+            
+            # Ships with significant SAM range are strategic threats
+            if threat_range.meters > 20000:  # 20km+ range worth considering
+                threat_score = self._calculate_naval_threat_score(
+                    ship,
+                    threat_range,
+                    friendly_cps,
+                    state
+                )
+                
+                if threat_score > 0:
+                    logger.debug(f"[DEAD Score] NAVAL {ship.name} at {ship.control_point.name} "
+                                f"- Score: {threat_score:.0f}")
+                    threats.append((threat_score, ship))
+        
+        # Sort by threat score (highest first) and return top 2 only
+        threats.sort(key=lambda x: x[0], reverse=True)
+        logger.info(f"[DEAD] Top strategic threats: " + 
+                   ", ".join(f"{t[1].name}({t[0]:.0f})" for t in threats[:5]))
+        return [ad for _, ad in threats[:2]]
+    
+    def _calculate_naval_threat_score(
+        self,
+        ship: NavalGroundObject,
+        threat_range: meters,
+        friendly_cps: list,
+        state: TheaterState
+    ) -> float:
+        """Calculate threat score for naval SAM systems.
+        
+        Prioritizes ships whose threat circle is closest to any friendly CP.
+        Lower distance = higher threat.
+        """
+        if threat_range.meters < 20000:
+            # Very short range, not worth targeting
+            return 0.0
+        
+        # Find the closest approach distance (distance - range)
+        # This tells us how close the threat circle edge gets to a friendly base
+        closest_threat_penetration = float('inf')
+        
+        for cp in friendly_cps:
+            distance = ship.distance_to(cp)
+            # How far is the threat circle edge from this CP?
+            penetration_distance = distance - threat_range.meters
+            closest_threat_penetration = min(closest_threat_penetration, penetration_distance)
+        
+        # If threat circle can't reach ANY base, lower priority
+        # Increased threshold to 150km to capture more strategic naval SAMs
+        if closest_threat_penetration > 150000:  # 150km+ away from all bases
+            return 0.0
+        
+        # Invert the score: closer threat circle = higher priority
+        # Normalize to reasonable scale (closer = bigger score)
+        # Using negative values for systems that can already reach bases
+        threat_score = 200000.0 - closest_threat_penetration
+        
+        return max(0.0, threat_score)
+    
+    def _calculate_threat_score(
+        self,
+        air_defense: IadsGroundObject,
+        threat_range: meters,
+        friendly_cps: list,
+        state: TheaterState
+    ) -> float:
+        """Calculate threat score for air defense system.
+        
+        Prioritizes SAMs whose threat circle is closest to any friendly CP.
+        Simple approach: distance_to_closest_cp - threat_range
+        Lower result = closer threat circle = higher priority.
+        """
+        # Only consider meaningful SAM systems
+        if air_defense.task not in [GroupTask.LORAD, GroupTask.MERAD]:
+            return 0.0
+        
+        # Find the closest approach distance (distance - range)
+        # This tells us how close the threat circle edge gets to a friendly base
+        closest_threat_penetration = float('inf')
+        closest_cp_name = ""
+        
+        for cp in friendly_cps:
+            distance = air_defense.distance_to(cp)
+            # How far is the threat circle edge from this CP?
+            penetration_distance = distance - threat_range.meters
+            if penetration_distance < closest_threat_penetration:
+                closest_threat_penetration = penetration_distance
+                closest_cp_name = cp.name
+        
+        # Log for debugging
+        logger.debug(f"[DEAD Score] {air_defense.name} at {air_defense.control_point.name} "
+                    f"(task={air_defense.task.name}, range={threat_range.meters/1000:.1f}km) "
+                    f"- Closest to {closest_cp_name}, penetration={closest_threat_penetration/1000:.1f}km")
+        
+        # If threat circle is very far away, deprioritize
+        # Increased threshold to 150km to capture more strategic SAMs
+        if closest_threat_penetration > 150000:  # 150km+ away from all bases
+            logger.debug(f"[DEAD Score]   -> FILTERED (penetration > 150km)")
+            return 0.0
+        
+        # Invert the score: closer threat circle = higher priority
+        # Normalize to reasonable scale (closer = bigger score)
+        # Using 200km as baseline - systems further than that get very low scores
+        threat_score = 200000.0 - closest_threat_penetration
+        
+        logger.debug(f"[DEAD Score]   -> Score: {threat_score:.0f}")
+        return max(0.0, threat_score)
 
     @staticmethod
     def plan_against(
@@ -36,3 +246,4 @@ class DegradeIads(CompoundTask[TheaterState]):
         if isinstance(target, IadsGroundObject):
             return PlanDead(target)
         return PlanAntiShip(target)
+

--- a/game/commander/tasks/compound/nextaction.py
+++ b/game/commander/tasks/compound/nextaction.py
@@ -6,6 +6,9 @@ from game.commander.tasks.compound.attackairinfrastructure import (
 )
 from game.commander.tasks.compound.attackbattlepositions import AttackBattlePositions
 from game.commander.tasks.compound.attackbuildings import AttackBuildings
+from game.commander.tasks.compound.attackinfrastructure import (
+    AttackInfrastructure,
+)
 from game.commander.tasks.compound.attackships import AttackShips
 from game.commander.tasks.compound.capturebases import CaptureBases
 from game.commander.tasks.compound.defendbases import DefendBases
@@ -28,11 +31,12 @@ class PlanNextAction(CompoundTask[TheaterState]):
         yield [TheaterSupport()]
         yield [ProtectAirSpace()]
         yield [DefendBases()]
+        yield [DegradeIads()]
         yield [InterdictReinforcements()]
         yield [AttackBattlePositions()]
         yield [CaptureBases()]
         yield [AttackAirInfrastructure(self.aircraft_cold_start)]
+        yield [AttackInfrastructure()]
         yield [AttackBuildings()]
         yield [AttackShips()]
-        yield [DegradeIads()]
         yield [RecoverySupport()]  # for recovery tankers

--- a/game/commander/tasks/primitive/barcap.py
+++ b/game/commander/tasks/primitive/barcap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from logging import getLogger
 
 from game.ato.flighttype import FlightType
 from game.commander.tasks.packageplanningtask import PackagePlanningTask
@@ -13,8 +14,8 @@ class PlanBarcap(PackagePlanningTask[ControlPoint]):
     max_orders: int
 
     def preconditions_met(self, state: TheaterState) -> bool:
-        if not state.barcaps_needed[self.target]:
-            return False
+        if not state.barcaps_needed.get(self.target, 0):
+            state.barcaps_needed[self.target] = 1
         return super().preconditions_met(state)
 
     def apply_effects(self, state: TheaterState) -> None:

--- a/game/commander/theaterstate.py
+++ b/game/commander/theaterstate.py
@@ -190,12 +190,43 @@ class TheaterState(WorldState["TheaterState"]):
         aewc_targets = [cp for cp in finder.friendly_control_points() if cp.is_carrier]
         aewc_targets.append(finder.farthest_friendly_control_point())
 
+        # Initial vulnerable CPs get full coverage
+        barcaps_needed = {
+            cp: 2 * barcap_rounds if cp.is_fleet else barcap_rounds
+            for cp in finder.vulnerable_control_points()
+        }
+
+        # Add limited BARCAP coverage to forward CPs closest to enemy
+        # Only adds CPs not already covered, spreads defense across multiple bases
+        from game.theater import Airfield, Carrier, Lha
+        friendly_cps = finder.friendly_control_points()
+        enemy_cps = list(game.theater.control_points_for(player.opponent))
+
+        if enemy_cps:
+            # Calculate closest distance from each friendly CP to ANY enemy CP
+            cp_distances = []
+            for cp in friendly_cps:
+                # Only consider airbases that can host fixed-wing CAP
+                if not isinstance(cp, (Airfield, Carrier, Lha)):
+                    continue
+                # Don't add to CPs already in the list
+                if cp in barcaps_needed:
+                    continue
+                
+                min_distance = min(
+                    cp.position.distance_to_point(enemy.position)
+                    for enemy in enemy_cps
+                )
+                cp_distances.append((min_distance, cp))
+            
+            # Sort by distance and take the 3 closest
+            cp_distances.sort(key=lambda x: x[0])
+            for _, cp in cp_distances[:3]:
+                barcaps_needed[cp] = 1  # Only 1 round for supplemental coverage
+
         return TheaterState(
             context=context,
-            barcaps_needed={
-                cp: 2 * barcap_rounds if cp.is_fleet else barcap_rounds
-                for cp in finder.vulnerable_control_points()
-            },
+            barcaps_needed=barcaps_needed,
             active_front_lines=list(finder.front_lines()),
             front_line_stances={f: None for f in finder.front_lines()},
             vulnerable_front_lines=list(finder.front_lines()),


### PR DESCRIPTION
The current version of the planner has limitations and flaws, and this PR attempts to address some of them.

Issues in the current implementation that I found to be suboptimal:
- BARCAP. Too few control points have CAP coverage. The current settings can create BARCAPs randomly, which is not ideal. OPFOR air presence is almost non-existent.
- SEAD/DEAD. The planner prioritizes SAMs that are not relevant to the theater, for example flying 150 km to destroy an SA-13 deep in the backline while completely ignoring an SA-5 located near the border.
- BAI. Targets are often not relevant to the theater, resulting in an almost random selection of target groups across the map.
- Scheduling of long-duration flights. For example, a 50-minute flight with a desired mission duration of 60 minutes can be scheduled with a TOT of 1:30+ after mission start.
- No planning to reduce opponent economy.

I’ve updated the planning logic to address these issues:
- BARCAP. It now creates more BARCAP packages, providing air superiority, especially at border control points.
- SEAD/DEAD. It now targets the most threatening SAM sites closest to friendly forces.
- BAI. It now targets groups near the closest control points.
- Scheduling. BARCAPs are now always scheduled ASAP. Longer missions spawn earlier, making them more likely to fit within the desired mission duration window.
- Additional planning to reduce opponent economy strength, targeting highest income buildings

This is not a complete solution to all problems and requires testing across different scenarios. It is more of a proposal for what can be done with the planning logic. I would be happy even if only some of these changes were accepted.