### PR TITLE
Add ground buildings repairs

### DIFF
--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -129,7 +129,7 @@ class Flight(
         # altitude offset for planes
         offset_factor = self.coalition.game.settings.max_plane_altitude_offset
         offset_factor = random.randint(0, offset_factor)
-        self.plane_altitude_offset = 1000 * offset_factor * random.choice([-1, 1])
+        self.plane_altitude_offset: int = 1000 * offset_factor * random.choice([-1, 1])
 
     @property
     def available_callsigns(self) -> List[str]:

--- a/game/coalition.py
+++ b/game/coalition.py
@@ -238,10 +238,12 @@ class Coalition:
             manage_runways = self.game.settings.automate_runway_repair
             manage_front_line = self.game.settings.automate_front_line_reinforcements
             manage_aircraft = self.game.settings.automate_aircraft_reinforcements
+            manage_buildings = self.game.settings.automate_building_repairs
         else:
             manage_runways = True
             manage_front_line = True
             manage_aircraft = True
+            manage_buildings = self.game.settings.automate_building_repairs
 
         self.budget = ProcurementAi(
             self.game,
@@ -250,6 +252,7 @@ class Coalition:
             manage_runways,
             manage_front_line,
             manage_aircraft,
+            manage_buildings,
         ).spend_budget(self.budget)
 
     def add_procurement_request(self, request: AircraftProcurementRequest) -> None:

--- a/game/config.py
+++ b/game/config.py
@@ -3,6 +3,10 @@
 # to be cheap enough to repair with a single turn's income.
 RUNWAY_REPAIR_COST = 100
 
+BUILDING_REPAIR_INCOME_MULTIPLIER = 4.0
+BUILDING_REPAIR_AMMO_BONUS = 10.0
+BUILDING_REPAIR_FACTORY_BONUS = 12.0
+
 REWARDS = {
     "warehouse": 2,
     "ware": 2,

--- a/game/config.py
+++ b/game/config.py
@@ -3,10 +3,6 @@
 # to be cheap enough to repair with a single turn's income.
 RUNWAY_REPAIR_COST = 100
 
-BUILDING_REPAIR_INCOME_MULTIPLIER = 4.0
-BUILDING_REPAIR_AMMO_BONUS = 10.0
-BUILDING_REPAIR_FACTORY_BONUS = 12.0
-
 REWARDS = {
     "warehouse": 2,
     "ware": 2,

--- a/game/game.py
+++ b/game/game.py
@@ -308,7 +308,7 @@ class Game:
         self.red.end_turn()
 
         for control_point in self.theater.controlpoints:
-            control_point.process_turn(self)
+            control_point.process_turn(self, events)
 
         if not skipped:
             for cp in self.theater.player_points():

--- a/game/procurement.py
+++ b/game/procurement.py
@@ -18,7 +18,8 @@ from game.theater import (
     TheaterUnit,
 )
 from game.theater.theatergroundobject import (
-    BuildingGroundObject, TheaterGroundObject,
+    BuildingGroundObject,
+    TheaterGroundObject,
 )
 
 if TYPE_CHECKING:
@@ -128,8 +129,8 @@ class ProcurementAi:
         repair_turns = self.game.settings.building_repair_turns
         if repair_turns < 0:
             return budget
-        repair_budget = (
-            budget * (self.game.settings.building_repair_budget_percent / 100.0)
+        repair_budget = budget * (
+            self.game.settings.building_repair_budget_percent / 100.0
         )
         if repair_budget <= 0:
             return budget
@@ -154,7 +155,7 @@ class ProcurementAi:
 
         repair_candidates.sort(key=lambda entry: (-entry[0], entry[1]))
 
-        repaired_objects: set[object] = set()
+        repaired_objects: set[TheaterGroundObject] = set()
         destroyed_units = self.game.get_destroyed_units()
         for _, price, unit in repair_candidates:
             if repair_budget < price:
@@ -165,7 +166,11 @@ class ProcurementAi:
                 unit.repair_turns_remaining = None
                 unit.revive(GameUpdateEvents())
                 for entry in list(destroyed_units):
-                    p = Point(entry["x"], entry["z"], self.game.theater.terrain)
+                    p = Point(
+                        float(entry["x"]),
+                        float(entry["z"]),
+                        self.game.theater.terrain,
+                    )
                     if p.distance_to_point(unit.position) < 15:
                         destroyed_units.remove(entry)
             else:
@@ -175,9 +180,7 @@ class ProcurementAi:
 
         for ground_object in repaired_objects:
             if self.is_player.is_blue:
-                self.game.message(
-                    f"We have begun repairs at {ground_object.obj_name}"
-                )
+                self.game.message(f"We have begun repairs at {ground_object.obj_name}")
             else:
                 self.game.message(
                     f"OPFOR has begun repairs at {ground_object.obj_name}"
@@ -188,9 +191,7 @@ class ProcurementAi:
             - repair_budget
         )
 
-    def building_repair_priority(
-        self, ground_object: BuildingGroundObject
-    ) -> float:
+    def building_repair_priority(self, ground_object: BuildingGroundObject) -> float:
         enemy_distance = self.distance_to_nearest_enemy_control_point(ground_object)
         frontline_distance = self.distance_to_nearest_frontline(ground_object)
         if math.isfinite(enemy_distance):
@@ -209,9 +210,9 @@ class ProcurementAi:
 
         settings = self.game.settings
         return (
-                remote_score * settings.building_repair_weight_remote
-                + income_score * settings.building_repair_weight_income
-                + ammo_frontline_score * settings.building_repair_weight_ammo_frontline
+            remote_score * settings.building_repair_weight_remote
+            + income_score * settings.building_repair_weight_income
+            + ammo_frontline_score * settings.building_repair_weight_ammo_frontline
             + ammo_bonus
             + factory_bonus
         )
@@ -236,8 +237,7 @@ class ProcurementAi:
         if not enemy_points:
             return math.inf
         return min(
-            ground_object.position.distance_to_point(cp.position)
-            for cp in enemy_points
+            ground_object.position.distance_to_point(cp.position) for cp in enemy_points
         )
 
     def repair_runways(self, budget: float) -> float:

--- a/game/procurement.py
+++ b/game/procurement.py
@@ -42,9 +42,6 @@ class AircraftProcurementRequest:
 
 
 class ProcurementAi:
-    BUILDING_REPAIR_WEIGHT_REMOTE = 1.2
-    BUILDING_REPAIR_WEIGHT_INCOME = 1.0
-    BUILDING_REPAIR_WEIGHT_AMMO_FRONTLINE = 1.1
     def __init__(
         self,
         game: Game,
@@ -210,10 +207,11 @@ class ProcurementAi:
         ammo_bonus = 1.0 if ground_object.is_ammo_depot else 0.0
         factory_bonus = 1.0 if ground_object.is_factory else 0.0
 
+        settings = self.game.settings
         return (
-            remote_score * self.BUILDING_REPAIR_WEIGHT_REMOTE
-            + income_score * self.BUILDING_REPAIR_WEIGHT_INCOME
-            + ammo_frontline_score * self.BUILDING_REPAIR_WEIGHT_AMMO_FRONTLINE
+                remote_score * settings.building_repair_weight_remote
+                + income_score * settings.building_repair_weight_income
+                + ammo_frontline_score * settings.building_repair_weight_ammo_frontline
             + ammo_bonus
             + factory_bonus
         )

--- a/game/procurement.py
+++ b/game/procurement.py
@@ -5,10 +5,21 @@ import random
 from dataclasses import dataclass
 from typing import Iterator, List, Optional, TYPE_CHECKING, Tuple
 
-from game.config import RUNWAY_REPAIR_COST
+from dcs import Point
+
+from game.config import RUNWAY_REPAIR_COST, REWARDS
 from game.data.units import UnitClass
 from game.dcs.groundunittype import GroundUnitType
-from game.theater import ControlPoint, MissionTarget, ParkingType, Player
+from game.theater import (
+    ControlPoint,
+    MissionTarget,
+    ParkingType,
+    Player,
+    TheaterUnit,
+)
+from game.theater.theatergroundobject import (
+    BuildingGroundObject, TheaterGroundObject,
+)
 
 if TYPE_CHECKING:
     from game import Game
@@ -31,6 +42,9 @@ class AircraftProcurementRequest:
 
 
 class ProcurementAi:
+    BUILDING_REPAIR_WEIGHT_REMOTE = 1.2
+    BUILDING_REPAIR_WEIGHT_INCOME = 1.0
+    BUILDING_REPAIR_WEIGHT_AMMO_FRONTLINE = 1.1
     def __init__(
         self,
         game: Game,
@@ -39,6 +53,7 @@ class ProcurementAi:
         manage_runways: bool,
         manage_front_line: bool,
         manage_aircraft: bool,
+        manage_buildings: bool,
     ) -> None:
         self.game = game
         self.is_player = owner
@@ -47,6 +62,7 @@ class ProcurementAi:
         self.manage_runways = manage_runways
         self.manage_front_line = manage_front_line
         self.manage_aircraft = manage_aircraft
+        self.manage_buildings = manage_buildings
         self.threat_zones = self.game.threat_zone_for(self.is_player.opponent)
 
     def calculate_ground_unit_budget_share(self) -> float:
@@ -98,6 +114,8 @@ class ProcurementAi:
     def spend_budget(self, budget: float) -> float:
         if self.manage_runways:
             budget = self.repair_runways(budget)
+        if self.manage_buildings:
+            budget = self.repair_buildings(budget)
         if self.manage_front_line:
             armor_budget = budget * self.calculate_ground_unit_budget_share()
             budget -= armor_budget
@@ -106,6 +124,123 @@ class ProcurementAi:
         if self.manage_aircraft:
             budget = self.purchase_aircraft(budget)
         return budget
+
+    def repair_buildings(self, budget: float) -> float:
+        if budget <= 0:
+            return budget
+        repair_turns = self.game.settings.building_repair_turns
+        if repair_turns < 0:
+            return budget
+        repair_budget = (
+            budget * (self.game.settings.building_repair_budget_percent / 100.0)
+        )
+        if repair_budget <= 0:
+            return budget
+
+        repair_candidates: list[tuple[float, float, TheaterUnit]] = []
+        for control_point in self.owned_points:
+            for ground_object in control_point.ground_objects:
+                if not ground_object.is_friendly(self.is_player):
+                    continue
+                if not isinstance(ground_object, BuildingGroundObject):
+                    continue
+                priority = self.building_repair_priority(ground_object)
+                cost = ground_object.repair_cost()
+                if cost <= 0:
+                    continue
+                for unit in ground_object.statics:
+                    if unit.alive:
+                        continue
+                    if unit.repair_turns_remaining is not None:
+                        continue
+                    repair_candidates.append((priority, cost, unit))
+
+        repair_candidates.sort(key=lambda entry: (-entry[0], entry[1]))
+
+        repaired_objects: set[object] = set()
+        destroyed_units = self.game.get_destroyed_units()
+        for _, price, unit in repair_candidates:
+            if repair_budget < price:
+                continue
+            if repair_turns == 0:
+                from game.sim.gameupdateevents import GameUpdateEvents
+
+                unit.repair_turns_remaining = None
+                unit.revive(GameUpdateEvents())
+                for entry in list(destroyed_units):
+                    p = Point(entry["x"], entry["z"], self.game.theater.terrain)
+                    if p.distance_to_point(unit.position) < 15:
+                        destroyed_units.remove(entry)
+            else:
+                unit.repair_turns_remaining = repair_turns
+            repair_budget -= price
+            repaired_objects.add(unit.ground_object)
+
+        for ground_object in repaired_objects:
+            if self.is_player.is_blue:
+                self.game.message(
+                    f"We have begun repairs at {ground_object.obj_name}"
+                )
+            else:
+                self.game.message(
+                    f"OPFOR has begun repairs at {ground_object.obj_name}"
+                )
+
+        return budget - (
+            budget * (self.game.settings.building_repair_budget_percent / 100.0)
+            - repair_budget
+        )
+
+    def building_repair_priority(
+        self, ground_object: BuildingGroundObject
+    ) -> float:
+        enemy_distance = self.distance_to_nearest_enemy_control_point(ground_object)
+        frontline_distance = self.distance_to_nearest_frontline(ground_object)
+        if math.isfinite(enemy_distance):
+            remote_score = min(enemy_distance / 20000.0, 2.0)
+        else:
+            remote_score = 2.0
+        if math.isfinite(frontline_distance):
+            ammo_frontline_score = 1.0 / (1.0 + (frontline_distance / 10000.0))
+        else:
+            ammo_frontline_score = 0.1
+
+        income = REWARDS.get(ground_object.category, 0.0)
+        income_score = min(income / 2.0, 2.0)
+        ammo_bonus = 1.0 if ground_object.is_ammo_depot else 0.0
+        factory_bonus = 1.0 if ground_object.is_factory else 0.0
+
+        return (
+            remote_score * self.BUILDING_REPAIR_WEIGHT_REMOTE
+            + income_score * self.BUILDING_REPAIR_WEIGHT_INCOME
+            + ammo_frontline_score * self.BUILDING_REPAIR_WEIGHT_AMMO_FRONTLINE
+            + ammo_bonus
+            + factory_bonus
+        )
+
+    def distance_to_nearest_frontline(
+        self, ground_object: TheaterGroundObject
+    ) -> float:
+        front_lines = ground_object.control_point.front_lines.values()
+        if not front_lines:
+            return math.inf
+        return min(
+            ground_object.position.distance_to_point(front_line.position)
+            for front_line in front_lines
+        )
+
+    def distance_to_nearest_enemy_control_point(
+        self, ground_object: TheaterGroundObject
+    ) -> float:
+        enemy_points = list(
+            self.game.theater.control_points_for(self.is_player.opponent)
+        )
+        if not enemy_points:
+            return math.inf
+        return min(
+            ground_object.position.distance_to_point(cp.position)
+            for cp in enemy_points
+        )
 
     def repair_runways(self, budget: float) -> float:
         for control_point in self.owned_points:

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -609,11 +609,44 @@ class Settings:
         HQ_AUTOMATION_SECTION,
         default=False,
     )
+    automate_building_repairs: bool = boolean_option(
+        "Automate building repairs",
+        CAMPAIGN_MANAGEMENT_PAGE,
+        HQ_AUTOMATION_SECTION,
+        default=False,
+        detail=(
+            "If enabled, AI can spend budget to repair destroyed income buildings "
+            "such as depots and factories."
+        ),
+    )
     automate_aircraft_reinforcements: bool = boolean_option(
         "Automate aircraft purchases",
         CAMPAIGN_MANAGEMENT_PAGE,
         HQ_AUTOMATION_SECTION,
         default=False,
+    )
+    building_repair_turns: int = bounded_int_option(
+        "Building repair turns",
+        CAMPAIGN_MANAGEMENT_PAGE,
+        HQ_AUTOMATION_SECTION,
+        min=0,
+        max=10,
+        default=4,
+        detail=(
+            "Turns required for repaired buildings to return to service. "
+            "Set to 0 for instant repairs."
+        ),
+    )
+    building_repair_budget_percent: int = bounded_int_option(
+        "Building repair budget (%)",
+        CAMPAIGN_MANAGEMENT_PAGE,
+        HQ_AUTOMATION_SECTION,
+        min=0,
+        max=100,
+        default=15,
+        detail=(
+            "Percent of the procurement budget that may be spent repairing buildings."
+        ),
     )
     auto_ato_behavior: AutoAtoBehavior = choices_option(
         "Automatic package planning behavior",

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -812,9 +812,7 @@ class Settings:
         max=20,
         divisor=10,
         default=4.0,
-        detail=(
-            "Multiplier applied to building income to compute repair cost."
-        ),
+        detail=("Multiplier applied to building income to compute repair cost."),
     )
     building_repair_ammo_bonus: float = bounded_float_option(
         "Building repair ammo bonus",
@@ -824,9 +822,7 @@ class Settings:
         max=50,
         divisor=5,
         default=10.0,
-        detail=(
-            "Added cost for ammo depots to reflect frontline value."
-        ),
+        detail=("Added cost for ammo depots to reflect frontline value."),
     )
     building_repair_factory_bonus: float = bounded_float_option(
         "Building repair factory bonus",
@@ -836,9 +832,7 @@ class Settings:
         max=50,
         divisor=10,
         default=12.0,
-        detail=(
-            "Added cost for factories to reflect production value."
-        ),
+        detail=("Added cost for factories to reflect production value."),
     )
     building_repair_weight_remote: float = bounded_float_option(
         "Building repair weight: remote",
@@ -849,8 +843,8 @@ class Settings:
         divisor=10,
         default=1.2,
         detail=(
-                "Weight for remoteness from enemy control points in repair priority. " +
-                "Buildings farther from enemy control points will be prioritized for repair."
+            "Weight for remoteness from enemy control points in repair priority. "
+            + "Buildings farther from enemy control points will be prioritized for repair."
         ),
     )
     building_repair_weight_income: float = bounded_float_option(
@@ -862,8 +856,8 @@ class Settings:
         divisor=10,
         default=1.0,
         detail=(
-                "Weight for building income in repair priority. " +
-                "Buildings that generate more income will be prioritized for repair."
+            "Weight for building income in repair priority. "
+            + "Buildings that generate more income will be prioritized for repair."
         ),
     )
     building_repair_weight_ammo_frontline: float = bounded_float_option(
@@ -875,8 +869,8 @@ class Settings:
         divisor=10,
         default=1.1,
         detail=(
-                "Weight for frontline proximity when prioritizing ammo depots. " +
-                "Ammo depots closer to the frontline will be prioritized for repair."
+            "Weight for frontline proximity when prioritizing ammo depots. "
+            + "Ammo depots closer to the frontline will be prioritized for repair."
         ),
     )
 

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -40,11 +40,13 @@ MISSION_DIFFICULTY_SECTION = "Mission Difficulty"
 MISSION_RESTRICTIONS_SECTION = "Mission Restrictions"
 
 CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management"
+ADVANCED_CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management+"
 
 GENERAL_SECTION = "General"
 PILOTS_AND_SQUADRONS_SECTION = "Pilots and Squadrons"
 HQ_AUTOMATION_SECTION = "HQ Automation"
 FLIGHT_PLANNER_AUTOMATION = "Flight Planner Automation"
+BUILDING_REPAIR_TUNING_SECTION = "Building Repairs"
 
 CAMPAIGN_DOCTRINE_PAGE = "Campaign Doctrine"
 DOCTRINE_DISTANCES_SECTION = "Doctrine distances"
@@ -799,6 +801,83 @@ class Settings:
         max=250,
         detail="A larger number will force the auto-planner to stick with squadrons that have a matching primary task."
         " A smaller number will ignore squadrons with a matching primary task that are too far out.",
+    )
+
+    # Campaign Management+
+    building_repair_income_multiplier: float = bounded_float_option(
+        "Building repair income multiplier",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=20,
+        divisor=10,
+        default=4.0,
+        detail=(
+            "Multiplier applied to building income to compute repair cost."
+        ),
+    )
+    building_repair_ammo_bonus: float = bounded_float_option(
+        "Building repair ammo bonus",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=50,
+        divisor=5,
+        default=10.0,
+        detail=(
+            "Added cost for ammo depots to reflect frontline value."
+        ),
+    )
+    building_repair_factory_bonus: float = bounded_float_option(
+        "Building repair factory bonus",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=50,
+        divisor=10,
+        default=12.0,
+        detail=(
+            "Added cost for factories to reflect production value."
+        ),
+    )
+    building_repair_weight_remote: float = bounded_float_option(
+        "Building repair weight: remote",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=5,
+        divisor=10,
+        default=1.2,
+        detail=(
+                "Weight for remoteness from enemy control points in repair priority. " +
+                "Buildings farther from enemy control points will be prioritized for repair."
+        ),
+    )
+    building_repair_weight_income: float = bounded_float_option(
+        "Building repair weight: income",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=5,
+        divisor=10,
+        default=1.0,
+        detail=(
+                "Weight for building income in repair priority. " +
+                "Buildings that generate more income will be prioritized for repair."
+        ),
+    )
+    building_repair_weight_ammo_frontline: float = bounded_float_option(
+        "Building repair weight: ammo frontline",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=5,
+        divisor=10,
+        default=1.1,
+        detail=(
+                "Weight for frontline proximity when prioritizing ammo depots. " +
+                "Ammo depots closer to the frontline will be prioritized for repair."
+        ),
     )
 
     # Mission Generator

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -57,11 +57,13 @@ MISSION_DIFFICULTY_SECTION = "Mission Difficulty"
 MISSION_RESTRICTIONS_SECTION = "Mission Restrictions"
 
 CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management"
+ADVANCED_CAMPAIGN_MANAGEMENT_PAGE = "Campaign Management+"
 
 GENERAL_SECTION = "General"
 PILOTS_AND_SQUADRONS_SECTION = "Pilots and Squadrons"
 HQ_AUTOMATION_SECTION = "HQ Automation"
 FLIGHT_PLANNER_AUTOMATION = "Flight Planner Automation"
+BUILDING_REPAIR_TUNING_SECTION = "Building Repairs"
 
 CAMPAIGN_DOCTRINE_PAGE = "Campaign Doctrine"
 DOCTRINE_DISTANCES_SECTION = "Doctrine distances"
@@ -827,6 +829,83 @@ class Settings:
         max=250,
         detail="A larger number will force the auto-planner to stick with squadrons that have a matching primary task."
         " A smaller number will ignore squadrons with a matching primary task that are too far out.",
+    )
+
+    # Campaign Management+
+    building_repair_income_multiplier: float = bounded_float_option(
+        "Building repair income multiplier",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=20,
+        divisor=10,
+        default=4.0,
+        detail=(
+            "Multiplier applied to building income to compute repair cost."
+        ),
+    )
+    building_repair_ammo_bonus: float = bounded_float_option(
+        "Building repair ammo bonus",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=50,
+        divisor=5,
+        default=10.0,
+        detail=(
+            "Added cost for ammo depots to reflect frontline value."
+        ),
+    )
+    building_repair_factory_bonus: float = bounded_float_option(
+        "Building repair factory bonus",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=50,
+        divisor=10,
+        default=12.0,
+        detail=(
+            "Added cost for factories to reflect production value."
+        ),
+    )
+    building_repair_weight_remote: float = bounded_float_option(
+        "Building repair weight: remote",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=5,
+        divisor=10,
+        default=1.2,
+        detail=(
+                "Weight for remoteness from enemy control points in repair priority. " +
+                "Buildings farther from enemy control points will be prioritized for repair."
+        ),
+    )
+    building_repair_weight_income: float = bounded_float_option(
+        "Building repair weight: income",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=5,
+        divisor=10,
+        default=1.0,
+        detail=(
+                "Weight for building income in repair priority. " +
+                "Buildings that generate more income will be prioritized for repair."
+        ),
+    )
+    building_repair_weight_ammo_frontline: float = bounded_float_option(
+        "Building repair weight: ammo frontline",
+        page=ADVANCED_CAMPAIGN_MANAGEMENT_PAGE,
+        section=BUILDING_REPAIR_TUNING_SECTION,
+        min=0,
+        max=5,
+        divisor=10,
+        default=1.1,
+        detail=(
+                "Weight for frontline proximity when prioritizing ammo depots. " +
+                "Ammo depots closer to the frontline will be prioritized for repair."
+        ),
     )
 
     # Mission Generator

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -840,9 +840,7 @@ class Settings:
         max=20,
         divisor=10,
         default=4.0,
-        detail=(
-            "Multiplier applied to building income to compute repair cost."
-        ),
+        detail=("Multiplier applied to building income to compute repair cost."),
     )
     building_repair_ammo_bonus: float = bounded_float_option(
         "Building repair ammo bonus",
@@ -852,9 +850,7 @@ class Settings:
         max=50,
         divisor=5,
         default=10.0,
-        detail=(
-            "Added cost for ammo depots to reflect frontline value."
-        ),
+        detail=("Added cost for ammo depots to reflect frontline value."),
     )
     building_repair_factory_bonus: float = bounded_float_option(
         "Building repair factory bonus",
@@ -864,9 +860,7 @@ class Settings:
         max=50,
         divisor=10,
         default=12.0,
-        detail=(
-            "Added cost for factories to reflect production value."
-        ),
+        detail=("Added cost for factories to reflect production value."),
     )
     building_repair_weight_remote: float = bounded_float_option(
         "Building repair weight: remote",
@@ -877,8 +871,8 @@ class Settings:
         divisor=10,
         default=1.2,
         detail=(
-                "Weight for remoteness from enemy control points in repair priority. " +
-                "Buildings farther from enemy control points will be prioritized for repair."
+            "Weight for remoteness from enemy control points in repair priority. "
+            + "Buildings farther from enemy control points will be prioritized for repair."
         ),
     )
     building_repair_weight_income: float = bounded_float_option(
@@ -890,8 +884,8 @@ class Settings:
         divisor=10,
         default=1.0,
         detail=(
-                "Weight for building income in repair priority. " +
-                "Buildings that generate more income will be prioritized for repair."
+            "Weight for building income in repair priority. "
+            + "Buildings that generate more income will be prioritized for repair."
         ),
     )
     building_repair_weight_ammo_frontline: float = bounded_float_option(
@@ -903,8 +897,8 @@ class Settings:
         divisor=10,
         default=1.1,
         detail=(
-                "Weight for frontline proximity when prioritizing ammo depots. " +
-                "Ammo depots closer to the frontline will be prioritized for repair."
+            "Weight for frontline proximity when prioritizing ammo depots. "
+            + "Ammo depots closer to the frontline will be prioritized for repair."
         ),
     )
 

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -637,11 +637,44 @@ class Settings:
         HQ_AUTOMATION_SECTION,
         default=False,
     )
