### PR TITLE
Add ground units repairs

### DIFF
--- a/game/armedforces/forcegroup.py
+++ b/game/armedforces/forcegroup.py
@@ -220,6 +220,17 @@ class ForceGroup:
     ) -> TheaterGroundObject:
         """Create a TheaterGroundObject for the given template"""
         go = layout.create_ground_object(name, location, control_point, task)
+        required_classes = set()
+        for unit_group in layout.all_unit_groups:
+            if unit_group.optional:
+                continue
+            required_classes.update(unit_group.unit_classes)
+            for unit_type in unit_group.unit_types:
+                if issubclass(unit_type, VehicleType):
+                    required_classes.add(
+                        next(GroundUnitType.for_dcs_type(unit_type)).unit_class
+                    )
+        go.required_unit_classes = required_classes
         # Generate all groups using the randomization if it defined
         for tgo_group in layout.groups:
             for unit_group in tgo_group.unit_groups:

--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -129,7 +129,7 @@ class Flight(
         # altitude offset for planes
         offset_factor = self.coalition.game.settings.max_plane_altitude_offset
         offset_factor = random.randint(0, offset_factor)
-        self.plane_altitude_offset = 1000 * offset_factor * random.choice([-1, 1])
+        self.plane_altitude_offset: int = 1000 * offset_factor * random.choice([-1, 1])
 
     @property
     def available_callsigns(self) -> List[str]:

--- a/game/coalition.py
+++ b/game/coalition.py
@@ -238,10 +238,12 @@ class Coalition:
             manage_runways = self.game.settings.automate_runway_repair
             manage_front_line = self.game.settings.automate_front_line_reinforcements
             manage_aircraft = self.game.settings.automate_aircraft_reinforcements
+            manage_ground_objects = self.game.settings.automate_ground_object_repairs
         else:
             manage_runways = True
             manage_front_line = True
             manage_aircraft = True
+            manage_ground_objects = self.game.settings.automate_ground_object_repairs
 
         self.budget = ProcurementAi(
             self.game,
@@ -250,6 +252,7 @@ class Coalition:
             manage_runways,
             manage_front_line,
             manage_aircraft,
+            manage_ground_objects,
         ).spend_budget(self.budget)
 
     def add_procurement_request(self, request: AircraftProcurementRequest) -> None:

--- a/game/game.py
+++ b/game/game.py
@@ -308,7 +308,7 @@ class Game:
         self.red.end_turn()
 
         for control_point in self.theater.controlpoints:
-            control_point.process_turn(self)
+            control_point.process_turn(self, events)
 
         if not skipped:
             for cp in self.theater.player_points():

--- a/game/procurement.py
+++ b/game/procurement.py
@@ -37,13 +37,6 @@ class AircraftProcurementRequest:
 
 
 class ProcurementAi:
-    SAM_REPAIR_BUDGET_FRACTION = 0.4
-    SAM_REPAIR_PRIORITY_THRESHOLD = 1.5
-    SAM_REPAIR_WEIGHT_THREAT = 0.5
-    SAM_REPAIR_WEIGHT_FRONTLINE = 1.5
-    SAM_REPAIR_WEIGHT_CP_COVERAGE = 0.6
-    SAM_REPAIR_WEIGHT_TGO_COVERAGE = 0.4
-    SAM_REPAIR_WEIGHT_TGO_INCOME = 0.4
     def __init__(
         self,
         game: Game,
@@ -131,7 +124,7 @@ class ProcurementAi:
         if repair_turns < 0:
             return budget
 
-        repair_budget = budget * self.SAM_REPAIR_BUDGET_FRACTION
+        repair_budget = budget * self.game.settings.sam_repair_budget_fraction
         if repair_budget <= 0:
             return budget
 
@@ -143,7 +136,7 @@ class ProcurementAi:
                 if not isinstance(ground_object, SamGroundObject):
                     continue
                 priority = self.ground_object_repair_priority(ground_object)
-                if priority < self.SAM_REPAIR_PRIORITY_THRESHOLD:
+                if priority < self.game.settings.sam_repair_priority_threshold:
                     continue
                 critical_types = self.critical_unit_types_for_sam(ground_object)
                 critical_dead_ids = {
@@ -164,13 +157,11 @@ class ProcurementAi:
                         continue
                     if unit.unit_type.price <= 0:
                         continue
-                    repair_candidates.append(
-                        (priority, unit.unit_type.price, unit)
-                    )
+                    repair_candidates.append((priority, unit.unit_type.price, unit))
 
         repair_candidates.sort(key=lambda entry: (-entry[0], entry[1]))
 
-        repaired_objects: set[object] = set()
+        repaired_objects: set[TheaterGroundObject] = set()
         destroyed_units = self.game.get_destroyed_units()
         for _, price, unit in repair_candidates:
             if repair_budget < price:
@@ -181,7 +172,11 @@ class ProcurementAi:
                 unit.repair_turns_remaining = None
                 unit.revive(GameUpdateEvents())
                 for entry in list(destroyed_units):
-                    p = Point(entry["x"], entry["z"], self.game.theater.terrain)
+                    p = Point(
+                        float(entry["x"]),
+                        float(entry["z"]),
+                        self.game.theater.terrain,
+                    )
                     if p.distance_to_point(unit.position) < 15:
                         destroyed_units.remove(entry)
             else:
@@ -191,15 +186,15 @@ class ProcurementAi:
 
         for ground_object in repaired_objects:
             if self.is_player.is_blue:
-                self.game.message(
-                    f"We have begun repairs at {ground_object.obj_name}"
-                )
+                self.game.message(f"We have begun repairs at {ground_object.obj_name}")
             else:
                 self.game.message(
                     f"OPFOR has begun repairs at {ground_object.obj_name}"
                 )
 
-        return budget - (budget * self.SAM_REPAIR_BUDGET_FRACTION - repair_budget)
+        return budget - (
+            budget * self.game.settings.sam_repair_budget_fraction - repair_budget
+        )
 
     def ground_object_repair_priority(
         self, ground_object: TheaterGroundObject
@@ -219,12 +214,13 @@ class ProcurementAi:
         tgo_score = min(tgo_count / 6.0, 2.0)
         income_score = min(tgo_income / 20.0, 2.0)
 
+        settings = self.game.settings
         return (
-            range_score * self.SAM_REPAIR_WEIGHT_THREAT
-            + frontline_score * self.SAM_REPAIR_WEIGHT_FRONTLINE
-            + cp_score * self.SAM_REPAIR_WEIGHT_CP_COVERAGE
-            + tgo_score * self.SAM_REPAIR_WEIGHT_TGO_COVERAGE
-            + income_score * self.SAM_REPAIR_WEIGHT_TGO_INCOME
+            range_score * settings.sam_repair_weight_threat
+            + frontline_score * settings.sam_repair_weight_frontline
+            + cp_score * settings.sam_repair_weight_cp_coverage
+            + tgo_score * settings.sam_repair_weight_tgo_coverage
+            + income_score * settings.sam_repair_weight_tgo_income
         )
 
     @staticmethod
@@ -232,7 +228,9 @@ class ProcurementAi:
         ground_object: SamGroundObject,
     ) -> set[type]:
         types_in_site = {unit.type for unit in ground_object.units if unit.unit_type}
-        required_classes = getattr(ground_object, "required_unit_classes", set())
+        required_classes: set[UnitClass] = getattr(
+            ground_object, "required_unit_classes", set()
+        )
         fallback_required_classes = {
             UnitClass.SEARCH_RADAR,
             UnitClass.SEARCH_TRACK_RADAR,
@@ -259,7 +257,10 @@ class ProcurementAi:
                             critical.add(tracker)
         else:
             for unit in ground_object.units:
-                if unit.unit_type and unit.unit_type.unit_class in fallback_required_classes:
+                if (
+                    unit.unit_type
+                    and unit.unit_type.unit_class in fallback_required_classes
+                ):
                     critical.add(unit.type)
             critical.update(t for t in types_in_site if t in TRACK_RADARS)
             critical.update(t for t in types_in_site if t in TELARS)
@@ -331,8 +332,7 @@ class ProcurementAi:
     @staticmethod
     def potential_detection_range(ground_object: TheaterGroundObject) -> float:
         ranges = [
-            getattr(unit.type, "detection_range", 0)
-            for unit in ground_object.units
+            getattr(unit.type, "detection_range", 0) for unit in ground_object.units
         ]
         return float(max(ranges, default=0))
 

--- a/game/procurement.py
+++ b/game/procurement.py
@@ -5,16 +5,22 @@ import random
 from dataclasses import dataclass
 from typing import Iterator, List, Optional, TYPE_CHECKING, Tuple
 
-from game.config import RUNWAY_REPAIR_COST
+from dcs import Point
+
+from game.config import REWARDS, RUNWAY_REPAIR_COST
+from game.data.radar_db import LAUNCHER_TRACKER_PAIRS, TELARS, TRACK_RADARS
 from game.data.units import UnitClass
 from game.dcs.groundunittype import GroundUnitType
+from dcs.unittype import VehicleType
 from game.theater import ControlPoint, MissionTarget, ParkingType, Player
+from game.theater.theatergroundobject import SamGroundObject, TheaterGroundObject
 
 if TYPE_CHECKING:
     from game import Game
     from game.ato import FlightType
     from game.factions.faction import Faction
     from game.squadrons import Squadron
+    from game.theater.theatergroup import TheaterUnit
 
 
 @dataclass(frozen=True)
@@ -31,6 +37,13 @@ class AircraftProcurementRequest:
 
 
 class ProcurementAi:
+    SAM_REPAIR_BUDGET_FRACTION = 0.4
+    SAM_REPAIR_PRIORITY_THRESHOLD = 1.5
+    SAM_REPAIR_WEIGHT_THREAT = 0.5
+    SAM_REPAIR_WEIGHT_FRONTLINE = 1.5
+    SAM_REPAIR_WEIGHT_CP_COVERAGE = 0.6
+    SAM_REPAIR_WEIGHT_TGO_COVERAGE = 0.4
+    SAM_REPAIR_WEIGHT_TGO_INCOME = 0.4
     def __init__(
         self,
         game: Game,
@@ -39,6 +52,7 @@ class ProcurementAi:
         manage_runways: bool,
         manage_front_line: bool,
         manage_aircraft: bool,
+        manage_ground_objects: bool,
     ) -> None:
         self.game = game
         self.is_player = owner
@@ -47,6 +61,7 @@ class ProcurementAi:
         self.manage_runways = manage_runways
         self.manage_front_line = manage_front_line
         self.manage_aircraft = manage_aircraft
+        self.manage_ground_objects = manage_ground_objects
         self.threat_zones = self.game.threat_zone_for(self.is_player.opponent)
 
     def calculate_ground_unit_budget_share(self) -> float:
@@ -98,14 +113,239 @@ class ProcurementAi:
     def spend_budget(self, budget: float) -> float:
         if self.manage_runways:
             budget = self.repair_runways(budget)
-        if self.manage_front_line:
+        if self.manage_front_line or self.manage_ground_objects:
             armor_budget = budget * self.calculate_ground_unit_budget_share()
             budget -= armor_budget
-            budget += self.reinforce_front_line(armor_budget)
+            if self.manage_ground_objects:
+                armor_budget = self.repair_ground_objects(armor_budget)
+            if self.manage_front_line:
+                armor_budget = self.reinforce_front_line(armor_budget)
+            budget += armor_budget
 
         if self.manage_aircraft:
             budget = self.purchase_aircraft(budget)
         return budget
+
+    def repair_ground_objects(self, budget: float) -> float:
+        repair_turns = self.game.settings.ground_object_repair_turns
+        if repair_turns < 0:
+            return budget
+
+        repair_budget = budget * self.SAM_REPAIR_BUDGET_FRACTION
+        if repair_budget <= 0:
+            return budget
+
+        repair_candidates: list[tuple[float, int, TheaterUnit]] = []
+        for control_point in self.owned_points:
+            for ground_object in control_point.ground_objects:
+                if not ground_object.is_friendly(self.is_player):
+                    continue
+                if not isinstance(ground_object, SamGroundObject):
+                    continue
+                priority = self.ground_object_repair_priority(ground_object)
+                if priority < self.SAM_REPAIR_PRIORITY_THRESHOLD:
+                    continue
+                critical_types = self.critical_unit_types_for_sam(ground_object)
+                critical_dead_ids = {
+                    unit.id
+                    for unit in ground_object.units
+                    if unit.type in critical_types
+                    and not unit.alive
+                    and unit.repairable
+                }
+                for unit in ground_object.units:
+                    if unit.alive or not unit.repairable:
+                        continue
+                    if critical_dead_ids and unit.id not in critical_dead_ids:
+                        continue
+                    if unit.repair_turns_remaining is not None:
+                        continue
+                    if unit.unit_type is None:
+                        continue
+                    if unit.unit_type.price <= 0:
+                        continue
+                    repair_candidates.append(
+                        (priority, unit.unit_type.price, unit)
+                    )
+
+        repair_candidates.sort(key=lambda entry: (-entry[0], entry[1]))
+
+        repaired_objects: set[object] = set()
+        destroyed_units = self.game.get_destroyed_units()
+        for _, price, unit in repair_candidates:
+            if repair_budget < price:
+                continue
+            if repair_turns == 0:
+                from game.sim.gameupdateevents import GameUpdateEvents
+
+                unit.repair_turns_remaining = None
+                unit.revive(GameUpdateEvents())
+                for entry in list(destroyed_units):
+                    p = Point(entry["x"], entry["z"], self.game.theater.terrain)
+                    if p.distance_to_point(unit.position) < 15:
+                        destroyed_units.remove(entry)
+            else:
+                unit.repair_turns_remaining = repair_turns
+            repair_budget -= price
+            repaired_objects.add(unit.ground_object)
+
+        for ground_object in repaired_objects:
+            if self.is_player.is_blue:
+                self.game.message(
+                    f"We have begun repairs at {ground_object.obj_name}"
+                )
+            else:
+                self.game.message(
+                    f"OPFOR has begun repairs at {ground_object.obj_name}"
+                )
+
+        return budget - (budget * self.SAM_REPAIR_BUDGET_FRACTION - repair_budget)
+
+    def ground_object_repair_priority(
+        self, ground_object: TheaterGroundObject
+    ) -> float:
+        threat_range = self.potential_threat_range(ground_object)
+        detection_range = self.potential_detection_range(ground_object)
+        range_score = max(threat_range, detection_range, 1.0) / 100000.0
+
+        cp_coverage, frontline_distance = self.covered_control_points(ground_object)
+        cp_score = min(cp_coverage / 4.0, 2.0)
+        if math.isfinite(frontline_distance):
+            frontline_score = 1.0 / (1.0 + (frontline_distance / 10000.0))
+        else:
+            frontline_score = 0.1
+
+        tgo_count, tgo_income = self.covered_ground_objects(ground_object)
+        tgo_score = min(tgo_count / 6.0, 2.0)
+        income_score = min(tgo_income / 20.0, 2.0)
+
+        return (
+            range_score * self.SAM_REPAIR_WEIGHT_THREAT
+            + frontline_score * self.SAM_REPAIR_WEIGHT_FRONTLINE
+            + cp_score * self.SAM_REPAIR_WEIGHT_CP_COVERAGE
+            + tgo_score * self.SAM_REPAIR_WEIGHT_TGO_COVERAGE
+            + income_score * self.SAM_REPAIR_WEIGHT_TGO_INCOME
+        )
+
+    @staticmethod
+    def critical_unit_types_for_sam(
+        ground_object: SamGroundObject,
+    ) -> set[type]:
+        types_in_site = {unit.type for unit in ground_object.units if unit.unit_type}
+        required_classes = getattr(ground_object, "required_unit_classes", set())
+        fallback_required_classes = {
+            UnitClass.SEARCH_RADAR,
+            UnitClass.SEARCH_TRACK_RADAR,
+            UnitClass.TRACK_RADAR,
+            UnitClass.LAUNCHER,
+            UnitClass.TELAR,
+        }
+        critical = set()
+        if required_classes:
+            for unit in ground_object.units:
+                if unit.unit_type and unit.unit_type.unit_class in required_classes:
+                    critical.add(unit.type)
+            for launcher, trackers in LAUNCHER_TRACKER_PAIRS.items():
+                if launcher not in types_in_site:
+                    continue
+                for tracker in trackers:
+                    if tracker not in types_in_site:
+                        continue
+                    if issubclass(tracker, VehicleType):
+                        tracker_class = next(
+                            GroundUnitType.for_dcs_type(tracker)
+                        ).unit_class
+                        if tracker_class in required_classes:
+                            critical.add(tracker)
+        else:
+            for unit in ground_object.units:
+                if unit.unit_type and unit.unit_type.unit_class in fallback_required_classes:
+                    critical.add(unit.type)
+            critical.update(t for t in types_in_site if t in TRACK_RADARS)
+            critical.update(t for t in types_in_site if t in TELARS)
+            for launcher, trackers in LAUNCHER_TRACKER_PAIRS.items():
+                if launcher in types_in_site:
+                    critical.update(trackers)
+        return critical
+
+    def covered_control_points(
+        self, ground_object: TheaterGroundObject
+    ) -> tuple[int, float]:
+        threat_range = self.potential_threat_range(ground_object)
+        if threat_range <= 0:
+            return 0, math.inf
+
+        covered = 0
+        closest_frontline = math.inf
+        for control_point in self.owned_points:
+            distance = ground_object.position.distance_to_point(control_point.position)
+            if distance > threat_range:
+                continue
+            covered += 1
+            frontline_distance = self.distance_to_nearest_frontline_from_cp(
+                control_point
+            )
+            if frontline_distance < closest_frontline:
+                closest_frontline = frontline_distance
+
+        return covered, closest_frontline
+
+    def covered_ground_objects(
+        self, ground_object: TheaterGroundObject
+    ) -> tuple[int, float]:
+        threat_range = self.potential_threat_range(ground_object)
+        if threat_range <= 0:
+            return 0, 0.0
+
+        count = 0
+        income = 0.0
+        for tgo in self.game.theater.ground_objects:
+            if not tgo.is_friendly(self.is_player):
+                continue
+            distance = ground_object.position.distance_to_point(tgo.position)
+            if distance > threat_range:
+                continue
+            count += 1
+            income += REWARDS.get(tgo.category, 0)
+        return count, income
+
+    @staticmethod
+    def distance_to_nearest_frontline_from_cp(control_point: ControlPoint) -> float:
+        front_lines = control_point.front_lines.values()
+        if not front_lines:
+            return math.inf
+        return min(
+            control_point.position.distance_to_point(front_line.position)
+            for front_line in front_lines
+        )
+
+    @staticmethod
+    def potential_threat_range(ground_object: TheaterGroundObject) -> float:
+        ranges = [
+            getattr(unit.type, "threat_range", 0)
+            for unit in ground_object.units
+            if unit.is_anti_air
+        ]
+        return float(max(ranges, default=0))
+
+    @staticmethod
+    def potential_detection_range(ground_object: TheaterGroundObject) -> float:
+        ranges = [
+            getattr(unit.type, "detection_range", 0)
+            for unit in ground_object.units
+        ]
+        return float(max(ranges, default=0))
+
+    def distance_to_nearest_frontline(
+        self, ground_object: TheaterGroundObject
+    ) -> float:
+        front_lines = ground_object.control_point.front_lines.values()
+        if not front_lines:
+            return math.inf
+        return min(
+            ground_object.position.distance_to_point(front_line.position)
+            for front_line in front_lines
+        )
 
     def repair_runways(self, budget: float) -> float:
         for control_point in self.owned_points:

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -40,11 +40,13 @@ MISSION_DIFFICULTY_SECTION = "Mission Difficulty"
 MISSION_RESTRICTIONS_SECTION = "Mission Restrictions"
 
 CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management"
+ADVANCED_CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management+"
 
 GENERAL_SECTION = "General"
 PILOTS_AND_SQUADRONS_SECTION = "Pilots and Squadrons"
 HQ_AUTOMATION_SECTION = "HQ Automation"
 FLIGHT_PLANNER_AUTOMATION = "Flight Planner Automation"
+GROUND_OBJECT_REPAIR_TUNING_SECTION = "Ground Object Repairs"
 
 CAMPAIGN_DOCTRINE_PAGE = "Campaign Doctrine"
 DOCTRINE_DISTANCES_SECTION = "Doctrine distances"
@@ -790,6 +792,77 @@ class Settings:
         " A smaller number will ignore squadrons with a matching primary task that are too far out.",
     )
 
+    # Campaign Management+
+    sam_repair_budget_fraction: float = bounded_float_option(
+        "SAM repair budget fraction",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=1.0,
+        divisor=100,
+        default=0.4,
+        detail=("Fraction of ground unit budget reserved for SAM repairs."),
+    )
+    sam_repair_priority_threshold: float = bounded_float_option(
+        "SAM repair priority threshold",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=1.5,
+        detail=("Minimum priority score required to queue SAM repairs."),
+    )
+    sam_repair_weight_threat: float = bounded_float_option(
+        "SAM repair weight: threat range",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=0.5,
+        detail="Weight applied to SAM threat range coverage.",
+    )
+    sam_repair_weight_frontline: float = bounded_float_option(
+        "SAM repair weight: frontline",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=1.5,
+        detail="Weight applied to proximity to the front line.",
+    )
+    sam_repair_weight_cp_coverage: float = bounded_float_option(
+        "SAM repair weight: CP coverage",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=0.6,
+        detail="Weight applied to covered control points.",
+    )
+    sam_repair_weight_tgo_coverage: float = bounded_float_option(
+        "SAM repair weight: TGO coverage",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=0.4,
+        detail="Weight applied to covered ground objects.",
+    )
+    sam_repair_weight_tgo_income: float = bounded_float_option(
+        "SAM repair weight: TGO income",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=0.4,
+        detail="Weight applied to covered ground object income.",
+    )
     # Mission Generator
     # Gameplay
     fast_forward_to_first_contact: bool = boolean_option(

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -609,6 +609,28 @@ class Settings:
         HQ_AUTOMATION_SECTION,
         default=False,
     )
+    automate_ground_object_repairs: bool = boolean_option(
+        "Automate ground object repairs",
+        CAMPAIGN_MANAGEMENT_PAGE,
+        HQ_AUTOMATION_SECTION,
+        default=False,
+        detail=(
+            "If enabled, AI can spend budget to repair destroyed ground object units "
+            "such as SAMs and EWRs."
+        ),
+    )
+    ground_object_repair_turns: int = bounded_int_option(
+        "Ground object repair turns",
+        CAMPAIGN_MANAGEMENT_PAGE,
+        HQ_AUTOMATION_SECTION,
+        min=0,
+        max=10,
+        default=2,
+        detail=(
+            "Turns required for repaired ground object units to return to service. "
+            "Set to 0 for instant repairs."
+        ),
+    )
     automate_aircraft_reinforcements: bool = boolean_option(
         "Automate aircraft purchases",
         CAMPAIGN_MANAGEMENT_PAGE,

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -57,11 +57,13 @@ MISSION_DIFFICULTY_SECTION = "Mission Difficulty"
 MISSION_RESTRICTIONS_SECTION = "Mission Restrictions"
 
 CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management"
+ADVANCED_CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management+"
 
 GENERAL_SECTION = "General"
 PILOTS_AND_SQUADRONS_SECTION = "Pilots and Squadrons"
 HQ_AUTOMATION_SECTION = "HQ Automation"
 FLIGHT_PLANNER_AUTOMATION = "Flight Planner Automation"
+GROUND_OBJECT_REPAIR_TUNING_SECTION = "Ground Object Repairs"
 
 CAMPAIGN_DOCTRINE_PAGE = "Campaign Doctrine"
 DOCTRINE_DISTANCES_SECTION = "Doctrine distances"
@@ -818,6 +820,77 @@ class Settings:
         " A smaller number will ignore squadrons with a matching primary task that are too far out.",
     )
 
+    # Campaign Management+
+    sam_repair_budget_fraction: float = bounded_float_option(
+        "SAM repair budget fraction",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=1.0,
+        divisor=100,
+        default=0.4,
+        detail=("Fraction of ground unit budget reserved for SAM repairs."),
+    )
+    sam_repair_priority_threshold: float = bounded_float_option(
+        "SAM repair priority threshold",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=1.5,
+        detail=("Minimum priority score required to queue SAM repairs."),
+    )
+    sam_repair_weight_threat: float = bounded_float_option(
+        "SAM repair weight: threat range",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=0.5,
+        detail="Weight applied to SAM threat range coverage.",
+    )
+    sam_repair_weight_frontline: float = bounded_float_option(
+        "SAM repair weight: frontline",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=1.5,
+        detail="Weight applied to proximity to the front line.",
+    )
+    sam_repair_weight_cp_coverage: float = bounded_float_option(
+        "SAM repair weight: CP coverage",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=0.6,
+        detail="Weight applied to covered control points.",
+    )
+    sam_repair_weight_tgo_coverage: float = bounded_float_option(
+        "SAM repair weight: TGO coverage",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=0.4,
+        detail="Weight applied to covered ground objects.",
+    )
+    sam_repair_weight_tgo_income: float = bounded_float_option(
+        "SAM repair weight: TGO income",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=GROUND_OBJECT_REPAIR_TUNING_SECTION,
+        min=0.0,
+        max=5.0,
+        divisor=10,
+        default=0.4,
+        detail="Weight applied to covered ground object income.",
+    )
     # Mission Generator
     # Gameplay
     fast_forward_stop_condition: FastForwardStopCondition = choices_option(

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -637,6 +637,28 @@ class Settings:
         HQ_AUTOMATION_SECTION,
         default=False,
     )
+    automate_ground_object_repairs: bool = boolean_option(
+        "Automate ground object repairs",
+        CAMPAIGN_MANAGEMENT_PAGE,
+        HQ_AUTOMATION_SECTION,
+        default=False,
+        detail=(
+            "If enabled, AI can spend budget to repair destroyed ground object units "
+            "such as SAMs and EWRs."
+        ),
+    )
+    ground_object_repair_turns: int = bounded_int_option(
+        "Ground object repair turns",
+        CAMPAIGN_MANAGEMENT_PAGE,
+        HQ_AUTOMATION_SECTION,
+        min=0,
+        max=10,
+        default=2,
+        detail=(
+            "Turns required for repaired ground object units to return to service. "
+            "Set to 0 for instant repairs."
+        ),
+    )
     automate_aircraft_reinforcements: bool = boolean_option(
         "Automate aircraft purchases",
         CAMPAIGN_MANAGEMENT_PAGE,

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1066,7 +1066,11 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
                     unit.repair_turns_remaining = None
                     unit.revive(events)
                     for entry in list(destroyed_units):
-                        p = Point(entry["x"], entry["z"], game.theater.terrain)
+                        p = Point(
+                            float(entry["x"]),
+                            float(entry["z"]),
+                            game.theater.terrain,
+                        )
                         if p.distance_to_point(unit.position) < 15:
                             destroyed_units.remove(entry)
                 else:

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1050,7 +1050,29 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
             return
         self.runway_status.begin_repair()
 
-    def process_turn(self, game: Game) -> None:
+    def process_ground_object_repairs(
+        self, game: Game, events: GameUpdateEvents
+    ) -> None:
+        destroyed_units = game.get_destroyed_units()
+        for ground_object in self.ground_objects:
+            for unit in ground_object.units:
+                turns_remaining = unit.repair_turns_remaining
+                if turns_remaining is None:
+                    continue
+                if unit.alive:
+                    unit.repair_turns_remaining = None
+                    continue
+                if turns_remaining <= 1:
+                    unit.repair_turns_remaining = None
+                    unit.revive(events)
+                    for entry in list(destroyed_units):
+                        p = Point(entry["x"], entry["z"], game.theater.terrain)
+                        if p.distance_to_point(unit.position) < 15:
+                            destroyed_units.remove(entry)
+                else:
+                    unit.repair_turns_remaining = turns_remaining - 1
+
+    def process_turn(self, game: Game, events: GameUpdateEvents) -> None:
         # We're running at the end of the turn, so the time right now is irrelevant, and
         # we don't know what time the next turn will start yet. It doesn't actually
         # matter though, because the first thing the start of turn action will do is
@@ -1062,6 +1084,8 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
         runway_status = self.runway_status
         if runway_status is not None:
             runway_status.process_turn()
+
+        self.process_ground_object_repairs(game, events)
 
         # Process movements for ships control points group
         if self.target_position is not None:

--- a/game/theater/theatergroundobject.py
+++ b/game/theater/theatergroundobject.py
@@ -19,6 +19,7 @@ from game.sidc import (
     Status,
     SymbolSet,
 )
+from game.data.units import UnitClass
 from game.theater.presetlocation import PresetLocation
 from .missiontarget import MissionTarget
 from .player import Player
@@ -78,6 +79,7 @@ class TheaterGroundObject(MissionTarget, SidcDescribable, ABC):
         self._threat_poly: ThreatPoly | None = None
         self.task = task
         self.hide_on_mfd = hide_on_mfd
+        self.required_unit_classes: set[UnitClass] = set()
 
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
@@ -93,11 +95,23 @@ class TheaterGroundObject(MissionTarget, SidcDescribable, ABC):
         if self.control_point.captured.is_neutral:
             return Status.PRESENT
         if self.is_dead:
+            if self.has_pending_repairs:
+                return Status.PRESENT_DAMAGED
             return Status.PRESENT_DESTROYED
         elif self.dead_units:
             return Status.PRESENT_DAMAGED
         else:
             return Status.PRESENT
+
+    @property
+    def has_pending_repairs(self) -> bool:
+        for unit in self.units:
+            if unit.alive:
+                continue
+            if unit.repair_turns_remaining is None:
+                continue
+            return True
+        return False
 
     @property
     def standard_identity(self) -> StandardIdentity:
@@ -580,8 +594,12 @@ class SamGroundObject(IadsGroundObject):
         if self.control_point.captured.is_neutral:
             return Status.PRESENT
         if self.is_dead:
+            if self.has_pending_repairs:
+                return Status.PRESENT_DAMAGED
             return Status.PRESENT_DESTROYED
         elif self.dead_units:
+            if self.has_pending_repairs:
+                return Status.PRESENT_DAMAGED
             if self.max_threat_range() > meters(0):
                 return Status.PRESENT
             else:

--- a/game/theater/theatergroup.py
+++ b/game/theater/theatergroup.py
@@ -45,6 +45,8 @@ class TheaterUnit:
     fixed_hdg: bool = False
     # State of the unit, dead or alive
     alive: bool = True
+    # Turns remaining until the unit is repaired and revived.
+    repair_turns_remaining: Optional[int] = None
 
     @staticmethod
     def from_template(

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -300,6 +300,7 @@ def create_game(
             automate_runway_repair=auto_procurement,
             automate_front_line_reinforcements=auto_procurement,
             automate_aircraft_reinforcements=auto_procurement,
+            automate_ground_object_repairs=auto_procurement,
             enable_frontline_cheats=cheats,
             enable_base_capture_cheat=cheats,
             enable_transfer_cheat=cheats,

--- a/qt_ui/uiconstants.py
+++ b/qt_ui/uiconstants.py
@@ -80,6 +80,7 @@ def load_icons():
         "./resources/ui/misc/" + get_theme_icons() + "/money_icon.png"
     )
     ICONS["Campaign Management"] = ICONS["Money"]
+    ICONS["Campaign Management+"] = ICONS["Money"]
     ICONS["Campaign Doctrine"] = QPixmap("./resources/ui/misc/blue-sam.png")
     ICONS["PassTurn"] = QPixmap(
         "./resources/ui/misc/" + get_theme_icons() + "/hourglass.png"

--- a/qt_ui/windows/groundobject/QGroundObjectBuyMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectBuyMenu.py
@@ -212,10 +212,18 @@ class QGroundObjectTemplateLayout(QGroupBox):
 
     def group_template_changed(self) -> None:
         price = self.layout_model.price
-        self.buy_button.setText(f"Buy [${price}M][-${self.current_group_value}M]")
+        if self.current_group_value:
+            self.buy_button.setText(
+                f"Buy [${price}M] (Refund ${self.current_group_value}M)"
+            )
+        else:
+            self.buy_button.setText(f"Buy [${price}M]")
         self.buy_button.setEnabled(self.affordable)
         if self.buy_button.isEnabled():
-            self.buy_button.setToolTip(f"Buy the group for ${self.cost}M")
+            if self.cost >= 0:
+                self.buy_button.setToolTip(f"Net cost ${self.cost}M")
+            else:
+                self.buy_button.setToolTip(f"Net refund ${abs(self.cost)}M")
         else:
             self.buy_button.setToolTip("Not enough money to buy this group")
 
@@ -233,6 +241,7 @@ class QGroundObjectTemplateLayout(QGroupBox):
         coalition = self.ground_object.coalition
         coalition.budget -= self.cost if self.game.turn else 0
         self.ground_object.groups = []
+        repair_turns = self.game.settings.ground_object_repair_turns
         for group_name, groups in self.layout_model.groups.items():
             for group in groups:
                 if group.enabled:
@@ -244,6 +253,13 @@ class QGroundObjectTemplateLayout(QGroupBox):
                         group.dcs_unit_type,  # Forced Type
                         group.amount,  # Forced Amount
                     )
+        if self.game.turn and repair_turns > 0:
+            # Player purchases should respect repair delays like AI repairs.
+            for unit in self.ground_object.units:
+                if not unit.repairable:
+                    continue
+                unit.alive = False
+                unit.repair_turns_remaining = repair_turns
         self.close_dialog_signal.emit()
 
 

--- a/qt_ui/windows/groundobject/QGroundObjectMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectMenu.py
@@ -137,8 +137,7 @@ class QGroundObjectMenu(QDialog):
                 if not unit.alive and unit.repairable:
                     if unit.repair_turns_remaining is not None:
                         repair_label = QLabel(
-                            "Repairing ("
-                            f"{unit.repair_turns_remaining} turns)"
+                            "Repairing (" f"{unit.repair_turns_remaining} turns)"
                         )
                         self.intelLayout.addWidget(repair_label, i, 1)
                     elif self.cp.captured.is_blue:

--- a/qt_ui/windows/groundobject/QGroundObjectMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectMenu.py
@@ -14,7 +14,6 @@ from PySide6.QtWidgets import (
     QCheckBox,
 )
 from dcs import Point
-
 from game.config import REWARDS
 from game.data.building_data import FORTIFICATION_BUILDINGS
 from game.server import EventStream
@@ -135,14 +134,23 @@ class QGroundObjectMenu(QDialog):
                     QLabel(f"<b>Unit {str(unit.display_name)}</b>"), i, 0
                 )
 
-                if not unit.alive and unit.repairable and self.cp.captured.is_blue:
-                    price = unit.unit_type.price if unit.unit_type else 0
-                    repair = QPushButton(f"Repair [{price}M]")
-                    repair.setProperty("style", "btn-success")
-                    repair.clicked.connect(
-                        lambda u=unit, p=price: self.repair_unit(u, p)
-                    )
-                    self.intelLayout.addWidget(repair, i, 1)
+                if not unit.alive and unit.repairable:
+                    if unit.repair_turns_remaining is not None:
+                        repair_label = QLabel(
+                            "Repairing ("
+                            f"{unit.repair_turns_remaining} turns)"
+                        )
+                        self.intelLayout.addWidget(repair_label, i, 1)
+                    elif self.cp.captured.is_blue:
+                        price = unit.unit_type.price if unit.unit_type else 0
+                        repair = QPushButton(f"Repair [{price}M]")
+                        repair.setProperty("style", "btn-success")
+                        repair.clicked.connect(
+                            lambda u=unit, p=price: self.repair_unit(u, p)
+                        )
+                        self.intelLayout.addWidget(repair, i, 1)
+                    else:
+                        self.intelLayout.addWidget(QLabel("Destroyed"), i, 1)
                 i += 1
 
         stretch = QVBoxLayout()
@@ -262,24 +270,39 @@ class QGroundObjectMenu(QDialog):
     def update_total_value(self):
         if not self.ground_object.purchasable:
             return
-        self.total_value = self.ground_object.value
+        self.total_value = self.ground_object.value + self.pending_repair_value()
         if self.sell_all_button is not None:
             self.sell_all_button.setText("Disband (+$" + str(self.total_value) + "M)")
+
+    def pending_repair_value(self) -> int:
+        total = 0
+        for unit in self.ground_object.units:
+            if unit.alive:
+                continue
+            if unit.repair_turns_remaining is None:
+                continue
+            if unit.unit_type is None:
+                continue
+            total += unit.unit_type.price
+        return total
 
     def repair_unit(self, unit, price):
         if self.game.blue.budget > price:
             self.game.blue.budget -= price
-            unit.alive = True
+            repair_turns = self.game.settings.ground_object_repair_turns
+            if repair_turns == 0:
+                unit.alive = True
+                destroyed_units = self.game.get_destroyed_units()
+                for d in list(destroyed_units):
+                    p = Point(d["x"], d["z"], self.game.theater.terrain)
+                    if p.distance_to_point(unit.position) < 15:
+                        destroyed_units.remove(d)
+                        logging.info("Removed destroyed units " + str(d))
+                logging.info(f"Repaired unit: {unit.unit_name}")
+            else:
+                unit.repair_turns_remaining = repair_turns
+                logging.info(f"Scheduled unit repair: {unit.unit_name}")
             GameUpdateSignal.get_instance().updateGame(self.game)
-
-            # Remove destroyed units in the vicinity
-            destroyed_units = self.game.get_destroyed_units()
-            for d in destroyed_units:
-                p = Point(d["x"], d["z"], self.game.theater.terrain)
-                if p.distance_to_point(unit.position) < 15:
-                    destroyed_units.remove(d)
-                    logging.info("Removed destroyed units " + str(d))
-            logging.info(f"Repaired unit: {unit.unit_name}")
 
         self.update_game()
 

--- a/qt_ui/windows/newgame/SettingNames.py
+++ b/qt_ui/windows/newgame/SettingNames.py
@@ -6,6 +6,9 @@ from game.settings import Settings
 RUNWAY_REPAIR = f"{Settings.automate_runway_repair=}".split("=")[0].split(".")[1]
 FRONTLINE = f"{Settings.automate_front_line_reinforcements=}".split("=")[0].split(".")[1]
 AIRCRAFT = f"{Settings.automate_aircraft_reinforcements=}".split("=")[0].split(".")[1]
+GROUND_OBJECT_REPAIR = (
+	f"{Settings.automate_ground_object_repairs=}".split("=")[0].split(".")[1]
+)
 MISSION_LENGTH = f"{Settings.desired_player_mission_duration=}".split("=")[0].split(".")[1]
 SUPER_CARRIER = f"{Settings.supercarrier=}".split("=")[0].split(".")[1]
 SQN_AC_LIMITS = f"{Settings.enable_squadron_aircraft_limits=}".split("=")[0].split(".")[1]


### PR DESCRIPTION
The AI can plan repairs for ground units (currently only SAMs are supported).
It identifies the most valuable SAM sites and prioritizes repairing them. The algorithm prioritizes search and tracking radars to make SAM systems operational. The repair budget is shared with ground units and limited to 40% of the it.
All ground objects are purchased or repaired with a configurable delay rather than instantly.

There are 2 new configs: 
- Automate ground object repairs:  If enabled, AI can spend budget to repair destroyed ground object units such as SAMs and EWRs.
- Ground object repair turns: Turns required for repaired ground object units to return to service. Set to 0 for instant repairs.

Here is how such units are displayed
<img width="696" height="625" alt="image" src="https://github.com/user-attachments/assets/e429a1ea-db50-4f3a-b4c7-2ab6f76264d8" />
