### PR TITLE
Revamp SEAD/DEAD planning

### DIFF
--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -129,7 +129,7 @@ class Flight(
         # altitude offset for planes
         offset_factor = self.coalition.game.settings.max_plane_altitude_offset
         offset_factor = random.randint(0, offset_factor)
-        self.plane_altitude_offset = 1000 * offset_factor * random.choice([-1, 1])
+        self.plane_altitude_offset: int = 1000 * offset_factor * random.choice([-1, 1])
 
     @property
     def available_callsigns(self) -> List[str]:

--- a/game/commander/tasks/compound/degradeiads.py
+++ b/game/commander/tasks/compound/degradeiads.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from typing import Union
 
 from game.commander.tasks.primitive.antiship import PlanAntiShip
@@ -7,8 +7,9 @@ from game.commander.tasks.primitive.dead import PlanDead
 from game.commander.theaterstate import TheaterState
 from game.data.groups import GroupTask
 from game.htn import CompoundTask, Method
+from game.theater.missiontarget import MissionTarget
 from game.theater.theatergroundobject import IadsGroundObject, NavalGroundObject
-from game.utils import meters
+from game.utils import Distance
 
 
 class DegradeIads(CompoundTask[TheaterState]):
@@ -18,6 +19,7 @@ class DegradeIads(CompoundTask[TheaterState]):
     def each_valid_method(self, state: TheaterState) -> Iterator[Method[TheaterState]]:
         # Get all candidate targets in priority order
         candidates = []
+        settings = state.context.settings
 
         # Priority 1: Strategic threats (based on threat circle proximity)
         strategically_threatening_sams = self._assess_strategic_threats(
@@ -27,7 +29,13 @@ class DegradeIads(CompoundTask[TheaterState]):
             candidates.append(("strategic", sam))
 
         # Priority 2: Systems actively threatening planned missions
-        prioritized_threats = self._prioritize_threatening_systems(state.threatening_air_defenses)
+        prioritized_threats = self._prioritize_threatening_systems(
+            [
+                defense
+                for defense in state.threatening_air_defenses
+                if isinstance(defense, IadsGroundObject)
+            ]
+        )
         for sam in prioritized_threats:
             # Only add if not already in candidates
             if not any(c[1] == sam for c in candidates):
@@ -35,10 +43,11 @@ class DegradeIads(CompoundTask[TheaterState]):
 
         # Priority 3: High-value detection systems (EWRs)
         high_value_detectors = [
-            d for d in state.detecting_air_defenses
+            d
+            for d in state.detecting_air_defenses
             if d.task == GroupTask.EARLY_WARNING_RADAR
         ]
-        for ewr in high_value_detectors[:2]:  # Top 2 EWRs
+        for ewr in high_value_detectors[:1]:
             if not any(c[1] == ewr for c in candidates):
                 candidates.append(("detector", ewr))
 
@@ -48,11 +57,10 @@ class DegradeIads(CompoundTask[TheaterState]):
             yield [self.plan_against(target)]
 
     def _prioritize_threatening_systems(
-            self,
-            threatening: list[IadsGroundObject]
+        self, threatening: list[IadsGroundObject]
     ) -> list[IadsGroundObject]:
         """Prioritize threatening systems to avoid targeting every AAA/SHORAD.
-        
+
         Focus on high-value threats: LORAD > MERAD > SHORAD.
         AAA is only targeted if it's one of the very few threats.
         """
@@ -66,35 +74,33 @@ class DegradeIads(CompoundTask[TheaterState]):
 
         # Prioritize: top LORAD, top MERAD only (very selective)
         prioritized = []
-        prioritized.extend(lorad_threats[:1])  # Top 1 long-range SAM only
+        prioritized.extend(lorad_threats[:1])
         if len(lorad_threats) == 0:
-            # Only if no LORAD, take top 1 MERAD
+            # Only if no LORAD, take top MERAD targets
             prioritized.extend(merad_threats[:1])
 
         return prioritized
 
     def _assess_strategic_threats(
-            self,
-            air_defenses: list[IadsGroundObject],
-            state: TheaterState
+        self, air_defenses: list[IadsGroundObject], state: TheaterState
     ) -> list[Union[IadsGroundObject, NavalGroundObject]]:
         """Assess and prioritize air defenses by strategic threat level.
-        
+
         Prioritizes based on:
         1. Capability tier (LORAD > MERAD, SHORAD/AAA generally ignored)
         2. Range and coverage of friendly bases
         3. Position relative to operations
-        
+
         Includes both land-based SAMs and naval SAM systems.
-        
+
         Returns sorted list with highest threats first (limited to top 2).
         """
-        threats = []
+        threats: list[tuple[float, Union[IadsGroundObject, NavalGroundObject]]] = []
 
         # Get all friendly control points for threat assessment
-        friendly_cps = list(state.context.theater.control_points_for(
-            state.context.coalition.player
-        ))
+        friendly_cps = list(
+            state.context.theater.control_points_for(state.context.coalition.player)
+        )
 
         # Assess land-based SAMs
         for air_defense in air_defenses:
@@ -109,7 +115,10 @@ class DegradeIads(CompoundTask[TheaterState]):
                 air_defense,
                 threat_range,
                 friendly_cps,
-                state
+                state,
+                state.context.settings.degrade_iads_max_land_threat_penetration_meters,
+                state.context.settings.degrade_iads_threat_range_effectiveness_percent,
+                state.context.settings.degrade_iads_threat_score_baseline_meters,
             )
 
             # Only consider systems that pose actual strategic threat
@@ -120,67 +129,87 @@ class DegradeIads(CompoundTask[TheaterState]):
         for ship in state.enemy_ships:
             threat_range = ship.max_threat_range()
 
-            # Ships with significant SAM range are strategic threats
-            if threat_range.meters > 20000:  # 20km+ range worth considering
-                threat_score = self._calculate_naval_threat_score(
-                    ship,
-                    threat_range,
-                    friendly_cps
-                )
+            threat_score = self._calculate_naval_threat_score(
+                ship,
+                threat_range,
+                friendly_cps,
+                state.context.settings.degrade_iads_min_naval_threat_range_meters,
+                state.context.settings.degrade_iads_max_naval_threat_penetration_meters,
+                state.context.settings.degrade_iads_threat_range_effectiveness_percent,
+                state.context.settings.degrade_iads_threat_score_baseline_meters,
+            )
 
-                if threat_score > 0:
-                    threats.append((threat_score, ship))
+            if threat_score > 0:
+                threats.append((threat_score, ship))
 
-        # Sort by threat score (highest first) and return top 2 only
+        # Sort by threat score (highest first) and return top strategic targets only
         threats.sort(key=lambda x: x[0], reverse=True)
-        return [ad for _, ad in threats[:2]]
+        return [
+            ad
+            for _, ad in threats[
+                : state.context.settings.degrade_iads_max_strategic_targets
+            ]
+        ]
 
     def _calculate_naval_threat_score(
-            self,
-            ship: NavalGroundObject,
-            threat_range: meters,
-            friendly_cps: list
+        self,
+        ship: NavalGroundObject,
+        threat_range: Distance,
+        friendly_cps: Sequence[MissionTarget],
+        min_threat_range_meters: int,
+        max_threat_penetration_meters: int,
+        threat_range_effectiveness_percent: int,
+        threat_score_baseline_meters: int,
     ) -> float:
         """Calculate threat score for naval SAM systems.
-        
+
         Prioritizes ships whose threat circle is closest to any friendly CP.
         Lower distance = higher threat.
         """
-        if threat_range.meters < 20000:
+        effective_range = threat_range.meters * (
+            float(threat_range_effectiveness_percent) / 100.0
+        )
+
+        if effective_range < min_threat_range_meters:
             # Very short range, not worth targeting
             return 0.0
 
         # Find the closest approach distance (distance - range)
         # This tells us how close the threat circle edge gets to a friendly base
-        closest_threat_penetration = float('inf')
+        closest_threat_penetration = float("inf")
 
         for cp in friendly_cps:
             distance = ship.distance_to(cp)
             # How far is the threat circle edge from this CP?
-            penetration_distance = distance - threat_range.meters
-            closest_threat_penetration = min(closest_threat_penetration, penetration_distance)
+            penetration_distance = distance - effective_range
+            closest_threat_penetration = min(
+                closest_threat_penetration, penetration_distance
+            )
 
         # If threat circle can't reach ANY base, lower priority
-        # Increased threshold to 150km to capture more strategic naval SAMs
-        if closest_threat_penetration > 150000:  # 150km+ away from all bases
+        # Increased threshold to N meters to capture more strategic naval SAMs
+        if closest_threat_penetration > max_threat_penetration_meters:
             return 0.0
 
         # Invert the score: closer threat circle = higher priority
         # Normalize to reasonable scale (closer = bigger score)
         # Using negative values for systems that can already reach bases
-        threat_score = 200000.0 - closest_threat_penetration
+        threat_score = float(threat_score_baseline_meters) - closest_threat_penetration
 
         return max(0.0, threat_score)
 
     def _calculate_threat_score(
-            self,
-            air_defense: IadsGroundObject,
-            threat_range: meters,
-            friendly_cps: list,
-            state: TheaterState
+        self,
+        air_defense: IadsGroundObject,
+        threat_range: Distance,
+        friendly_cps: Sequence[MissionTarget],
+        state: TheaterState,
+        max_threat_penetration_meters: int,
+        threat_range_effectiveness_percent: int,
+        threat_score_baseline_meters: int,
     ) -> float:
         """Calculate threat score for air defense system.
-        
+
         Prioritizes SAMs whose threat circle is closest to any friendly CP.
         Simple approach: distance_to_closest_cp - threat_range
         Lower result = closer threat circle = higher priority.
@@ -189,32 +218,36 @@ class DegradeIads(CompoundTask[TheaterState]):
         if air_defense.task not in [GroupTask.LORAD, GroupTask.MERAD]:
             return 0.0
 
+        effective_range = threat_range.meters * (
+            float(threat_range_effectiveness_percent) / 100.0
+        )
+
         # Find the closest approach distance (distance - range)
         # This tells us how close the threat circle edge gets to a friendly base
-        closest_threat_penetration = float('inf')
+        closest_threat_penetration = float("inf")
 
         for cp in friendly_cps:
             distance = air_defense.distance_to(cp)
             # How far is the threat circle edge from this CP?
-            penetration_distance = distance - threat_range.meters
+            penetration_distance = distance - effective_range
             if penetration_distance < closest_threat_penetration:
                 closest_threat_penetration = penetration_distance
 
         # If threat circle is very far away, deprioritize
-        # Increased threshold to 100km to capture more strategic SAMs
-        if closest_threat_penetration > 100000:  # 100km+ away from all bases
+        # Increased threshold to N meters to capture more strategic SAMs
+        if closest_threat_penetration > max_threat_penetration_meters:
             return 0.0
 
         # Invert the score: closer threat circle = higher priority
         # Normalize to reasonable scale (closer = bigger score)
-        # Using 200km as baseline - systems further than that get very low scores
-        threat_score = 200000.0 - closest_threat_penetration
+        # Using N meters as baseline - systems further than that get very low scores
+        threat_score = float(threat_score_baseline_meters) - closest_threat_penetration
 
         return max(0.0, threat_score)
 
     @staticmethod
     def plan_against(
-            target: Union[IadsGroundObject, NavalGroundObject],
+        target: Union[IadsGroundObject, NavalGroundObject],
     ) -> Union[PlanDead, PlanAntiShip]:
         if isinstance(target, IadsGroundObject):
             return PlanDead(target)

--- a/game/commander/tasks/compound/degradeiads.py
+++ b/game/commander/tasks/compound/degradeiads.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterator
 from typing import Union
 
@@ -7,31 +8,213 @@ from game.commander.theaterstate import TheaterState
 from game.data.groups import GroupTask
 from game.htn import CompoundTask, Method
 from game.theater.theatergroundobject import IadsGroundObject, NavalGroundObject
+from game.utils import meters
 
 
 class DegradeIads(CompoundTask[TheaterState]):
+    # Yield multiple DEAD targets as alternatives for HTN planner to try
+    # If first target fails planning, HTN will automatically try next alternative
+
     def each_valid_method(self, state: TheaterState) -> Iterator[Method[TheaterState]]:
-        for air_defense in state.threatening_air_defenses:
-            yield [self.plan_against(air_defense)]
+        # Get all candidate targets in priority order
+        candidates = []
 
-        prioritized_air_defenses = sorted(
-            [
-                tgo
-                for tgo in state.enemy_air_defenses
-                if tgo.task in [GroupTask.LORAD, GroupTask.MERAD]
-            ],
-            key=lambda x: (state.priority_cp.distance_to(x) if state.priority_cp else 0)
-            - x.max_threat_range().meters,
+        # Priority 1: Strategic threats (based on threat circle proximity)
+        strategically_threatening_sams = self._assess_strategic_threats(
+            state.enemy_air_defenses, state
         )
+        for sam in strategically_threatening_sams:
+            candidates.append(("strategic", sam))
 
-        for air_defense in prioritized_air_defenses:
-            yield [self.plan_against(air_defense)]
-        for detector in state.detecting_air_defenses:
-            yield [self.plan_against(detector)]
+        # Priority 2: Systems actively threatening planned missions
+        prioritized_threats = self._prioritize_threatening_systems(state.threatening_air_defenses)
+        for sam in prioritized_threats:
+            # Only add if not already in candidates
+            if not any(c[1] == sam for c in candidates):
+                candidates.append(("threatening", sam))
+
+        # Priority 3: High-value detection systems (EWRs)
+        high_value_detectors = [
+            d for d in state.detecting_air_defenses
+            if d.task == GroupTask.EARLY_WARNING_RADAR
+        ]
+        for ewr in high_value_detectors[:2]:  # Top 2 EWRs
+            if not any(c[1] == ewr for c in candidates):
+                candidates.append(("detector", ewr))
+
+        # Yield each candidate as a separate method
+        # HTN planner will try them in order until one succeeds
+        for priority_type, target in candidates:
+            yield [self.plan_against(target)]
+
+    def _prioritize_threatening_systems(
+            self,
+            threatening: list[IadsGroundObject]
+    ) -> list[IadsGroundObject]:
+        """Prioritize threatening systems to avoid targeting every AAA/SHORAD.
+        
+        Focus on high-value threats: LORAD > MERAD > SHORAD.
+        AAA is only targeted if it's one of the very few threats.
+        """
+        if not threatening:
+            return []
+
+        # Categorize by threat tier
+        lorad_threats = [t for t in threatening if t.task == GroupTask.LORAD]
+        merad_threats = [t for t in threatening if t.task == GroupTask.MERAD]
+        shorad_threats = [t for t in threatening if t.task == GroupTask.SHORAD]
+
+        # Prioritize: top LORAD, top MERAD only (very selective)
+        prioritized = []
+        prioritized.extend(lorad_threats[:1])  # Top 1 long-range SAM only
+        if len(lorad_threats) == 0:
+            # Only if no LORAD, take top 1 MERAD
+            prioritized.extend(merad_threats[:1])
+
+        return prioritized
+
+    def _assess_strategic_threats(
+            self,
+            air_defenses: list[IadsGroundObject],
+            state: TheaterState
+    ) -> list[Union[IadsGroundObject, NavalGroundObject]]:
+        """Assess and prioritize air defenses by strategic threat level.
+        
+        Prioritizes based on:
+        1. Capability tier (LORAD > MERAD, SHORAD/AAA generally ignored)
+        2. Range and coverage of friendly bases
+        3. Position relative to operations
+        
+        Includes both land-based SAMs and naval SAM systems.
+        
+        Returns sorted list with highest threats first (limited to top 2).
+        """
+        threats = []
+
+        # Get all friendly control points for threat assessment
+        friendly_cps = list(state.context.theater.control_points_for(
+            state.context.coalition.player
+        ))
+
+        # Assess land-based SAMs
+        for air_defense in air_defenses:
+            # Only consider SAM systems that are meaningful threats
+            if air_defense.task not in [GroupTask.LORAD, GroupTask.MERAD]:
+                continue
+
+            threat_range = air_defense.max_threat_range()
+
+            # Calculate threat value based on multiple factors
+            threat_score = self._calculate_threat_score(
+                air_defense,
+                threat_range,
+                friendly_cps,
+                state
+            )
+
+            # Only consider systems that pose actual strategic threat
+            if threat_score > 0:
+                threats.append((threat_score, air_defense))
+
+        # Assess naval SAM threats (ships with air defense capabilities)
+        for ship in state.enemy_ships:
+            threat_range = ship.max_threat_range()
+
+            # Ships with significant SAM range are strategic threats
+            if threat_range.meters > 20000:  # 20km+ range worth considering
+                threat_score = self._calculate_naval_threat_score(
+                    ship,
+                    threat_range,
+                    friendly_cps
+                )
+
+                if threat_score > 0:
+                    threats.append((threat_score, ship))
+
+        # Sort by threat score (highest first) and return top 2 only
+        threats.sort(key=lambda x: x[0], reverse=True)
+        return [ad for _, ad in threats[:2]]
+
+    def _calculate_naval_threat_score(
+            self,
+            ship: NavalGroundObject,
+            threat_range: meters,
+            friendly_cps: list
+    ) -> float:
+        """Calculate threat score for naval SAM systems.
+        
+        Prioritizes ships whose threat circle is closest to any friendly CP.
+        Lower distance = higher threat.
+        """
+        if threat_range.meters < 20000:
+            # Very short range, not worth targeting
+            return 0.0
+
+        # Find the closest approach distance (distance - range)
+        # This tells us how close the threat circle edge gets to a friendly base
+        closest_threat_penetration = float('inf')
+
+        for cp in friendly_cps:
+            distance = ship.distance_to(cp)
+            # How far is the threat circle edge from this CP?
+            penetration_distance = distance - threat_range.meters
+            closest_threat_penetration = min(closest_threat_penetration, penetration_distance)
+
+        # If threat circle can't reach ANY base, lower priority
+        # Increased threshold to 150km to capture more strategic naval SAMs
+        if closest_threat_penetration > 150000:  # 150km+ away from all bases
+            return 0.0
+
+        # Invert the score: closer threat circle = higher priority
+        # Normalize to reasonable scale (closer = bigger score)
+        # Using negative values for systems that can already reach bases
+        threat_score = 200000.0 - closest_threat_penetration
+
+        return max(0.0, threat_score)
+
+    def _calculate_threat_score(
+            self,
+            air_defense: IadsGroundObject,
+            threat_range: meters,
+            friendly_cps: list,
+            state: TheaterState
+    ) -> float:
+        """Calculate threat score for air defense system.
+        
+        Prioritizes SAMs whose threat circle is closest to any friendly CP.
+        Simple approach: distance_to_closest_cp - threat_range
+        Lower result = closer threat circle = higher priority.
+        """
+        # Only consider meaningful SAM systems
+        if air_defense.task not in [GroupTask.LORAD, GroupTask.MERAD]:
+            return 0.0
+
+        # Find the closest approach distance (distance - range)
+        # This tells us how close the threat circle edge gets to a friendly base
+        closest_threat_penetration = float('inf')
+
+        for cp in friendly_cps:
+            distance = air_defense.distance_to(cp)
+            # How far is the threat circle edge from this CP?
+            penetration_distance = distance - threat_range.meters
+            if penetration_distance < closest_threat_penetration:
+                closest_threat_penetration = penetration_distance
+
+        # If threat circle is very far away, deprioritize
+        # Increased threshold to 100km to capture more strategic SAMs
+        if closest_threat_penetration > 100000:  # 100km+ away from all bases
+            return 0.0
+
+        # Invert the score: closer threat circle = higher priority
+        # Normalize to reasonable scale (closer = bigger score)
+        # Using 200km as baseline - systems further than that get very low scores
+        threat_score = 200000.0 - closest_threat_penetration
+
+        return max(0.0, threat_score)
 
     @staticmethod
     def plan_against(
-        target: Union[IadsGroundObject, NavalGroundObject],
+            target: Union[IadsGroundObject, NavalGroundObject],
     ) -> Union[PlanDead, PlanAntiShip]:
         if isinstance(target, IadsGroundObject):
             return PlanDead(target)

--- a/game/commander/tasks/compound/nextaction.py
+++ b/game/commander/tasks/compound/nextaction.py
@@ -29,10 +29,10 @@ class PlanNextAction(CompoundTask[TheaterState]):
         yield [ProtectAirSpace()]
         yield [DefendBases()]
         yield [InterdictReinforcements()]
+        yield [DegradeIads()]
         yield [AttackBattlePositions()]
         yield [CaptureBases()]
         yield [AttackAirInfrastructure(self.aircraft_cold_start)]
         yield [AttackBuildings()]
         yield [AttackShips()]
-        yield [DegradeIads()]
         yield [RecoverySupport()]  # for recovery tankers

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -40,11 +40,13 @@ MISSION_DIFFICULTY_SECTION = "Mission Difficulty"
 MISSION_RESTRICTIONS_SECTION = "Mission Restrictions"
 
 CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management"
+ADVANCED_CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management+"
 
 GENERAL_SECTION = "General"
 PILOTS_AND_SQUADRONS_SECTION = "Pilots and Squadrons"
 HQ_AUTOMATION_SECTION = "HQ Automation"
 FLIGHT_PLANNER_AUTOMATION = "Flight Planner Automation"
+DEGRADE_IADS_SECTION = "Degrade IADS"
 
 CAMPAIGN_DOCTRINE_PAGE = "Campaign Doctrine"
 DOCTRINE_DISTANCES_SECTION = "Doctrine distances"
@@ -766,6 +768,62 @@ class Settings:
         max=250,
         detail="A larger number will force the auto-planner to stick with squadrons that have a matching primary task."
         " A smaller number will ignore squadrons with a matching primary task that are too far out.",
+    )
+
+    # Campaign Management+
+    degrade_iads_max_strategic_targets: int = bounded_int_option(
+        "Max strategic IADS targets",
+        ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        DEGRADE_IADS_SECTION,
+        default=2,
+        min=0,
+        max=10,
+        detail="Maximum number of strategic IADS targets to consider each turn.",
+    )
+    degrade_iads_threat_range_effectiveness_percent: int = bounded_int_option(
+        "Threat range effectiveness (%)",
+        ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        DEGRADE_IADS_SECTION,
+        default=70,
+        min=0,
+        max=100,
+        detail="Percent of a SAM's nominal range used when evaluating strategic threat.",
+    )
+    degrade_iads_min_naval_threat_range_meters: int = bounded_int_option(
+        "Min naval SAM range (m)",
+        ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        DEGRADE_IADS_SECTION,
+        default=20000,
+        min=0,
+        max=300000,
+        detail="Minimum naval SAM range required for a ship to be considered a strategic threat.",
+    )
+    degrade_iads_max_naval_threat_penetration_meters: int = bounded_int_option(
+        "Max naval threat distance to bases (m)",
+        ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        DEGRADE_IADS_SECTION,
+        default=150000,
+        min=0,
+        max=1000000,
+        detail="Maximum distance from a naval threat's coverage edge to a friendly base to consider it strategic.",
+    )
+    degrade_iads_max_land_threat_penetration_meters: int = bounded_int_option(
+        "Max land threat distance to bases (m)",
+        ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        DEGRADE_IADS_SECTION,
+        default=100000,
+        min=0,
+        max=3000000,
+        detail="Maximum distance from a land SAM's coverage edge to a friendly base to consider it strategic.",
+    )
+    degrade_iads_threat_score_baseline_meters: int = bounded_int_option(
+        "Threat score baseline distance (m)",
+        ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        DEGRADE_IADS_SECTION,
+        default=200000,
+        min=10000,
+        max=3000000,
+        detail="Baseline distance used to convert threat penetration into a threat score.",
     )
 
     # Mission Generator

--- a/qt_ui/uiconstants.py
+++ b/qt_ui/uiconstants.py
@@ -80,6 +80,7 @@ def load_icons():
         "./resources/ui/misc/" + get_theme_icons() + "/money_icon.png"
     )
     ICONS["Campaign Management"] = ICONS["Money"]
+    ICONS["Campaign Management+"] = ICONS["Money"]
     ICONS["Campaign Doctrine"] = QPixmap("./resources/ui/misc/blue-sam.png")
     ICONS["PassTurn"] = QPixmap(
         "./resources/ui/misc/" + get_theme_icons() + "/hourglass.png"


### PR DESCRIPTION
Current implementation of DEAD/SEAD produces suboptimal packages
Issue is: the planner prioritizes SAMs that are not relevant to the theater, for example flying 150 km to destroy an SA-13 deep in the backline while completely ignoring an SA-5 located near the border. 

The solution this PR has:
SEAD/DEAD planner now targets the most threatening SAM sites closest to friendly control points. It calculates range from each SAM to the closest CP with consideration of a SAMs range