+    automate_building_repairs: bool = boolean_option(
+        "Automate building repairs",
+        CAMPAIGN_MANAGEMENT_PAGE,
+        HQ_AUTOMATION_SECTION,
+        default=False,
+        detail=(
+            "If enabled, AI can spend budget to repair destroyed income buildings "
+            "such as depots and factories."
+        ),
+    )
     automate_aircraft_reinforcements: bool = boolean_option(
         "Automate aircraft purchases",
         CAMPAIGN_MANAGEMENT_PAGE,
         HQ_AUTOMATION_SECTION,
         default=False,
+    )
+    building_repair_turns: int = bounded_int_option(
+        "Building repair turns",
+        CAMPAIGN_MANAGEMENT_PAGE,
+        HQ_AUTOMATION_SECTION,
+        min=0,
+        max=10,
+        default=4,
+        detail=(
+            "Turns required for repaired buildings to return to service. "
+            "Set to 0 for instant repairs."
+        ),
+    )
+    building_repair_budget_percent: int = bounded_int_option(
+        "Building repair budget (%)",
+        CAMPAIGN_MANAGEMENT_PAGE,
+        HQ_AUTOMATION_SECTION,
+        min=0,
+        max=100,
+        default=15,
+        detail=(
+            "Percent of the procurement budget that may be spent repairing buildings."
+        ),
     )
     auto_ato_behavior: AutoAtoBehavior = choices_option(
         "Automatic package planning behavior",

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1066,7 +1066,11 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
                     unit.repair_turns_remaining = None
                     unit.revive(events)
                     for entry in list(destroyed_units):
-                        p = Point(entry["x"], entry["z"], game.theater.terrain)
+                        p = Point(
+                            float(entry["x"]),
+                            float(entry["z"]),
+                            game.theater.terrain,
+                        )
                         if p.distance_to_point(unit.position) < 15:
                             destroyed_units.remove(entry)
                 else:

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1050,7 +1050,29 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
             return
         self.runway_status.begin_repair()
 
-    def process_turn(self, game: Game) -> None:
+    def process_ground_object_repairs(
+        self, game: Game, events: GameUpdateEvents
+    ) -> None:
+        destroyed_units = game.get_destroyed_units()
+        for ground_object in self.ground_objects:
+            for unit in ground_object.units:
+                turns_remaining = unit.repair_turns_remaining
+                if turns_remaining is None:
+                    continue
+                if unit.alive:
+                    unit.repair_turns_remaining = None
+                    continue
+                if turns_remaining <= 1:
+                    unit.repair_turns_remaining = None
+                    unit.revive(events)
+                    for entry in list(destroyed_units):
+                        p = Point(entry["x"], entry["z"], game.theater.terrain)
+                        if p.distance_to_point(unit.position) < 15:
+                            destroyed_units.remove(entry)
+                else:
+                    unit.repair_turns_remaining = turns_remaining - 1
+
+    def process_turn(self, game: Game, events: GameUpdateEvents) -> None:
         # We're running at the end of the turn, so the time right now is irrelevant, and
         # we don't know what time the next turn will start yet. It doesn't actually
         # matter though, because the first thing the start of turn action will do is
@@ -1062,6 +1084,8 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
         runway_status = self.runway_status
         if runway_status is not None:
             runway_status.process_turn()
+
+        self.process_ground_object_repairs(game, events)
 
         # Process movements for ships control points group
         if self.target_position is not None:

--- a/game/theater/theatergroundobject.py
+++ b/game/theater/theatergroundobject.py
@@ -8,6 +8,12 @@ from typing import Any, Iterator, List, Optional, TYPE_CHECKING
 from dcs.mapping import Point
 from shapely.geometry import Point as ShapelyPoint
 
+from game.config import (
+    BUILDING_REPAIR_AMMO_BONUS,
+    BUILDING_REPAIR_FACTORY_BONUS,
+    BUILDING_REPAIR_INCOME_MULTIPLIER,
+    REWARDS,
+)
 from game.sidc import (
     Entity,
     LandEquipmentEntity,
@@ -19,6 +25,7 @@ from game.sidc import (
     Status,
     SymbolSet,
 )
+from game.data.units import UnitClass
 from game.theater.presetlocation import PresetLocation
 from .missiontarget import MissionTarget
 from .player import Player
@@ -78,6 +85,7 @@ class TheaterGroundObject(MissionTarget, SidcDescribable, ABC):
         self._threat_poly: ThreatPoly | None = None
         self.task = task
         self.hide_on_mfd = hide_on_mfd
+        self.required_unit_classes: set[UnitClass] = set()
 
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
@@ -93,11 +101,23 @@ class TheaterGroundObject(MissionTarget, SidcDescribable, ABC):
         if self.control_point.captured.is_neutral:
             return Status.PRESENT
         if self.is_dead:
+            if self.has_pending_repairs:
+                return Status.PRESENT_DAMAGED
             return Status.PRESENT_DESTROYED
         elif self.dead_units:
             return Status.PRESENT_DAMAGED
         else:
             return Status.PRESENT
+
+    @property
+    def has_pending_repairs(self) -> bool:
+        for unit in self.units:
+            if unit.alive:
+                continue
+            if unit.repair_turns_remaining is None:
+                continue
+            return True
+        return False
 
     @property
     def standard_identity(self) -> StandardIdentity:
@@ -364,6 +384,17 @@ class BuildingGroundObject(TheaterGroundObject):
     def purchasable(self) -> bool:
         return False
 
+    def repair_cost(self) -> float:
+        income = REWARDS.get(self.category, 0.0)
+        if income <= 0:
+            return 0.0
+        cost = income * BUILDING_REPAIR_INCOME_MULTIPLIER
+        if self.is_ammo_depot:
+            cost += BUILDING_REPAIR_AMMO_BONUS
+        if self.is_factory:
+            cost += BUILDING_REPAIR_FACTORY_BONUS
+        return cost
+
 
 class NavalGroundObject(TheaterGroundObject, ABC):
     def mission_types(self, for_player: Player) -> Iterator[FlightType]:
@@ -580,8 +611,12 @@ class SamGroundObject(IadsGroundObject):
         if self.control_point.captured.is_neutral:
             return Status.PRESENT
         if self.is_dead:
+            if self.has_pending_repairs:
+                return Status.PRESENT_DAMAGED
             return Status.PRESENT_DESTROYED
         elif self.dead_units:
+            if self.has_pending_repairs:
+                return Status.PRESENT_DAMAGED
             if self.max_threat_range() > meters(0):
                 return Status.PRESENT
             else:

--- a/game/theater/theatergroundobject.py
+++ b/game/theater/theatergroundobject.py
@@ -8,12 +8,8 @@ from typing import Any, Iterator, List, Optional, TYPE_CHECKING
 from dcs.mapping import Point
 from shapely.geometry import Point as ShapelyPoint
 
-from game.config import (
-    BUILDING_REPAIR_AMMO_BONUS,
-    BUILDING_REPAIR_FACTORY_BONUS,
-    BUILDING_REPAIR_INCOME_MULTIPLIER,
-    REWARDS,
-)
+from game.config import REWARDS
+from game.data.units import UnitClass
 from game.sidc import (
     Entity,
     LandEquipmentEntity,
@@ -25,7 +21,6 @@ from game.sidc import (
     Status,
     SymbolSet,
 )
-from game.data.units import UnitClass
 from game.theater.presetlocation import PresetLocation
 from .missiontarget import MissionTarget
 from .player import Player
@@ -388,11 +383,12 @@ class BuildingGroundObject(TheaterGroundObject):
         income = REWARDS.get(self.category, 0.0)
         if income <= 0:
             return 0.0
-        cost = income * BUILDING_REPAIR_INCOME_MULTIPLIER
+        settings = self.control_point.coalition.game.settings
+        cost = income * settings.building_repair_income_multiplier
         if self.is_ammo_depot:
-            cost += BUILDING_REPAIR_AMMO_BONUS
+            cost += settings.building_repair_ammo_bonus
         if self.is_factory:
-            cost += BUILDING_REPAIR_FACTORY_BONUS
+            cost += settings.building_repair_factory_bonus
         return cost
 
 

--- a/game/theater/theatergroup.py
+++ b/game/theater/theatergroup.py
@@ -45,6 +45,8 @@ class TheaterUnit:
     fixed_hdg: bool = False
     # State of the unit, dead or alive
     alive: bool = True
+    # Turns remaining until the unit is repaired and revived.
+    repair_turns_remaining: Optional[int] = None
 
     @staticmethod
     def from_template(

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -300,6 +300,7 @@ def create_game(
             automate_runway_repair=auto_procurement,
             automate_front_line_reinforcements=auto_procurement,
             automate_aircraft_reinforcements=auto_procurement,
+            automate_building_repairs=auto_procurement,
             enable_frontline_cheats=cheats,
             enable_base_capture_cheat=cheats,
             enable_transfer_cheat=cheats,

--- a/qt_ui/uiconstants.py
+++ b/qt_ui/uiconstants.py
@@ -80,6 +80,7 @@ def load_icons():
         "./resources/ui/misc/" + get_theme_icons() + "/money_icon.png"
     )
     ICONS["Campaign Management"] = ICONS["Money"]
+    ICONS["Campaign Management+"] = ICONS["Money"]
     ICONS["Campaign Doctrine"] = QPixmap("./resources/ui/misc/blue-sam.png")
     ICONS["PassTurn"] = QPixmap(
         "./resources/ui/misc/" + get_theme_icons() + "/hourglass.png"

--- a/qt_ui/windows/groundobject/QBuildingInfo.py
+++ b/qt_ui/windows/groundobject/QBuildingInfo.py
@@ -52,8 +52,7 @@ class QBuildingInfo(QGroupBox):
             if self.building.repair_turns_remaining is not None:
                 layout.addWidget(
                     QLabel(
-                        "Repairing ("
-                        f"{self.building.repair_turns_remaining} turns)"
+                        "Repairing (" f"{self.building.repair_turns_remaining} turns)"
                     )
                 )
             elif self.ground_object.control_point.captured.is_blue:

--- a/qt_ui/windows/groundobject/QBuildingInfo.py
+++ b/qt_ui/windows/groundobject/QBuildingInfo.py
@@ -1,17 +1,24 @@
 import os
+from typing import Callable
 
 from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QGroupBox, QHBoxLayout, QLabel, QVBoxLayout
+from PySide6.QtWidgets import QGroupBox, QLabel, QPushButton, QVBoxLayout
 
 from game.config import REWARDS
 from game.theater import TheaterUnit
 
 
 class QBuildingInfo(QGroupBox):
-    def __init__(self, building: TheaterUnit, ground_object):
+    def __init__(
+        self,
+        building: TheaterUnit,
+        ground_object,
+        on_repair: Callable[[TheaterUnit, float], None],
+    ):
         super(QBuildingInfo, self).__init__()
         self.building = building
         self.ground_object = ground_object
+        self.on_repair = on_repair
         self.init_ui()
 
     def init_ui(self):
@@ -41,5 +48,26 @@ class QBuildingInfo(QGroupBox):
             self.reward = QLabel(income_label_text)
             layout.addWidget(self.reward)
 
-        footer = QHBoxLayout()
+        if not self.building.alive:
+            if self.building.repair_turns_remaining is not None:
+                layout.addWidget(
+                    QLabel(
+                        "Repairing ("
+                        f"{self.building.repair_turns_remaining} turns)"
+                    )
+                )
+            elif self.ground_object.control_point.captured.is_blue:
+                price = self.ground_object.repair_cost()
+                if price > 0:
+                    repair = QPushButton(f"Repair [{price}M]")
+                    repair.setProperty("style", "btn-success")
+                    repair.clicked.connect(
+                        lambda checked=False, u=self.building, p=price: self.on_repair(
+                            u, p
+                        )
+                    )
+                    layout.addWidget(repair)
+            else:
+                layout.addWidget(QLabel("Destroyed"))
+
         self.setLayout(layout)

--- a/qt_ui/windows/groundobject/QGroundObjectMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectMenu.py
@@ -158,7 +158,11 @@ class QGroundObjectMenu(QDialog):
         for static in self.ground_object.statics:
             if static not in FORTIFICATION_BUILDINGS:
                 self.buildingsLayout.addWidget(
-                    QBuildingInfo(static, self.ground_object), j / 3, j % 3
+                    QBuildingInfo(
+                        static, self.ground_object, self.repair_building
+                    ),
+                    j / 3,
+                    j % 3,
                 )
                 j = j + 1
 
@@ -280,6 +284,26 @@ class QGroundObjectMenu(QDialog):
                     destroyed_units.remove(d)
                     logging.info("Removed destroyed units " + str(d))
             logging.info(f"Repaired unit: {unit.unit_name}")
+
+        self.update_game()
+
+    def repair_building(self, unit, price):
+        if self.game.blue.budget > price:
+            self.game.blue.budget -= price
+            repair_turns = self.game.settings.building_repair_turns
+            if repair_turns == 0:
+                unit.alive = True
+                destroyed_units = self.game.get_destroyed_units()
+                for d in list(destroyed_units):
+                    p = Point(d["x"], d["z"], self.game.theater.terrain)
+                    if p.distance_to_point(unit.position) < 15:
+                        destroyed_units.remove(d)
+                        logging.info("Removed destroyed units " + str(d))
+                logging.info(f"Repaired building: {unit.unit_name}")
+            else:
+                unit.repair_turns_remaining = repair_turns
+                logging.info(f"Scheduled building repair: {unit.unit_name}")
+            GameUpdateSignal.get_instance().updateGame(self.game)
 
         self.update_game()
 

--- a/qt_ui/windows/groundobject/QGroundObjectMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectMenu.py
@@ -158,9 +158,7 @@ class QGroundObjectMenu(QDialog):
         for static in self.ground_object.statics:
             if static not in FORTIFICATION_BUILDINGS:
                 self.buildingsLayout.addWidget(
-                    QBuildingInfo(
-                        static, self.ground_object, self.repair_building
-                    ),
+                    QBuildingInfo(static, self.ground_object, self.repair_building),
                     j / 3,
                     j % 3,
                 )

--- a/qt_ui/windows/newgame/SettingNames.py
+++ b/qt_ui/windows/newgame/SettingNames.py
@@ -6,6 +6,9 @@ from game.settings import Settings
 RUNWAY_REPAIR = f"{Settings.automate_runway_repair=}".split("=")[0].split(".")[1]
 FRONTLINE = f"{Settings.automate_front_line_reinforcements=}".split("=")[0].split(".")[1]
 AIRCRAFT = f"{Settings.automate_aircraft_reinforcements=}".split("=")[0].split(".")[1]
+BUILDING_REPAIR = (
+	f"{Settings.automate_building_repairs=}".split("=")[0].split(".")[1]
+)
 MISSION_LENGTH = f"{Settings.desired_player_mission_duration=}".split("=")[0].split(".")[1]
 SUPER_CARRIER = f"{Settings.supercarrier=}".split("=")[0].split(".")[1]
 SQN_AC_LIMITS = f"{Settings.enable_squadron_aircraft_limits=}".split("=")[0].split(".")[1]


### PR DESCRIPTION
The AI can plan repairs for buildings. Additionally, users can now repair buildings on demand.
It identifies the most valuable buildings that are farthest from the opponent. An exception is ammo depots, which must be closest to the frontline. The potential income value of a building is also taken into consideration.
Building repairs have a configurable and substantial delay, with a default of 4 turns. The repair cost is calculated as income_value × 4, subject to change. There is also a new repair budget option with a default value of 15% of the total budget.

The current implementation does not support refunding or canceling repairs, so please keep that in mind.


Examples:
<img width="720" height="709" alt="image" src="https://github.com/user-attachments/assets/6e915784-c41e-474f-9b0e-8dd9a27350c8" />
<img width="731" height="718" alt="image" src="https://github.com/user-attachments/assets/5deaa0c3-c57a-4c01-a2ff-b6e339634eae" />
<img width="803" height="244" alt="image" src="https://github.com/user-attachments/assets/6421b7ab-eac9-41e5-96f0-6a0223552ee3" />
