### PR TITLE
DEAD - Old aircraft drop all bombs at once

### DIFF
--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -243,6 +243,9 @@ class AircraftType(UnitType[Type[FlyingType]]):
     # without the need for a jamming pod
     has_built_in_jamming: bool
 
+    # If true, drop all dumb bombs in a single pass when possible.
+    single_pass_dumb_bombs: bool
+
     task_priorities: dict[FlightType, int]
     laser_code_configs: list[LaserCodeConfig]
 
@@ -611,6 +614,7 @@ class AircraftType(UnitType[Type[FlyingType]]):
             has_built_in_target_pod=data.get("has_built_in_target_pod", False),
             has_built_in_ecm=data.get("has_built_in_ecm", False),
             has_built_in_jamming=data.get("has_built_in_jamming", False),
+            single_pass_dumb_bombs=data.get("single_pass_dumb_bombs", False),
             laser_code_configs=[
                 LaserCodeConfig.from_yaml(d) for d in data.get("laser_codes", [])
             ],

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -243,7 +243,8 @@ class AircraftType(UnitType[Type[FlyingType]]):
     # without the need for a jamming pod
     has_built_in_jamming: bool
 
-    # If true, drop all dumb bombs in a single pass when possible.
+    # If true, prefer single-pass delivery of unguided ("dumb") bombs for DEAD ingress
+    # AttackGroup task generation when possible, instead of multiple bombing passes.
     single_pass_dumb_bombs: bool
 
     task_priorities: dict[FlightType, int]

--- a/game/missiongenerator/aircraft/waypoints/deadingress.py
+++ b/game/missiongenerator/aircraft/waypoints/deadingress.py
@@ -60,10 +60,11 @@ class DeadIngressBuilder(PydcsWaypointBuilder):
 
             dir = target.position.heading_between_point(waypoint.position)
 
+            attack_limit = 1 if self.flight.unit_type.single_pass_dumb_bombs else None
             task = AttackGroup(
                 miz_group.id,
                 weapon_type=WeaponType.Unguided,
-                attack_limit=1,
+                attack_limit=attack_limit,
                 expend=Expend.All,
                 direction=math.radians(dir),
                 altitude=waypoint.alt,

--- a/game/missiongenerator/aircraft/waypoints/strikeingress.py
+++ b/game/missiongenerator/aircraft/waypoints/strikeingress.py
@@ -57,10 +57,6 @@ class StrikeIngressBuilder(PydcsWaypointBuilder):
                 group_attack=True,
                 altitude=waypoint.alt,
             )
-        if self.flight.unit_type.single_pass_dumb_bombs:
-            bombing.params["expend"] = Expend.All.value
-            bombing.params["attackQtyLimit"] = True
-            bombing.params["attackQty"] = 1
         waypoint.tasks.append(bombing)
 
     def add_strike_tasks(

--- a/game/missiongenerator/aircraft/waypoints/strikeingress.py
+++ b/game/missiongenerator/aircraft/waypoints/strikeingress.py
@@ -57,6 +57,10 @@ class StrikeIngressBuilder(PydcsWaypointBuilder):
                 group_attack=True,
                 altitude=waypoint.alt,
             )
+        if self.flight.unit_type.single_pass_dumb_bombs:
+            bombing.params["expend"] = Expend.All.value
+            bombing.params["attackQtyLimit"] = True
+            bombing.params["attackQty"] = 1
         waypoint.tasks.append(bombing)
 
     def add_strike_tasks(

--- a/resources/units/aircraft/A-4E-C.yaml
+++ b/resources/units/aircraft/A-4E-C.yaml
@@ -13,6 +13,7 @@ origin: USA
 price: 7
 role: Carrier-based Attack/Light Fighter
 gunfighter: true
+single_pass_dumb_bombs: true
 variants:
   A-4E Skyhawk: {}
 tasks:

--- a/resources/units/aircraft/A-7E.yaml
+++ b/resources/units/aircraft/A-7E.yaml
@@ -11,6 +11,7 @@ manufacturer: Vought
 origin: USA
 price: 10
 role: Carrier-based Attack
+single_pass_dumb_bombs: true
 gunfighter: true
 variants:
   A-7E Corsair II: {}

--- a/resources/units/aircraft/A6E.yaml
+++ b/resources/units/aircraft/A6E.yaml
@@ -12,6 +12,7 @@ manufacturer: Grumman
 origin: USA
 price: 10
 role: Carrier-based Attack
+single_pass_dumb_bombs: true
 variants:
   A-6E Intruder: {}
 tasks:

--- a/resources/units/aircraft/F-4E-45MC.yaml
+++ b/resources/units/aircraft/F-4E-45MC.yaml
@@ -14,6 +14,7 @@ origin: USA
 price: 10
 role: Fighter-Bomber
 max_range: 200
+single_pass_dumb_bombs: true
 variants:
   F-4E-45MC Phantom II: {}
   Phantom FGR.2: {}

--- a/resources/units/aircraft/F-4E.yaml
+++ b/resources/units/aircraft/F-4E.yaml
@@ -14,6 +14,7 @@ origin: USA
 price: 10
 role: Fighter-Bomber
 max_range: 200
+single_pass_dumb_bombs: true
 variants:
   F-4E Phantom II: {}
   F-4EJ Kai Phantom II: {}


### PR DESCRIPTION
**Problem**
- Dumb-bomb AI often makes multiple attack passes on DEAD targets, which looks unrealistic for aircraft that should release most or all unguided bombs in a single run.

**How It Works**
- Adds an aircraft-level flag `single_pass_dumb_bombs`.
- For DEAD ingress unguided attacks, sets `attackQtyLimit=1` so the AI makes only one pass.

**Applies To Aircraft**
- The behavior is opt-in per aircraft via `single_pass_dumb_bombs` in the unit YAML.
- Enabled for A-4E, A-7E, A-6E, and F-4E variants; other aircraft are unchanged unless the flag is added.