### PR TITLE
Revamp BARCAP planning

### DIFF
--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -129,7 +129,7 @@ class Flight(
         # altitude offset for planes
         offset_factor = self.coalition.game.settings.max_plane_altitude_offset
         offset_factor = random.randint(0, offset_factor)
-        self.plane_altitude_offset = 1000 * offset_factor * random.choice([-1, 1])
+        self.plane_altitude_offset: int = 1000 * offset_factor * random.choice([-1, 1])
 
     @property
     def available_callsigns(self) -> List[str]:

--- a/game/commander/tasks/packageplanningtask.py
+++ b/game/commander/tasks/packageplanningtask.py
@@ -111,14 +111,8 @@ class PackagePlanningTask(TheaterCommanderTask, Generic[MissionTargetT]):
             state.context.settings,
         )
         with state.context.tracer.trace(f"{color} {self.flights[0].task} planning"):
-            asap = False
-            if (
-                not state.context.coalition.ato.has_awacs_package
-                and FlightType.AEWC in [f.task for f in self.flights]
-            ):
-                asap = True
             self.package = fulfiller.plan_mission(
-                ProposedMission(self.target, self.flights, asap=asap),
+                ProposedMission(self.target, self.flights, asap=self.asap),
                 self.purchase_multiplier,
                 state.context.now,
                 state.context.tracer,

--- a/game/commander/tasks/primitive/barcap.py
+++ b/game/commander/tasks/primitive/barcap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from logging import getLogger
 
 from game.ato.flighttype import FlightType
 from game.commander.tasks.packageplanningtask import PackagePlanningTask
@@ -13,8 +14,8 @@ class PlanBarcap(PackagePlanningTask[ControlPoint]):
     max_orders: int
 
     def preconditions_met(self, state: TheaterState) -> bool:
-        if not state.barcaps_needed[self.target]:
-            return False
+        if not state.barcaps_needed.get(self.target, 0):
+            state.barcaps_needed[self.target] = 1
         return super().preconditions_met(state)
 
     def apply_effects(self, state: TheaterState) -> None:
@@ -28,3 +29,7 @@ class PlanBarcap(PackagePlanningTask[ControlPoint]):
     @property
     def purchase_multiplier(self) -> int:
         return self.max_orders
+
+    @property
+    def asap(self) -> bool:
+        return True

--- a/game/commander/theaterstate.py
+++ b/game/commander/theaterstate.py
@@ -20,7 +20,8 @@ from game.theater import (
     ControlPoint,
     FrontLine,
     MissionTarget,
-    Player, Fob,
+    Player,
+    Fob,
 )
 from game.theater.theatergroundobject import (
     BuildingGroundObject,
@@ -191,18 +192,24 @@ class TheaterState(WorldState["TheaterState"]):
         aewc_targets.append(finder.farthest_friendly_control_point())
 
         # Initial vulnerable CPs get full coverage
+        fleet_multiplier = max(0, game.settings.barcap_fleet_round_multiplier)
         barcaps_needed = {
-            cp: 2 * barcap_rounds if cp.is_fleet else barcap_rounds
+            cp: (barcap_rounds * fleet_multiplier) if cp.is_fleet else barcap_rounds
             for cp in finder.vulnerable_control_points()
         }
 
         # Add limited BARCAP coverage to forward CPs closest to enemy
         # Only adds CPs not already covered, spreads defense across multiple bases
         from game.theater import Airfield, Carrier, Lha
+
         friendly_cps = finder.friendly_control_points()
         enemy_cps = list(game.theater.control_points_for(player.opponent))
 
-        if enemy_cps:
+        supplemental_count = max(0, game.settings.barcap_supplemental_control_points)
+        supplemental_multiplier = max(
+            0, game.settings.barcap_supplemental_round_multiplier
+        )
+        if enemy_cps and supplemental_count > 0:
             # Calculate the closest distance from each friendly CP to ANY enemy CP
             cp_distances = []
             for cp in friendly_cps:
@@ -212,17 +219,18 @@ class TheaterState(WorldState["TheaterState"]):
                 # Don't add to CPs already in the list
                 if cp in barcaps_needed:
                     continue
-                
+
                 min_distance = min(
-                    cp.position.distance_to_point(enemy.position)
-                    for enemy in enemy_cps
+                    cp.position.distance_to_point(enemy.position) for enemy in enemy_cps
                 )
                 cp_distances.append((min_distance, cp))
-            
-            # Sort by distance and take the 3 closest
+
+            # Sort by distance and take the closest control points
             cp_distances.sort(key=lambda x: x[0])
-            for _, cp in cp_distances[:3]:
-                barcaps_needed[cp] = 1  # Only 1 round for supplemental coverage
+            for _, cp in cp_distances[:supplemental_count]:
+                barcaps_needed[cp] = (
+                    barcap_rounds * supplemental_multiplier
+                )  # Supplemental coverage
 
         return TheaterState(
             context=context,

--- a/game/commander/theaterstate.py
+++ b/game/commander/theaterstate.py
@@ -20,7 +20,7 @@ from game.theater import (
     ControlPoint,
     FrontLine,
     MissionTarget,
-    Player,
+    Player, Fob,
 )
 from game.theater.theatergroundobject import (
     BuildingGroundObject,
@@ -190,12 +190,43 @@ class TheaterState(WorldState["TheaterState"]):
         aewc_targets = [cp for cp in finder.friendly_control_points() if cp.is_carrier]
         aewc_targets.append(finder.farthest_friendly_control_point())
 
+        # Initial vulnerable CPs get full coverage
+        barcaps_needed = {
+            cp: 2 * barcap_rounds if cp.is_fleet else barcap_rounds
+            for cp in finder.vulnerable_control_points()
+        }
+
+        # Add limited BARCAP coverage to forward CPs closest to enemy
+        # Only adds CPs not already covered, spreads defense across multiple bases
+        from game.theater import Airfield, Carrier, Lha
+        friendly_cps = finder.friendly_control_points()
+        enemy_cps = list(game.theater.control_points_for(player.opponent))
+
+        if enemy_cps:
+            # Calculate the closest distance from each friendly CP to ANY enemy CP
+            cp_distances = []
+            for cp in friendly_cps:
+                # Only consider airbases that can host fixed-wing CAP or rotary wings
+                if not isinstance(cp, (Airfield, Carrier, Lha, Fob)):
+                    continue
+                # Don't add to CPs already in the list
+                if cp in barcaps_needed:
+                    continue
+                
+                min_distance = min(
+                    cp.position.distance_to_point(enemy.position)
+                    for enemy in enemy_cps
+                )
+                cp_distances.append((min_distance, cp))
+            
+            # Sort by distance and take the 3 closest
+            cp_distances.sort(key=lambda x: x[0])
+            for _, cp in cp_distances[:3]:
+                barcaps_needed[cp] = 1  # Only 1 round for supplemental coverage
+
         return TheaterState(
             context=context,
-            barcaps_needed={
-                cp: 2 * barcap_rounds if cp.is_fleet else barcap_rounds
-                for cp in finder.vulnerable_control_points()
-            },
+            barcaps_needed=barcaps_needed,
             active_front_lines=list(finder.front_lines()),
             front_line_stances={f: None for f in finder.front_lines()},
             vulnerable_front_lines=list(finder.front_lines()),

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -40,11 +40,13 @@ MISSION_DIFFICULTY_SECTION = "Mission Difficulty"
 MISSION_RESTRICTIONS_SECTION = "Mission Restrictions"
 
 CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management"
+ADVANCED_CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management+"
 
 GENERAL_SECTION = "General"
 PILOTS_AND_SQUADRONS_SECTION = "Pilots and Squadrons"
 HQ_AUTOMATION_SECTION = "HQ Automation"
 FLIGHT_PLANNER_AUTOMATION = "Flight Planner Automation"
+BARCAP_COVERAGE_SECTION = "BARCAP Coverage"
 
 CAMPAIGN_DOCTRINE_PAGE = "Campaign Doctrine"
 DOCTRINE_DISTANCES_SECTION = "Doctrine distances"
@@ -766,6 +768,40 @@ class Settings:
         max=250,
         detail="A larger number will force the auto-planner to stick with squadrons that have a matching primary task."
         " A smaller number will ignore squadrons with a matching primary task that are too far out.",
+    )
+
+    # Campaign Management+
+    barcap_fleet_round_multiplier: int = bounded_int_option(
+        "Fleet BARCAP round multiplier",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BARCAP_COVERAGE_SECTION,
+        min=0,
+        max=5,
+        default=2,
+        detail=(
+            "Multiplier applied to BARCAP rounds for fleet control points. "
+            "Set to 0 to disable fleet BARCAP rounds."
+        ),
+    )
+    barcap_supplemental_control_points: int = bounded_int_option(
+        "Supplemental BARCAP control points",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BARCAP_COVERAGE_SECTION,
+        min=0,
+        max=10,
+        default=3,
+        detail=(
+            "Number of additional forward control points that receive supplemental BARCAPs."
+        ),
+    )
+    barcap_supplemental_round_multiplier: int = bounded_int_option(
+        "Supplemental BARCAP round multiplier",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BARCAP_COVERAGE_SECTION,
+        min=0,
+        max=5,
+        default=1,
+        detail=("Multiplier applied to BARCAP rounds for supplemental control points."),
     )
 
     # Mission Generator

--- a/qt_ui/uiconstants.py
+++ b/qt_ui/uiconstants.py
@@ -80,6 +80,7 @@ def load_icons():
         "./resources/ui/misc/" + get_theme_icons() + "/money_icon.png"
     )
     ICONS["Campaign Management"] = ICONS["Money"]
+    ICONS["Campaign Management+"] = ICONS["Money"]
     ICONS["Campaign Doctrine"] = QPixmap("./resources/ui/misc/blue-sam.png")
     ICONS["PassTurn"] = QPixmap(
         "./resources/ui/misc/" + get_theme_icons() + "/hourglass.png"


### PR DESCRIPTION
Issue with current BARCAP planning is too few control points have CAP coverage. The current settings can create BARCAPs randomly, which is not ideal. OPFOR air presence is almost non-existent.

This PR adds additional BARCAPs for the closest to enemy control points. Also, BARCAPs are scheduled ASAP to provide air superiority for other packages and defend crucial targets