### PR TITLE
Revamp BAI planning

### DIFF
--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -129,7 +129,7 @@ class Flight(
         # altitude offset for planes
         offset_factor = self.coalition.game.settings.max_plane_altitude_offset
         offset_factor = random.randint(0, offset_factor)
-        self.plane_altitude_offset = 1000 * offset_factor * random.choice([-1, 1])
+        self.plane_altitude_offset: int = 1000 * offset_factor * random.choice([-1, 1])
 
     @property
     def available_callsigns(self) -> List[str]:

--- a/game/commander/tasks/compound/attackbattlepositions.py
+++ b/game/commander/tasks/compound/attackbattlepositions.py
@@ -6,69 +6,66 @@ from game.commander.tasks.primitive.bai import PlanBai
 from game.commander.theaterstate import TheaterState
 from game.htn import CompoundTask, Method
 
-# Maximum number of BAI packages to plan
-MAX_BAI_PACKAGES = 4
-# Maximum number of battle positions per enemy CP
-MAX_POSITIONS_PER_CP = 2
-# Maximum distance to consider enemy CP for BAI (in meters)
-MAX_BAI_DISTANCE = 200000  # 200km
-
 
 class AttackBattlePositions(CompoundTask[TheaterState]):
     def each_valid_method(self, state: TheaterState) -> Iterator[Method[TheaterState]]:
         """Plan BAI missions against nearest enemy control points.
-        
+
         Prioritizes enemy CPs that are closest to friendly CPs.
         Limits total BAI packages to prevent spending all aircraft on ground attack.
         """
         # Get friendly control points for distance calculation
-        friendly_cps = list(state.context.theater.control_points_for(
-            state.context.coalition.player
-        ))
-        
+        friendly_cps = list(
+            state.context.theater.control_points_for(state.context.coalition.player)
+        )
+
         if not friendly_cps:
             return
-        
+
+        settings = state.context.settings
+
         # Score and sort enemy CPs by distance to nearest friendly CP
         enemy_cp_scores = []
         for enemy_cp, battle_positions in state.enemy_battle_positions.items():
             # Skip if no battle positions
             if not list(battle_positions.in_priority_order):
                 continue
-            
+
             # Find distance to closest friendly CP
             min_distance = min(enemy_cp.distance_to(fcp) for fcp in friendly_cps)
-            
+
             # Filter out CPs that are too far away
-            if min_distance > MAX_BAI_DISTANCE:
+            if min_distance > settings.bai_max_distance_meters:
                 continue
-            
+
             # Lower distance = higher priority (negate for sorting)
             enemy_cp_scores.append((min_distance, enemy_cp, battle_positions))
-        
+
         # Sort by distance (closest first)
         enemy_cp_scores.sort(key=lambda x: x[0])
-        
-        # Yield BAI targets from closest CPs, limited to MAX_BAI_PACKAGES total
+
+        # Yield BAI targets from closest CPs, limited to configured total
         packages_yielded = 0
         for distance, enemy_cp, battle_positions in enemy_cp_scores:
-            if packages_yielded >= MAX_BAI_PACKAGES:
+            if packages_yielded >= settings.bai_max_packages:
                 break
-            
+
             # Yield top battle positions from this CP
             positions_from_cp = 0
             for battle_position in battle_positions.in_priority_order:
-                if positions_from_cp >= MAX_POSITIONS_PER_CP:
+                if positions_from_cp >= settings.bai_max_positions_per_cp:
                     break
-                
+
                 yield [PlanBai(battle_position)]
                 packages_yielded += 1
                 positions_from_cp += 1
-                
-                if packages_yielded >= MAX_BAI_PACKAGES:
+
+                if packages_yielded >= settings.bai_max_packages:
                     break
-        
+
         # Plan armed recon against highest priority CPs
-        for cp in state.control_point_priority_queue[:2]:
+        for cp in state.control_point_priority_queue[
+            : settings.bai_armed_recon_target_count
+        ]:
             if not cp.is_fleet:
                 yield [PlanArmedRecon(cp)]

--- a/game/commander/tasks/compound/attackbattlepositions.py
+++ b/game/commander/tasks/compound/attackbattlepositions.py
@@ -1,17 +1,74 @@
 from collections.abc import Iterator
+import logging
 
 from game.commander.tasks.primitive.armedrecon import PlanArmedRecon
 from game.commander.tasks.primitive.bai import PlanBai
 from game.commander.theaterstate import TheaterState
 from game.htn import CompoundTask, Method
 
+# Maximum number of BAI packages to plan
+MAX_BAI_PACKAGES = 4
+# Maximum number of battle positions per enemy CP
+MAX_POSITIONS_PER_CP = 2
+# Maximum distance to consider enemy CP for BAI (in meters)
+MAX_BAI_DISTANCE = 200000  # 200km
+
 
 class AttackBattlePositions(CompoundTask[TheaterState]):
     def each_valid_method(self, state: TheaterState) -> Iterator[Method[TheaterState]]:
-        for battle_positions in state.enemy_battle_positions.values():
+        """Plan BAI missions against nearest enemy control points.
+        
+        Prioritizes enemy CPs that are closest to friendly CPs.
+        Limits total BAI packages to prevent spending all aircraft on ground attack.
+        """
+        # Get friendly control points for distance calculation
+        friendly_cps = list(state.context.theater.control_points_for(
+            state.context.coalition.player
+        ))
+        
+        if not friendly_cps:
+            return
+        
+        # Score and sort enemy CPs by distance to nearest friendly CP
+        enemy_cp_scores = []
+        for enemy_cp, battle_positions in state.enemy_battle_positions.items():
+            # Skip if no battle positions
+            if not list(battle_positions.in_priority_order):
+                continue
+            
+            # Find distance to closest friendly CP
+            min_distance = min(enemy_cp.distance_to(fcp) for fcp in friendly_cps)
+            
+            # Filter out CPs that are too far away
+            if min_distance > MAX_BAI_DISTANCE:
+                continue
+            
+            # Lower distance = higher priority (negate for sorting)
+            enemy_cp_scores.append((min_distance, enemy_cp, battle_positions))
+        
+        # Sort by distance (closest first)
+        enemy_cp_scores.sort(key=lambda x: x[0])
+        
+        # Yield BAI targets from closest CPs, limited to MAX_BAI_PACKAGES total
+        packages_yielded = 0
+        for distance, enemy_cp, battle_positions in enemy_cp_scores:
+            if packages_yielded >= MAX_BAI_PACKAGES:
+                break
+            
+            # Yield top battle positions from this CP
+            positions_from_cp = 0
             for battle_position in battle_positions.in_priority_order:
+                if positions_from_cp >= MAX_POSITIONS_PER_CP:
+                    break
+                
                 yield [PlanBai(battle_position)]
-        # Only plan against the 2 most important CPs
+                packages_yielded += 1
+                positions_from_cp += 1
+                
+                if packages_yielded >= MAX_BAI_PACKAGES:
+                    break
+        
+        # Plan armed recon against highest priority CPs
         for cp in state.control_point_priority_queue[:2]:
             if not cp.is_fleet:
                 yield [PlanArmedRecon(cp)]

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -40,11 +40,13 @@ MISSION_DIFFICULTY_SECTION = "Mission Difficulty"
 MISSION_RESTRICTIONS_SECTION = "Mission Restrictions"
 
 CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management"
+ADVANCED_CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management+"
 
 GENERAL_SECTION = "General"
 PILOTS_AND_SQUADRONS_SECTION = "Pilots and Squadrons"
 HQ_AUTOMATION_SECTION = "HQ Automation"
 FLIGHT_PLANNER_AUTOMATION = "Flight Planner Automation"
+BAI_SECTION = "BAI"
 
 CAMPAIGN_DOCTRINE_PAGE = "Campaign Doctrine"
 DOCTRINE_DISTANCES_SECTION = "Doctrine distances"
@@ -766,6 +768,44 @@ class Settings:
         max=250,
         detail="A larger number will force the auto-planner to stick with squadrons that have a matching primary task."
         " A smaller number will ignore squadrons with a matching primary task that are too far out.",
+    )
+
+    # Campaign Management+
+    bai_max_packages: int = bounded_int_option(
+        "BAI max packages",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BAI_SECTION,
+        min=0,
+        max=20,
+        default=4,
+        detail="Maximum number of BAI packages planned per turn.",
+    )
+    bai_max_positions_per_cp: int = bounded_int_option(
+        "BAI max positions per CP",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BAI_SECTION,
+        min=0,
+        max=10,
+        default=2,
+        detail="Maximum number of battle positions attacked per enemy control point.",
+    )
+    bai_max_distance_meters: int = bounded_int_option(
+        "BAI max distance (meters)",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BAI_SECTION,
+        min=0,
+        max=200000,
+        default=100000,
+        detail="Maximum distance from friendly control points to consider BAI targets.",
+    )
+    bai_armed_recon_target_count: int = bounded_int_option(
+        "BAI armed recon target count",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BAI_SECTION,
+        min=0,
+        max=10,
+        default=2,
+        detail="Number of priority control points to target with armed recon.",
     )
 
     # Mission Generator

--- a/qt_ui/uiconstants.py
+++ b/qt_ui/uiconstants.py
@@ -80,6 +80,7 @@ def load_icons():
         "./resources/ui/misc/" + get_theme_icons() + "/money_icon.png"
     )
     ICONS["Campaign Management"] = ICONS["Money"]
+    ICONS["Campaign Management+"] = ICONS["Money"]
     ICONS["Campaign Doctrine"] = QPixmap("./resources/ui/misc/blue-sam.png")
     ICONS["PassTurn"] = QPixmap(
         "./resources/ui/misc/" + get_theme_icons() + "/hourglass.png"


### PR DESCRIPTION
Targets are often not relevant to the theater, resulting in an almost random selection of target groups across the map. Often BAI targets are too far away (100nm+ on big maps)

This solves this problem, BAI now targets groups near the closest control points.

However, this need a lot of tuning to get it right. Community help would be appreciated