### PR TITLE
Captured airfields will get TACANs

### DIFF
--- a/game/missiongenerator/luagenerator.py
+++ b/game/missiongenerator/luagenerator.py
@@ -52,7 +52,16 @@ class LuaGenerator:
         install_path = lua_data.add_item("installPath")
         install_path.set_value(os.path.abspath("."))
 
-        lua_data.add_item("Airbases")
+        airbases_object = lua_data.add_item("Airbases")
+        for runway in self.mission_data.runways:
+            if runway.tacan is not None:
+                airbase_item = airbases_object.add_item()
+                airbase_item.add_key_value("name", runway.airfield_name)
+                airbase_item.add_key_value("tacan", str(runway.tacan))
+                airbase_item.add_key_value(
+                    "tacan_callsign", runway.tacan_callsign or ""
+                )
+
         carriers_object = lua_data.add_item("Carriers")
 
         for carrier in self.mission_data.carriers:

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -53,7 +53,7 @@ from dcs.triggers import (
 from dcs.unit import Unit, InvisibleFARP, BaseFARP, SingleHeliPad, FARP
 from dcs.unitgroup import MovingGroup, ShipGroup, StaticGroup, VehicleGroup
 from dcs.unittype import ShipType, VehicleType
-from dcs.vehicles import vehicle_map, Unarmed
+from dcs.vehicles import vehicle_map, Unarmed, Fortification as VehicleFortification
 
 from game.missiongenerator.groundforcepainter import (
     NavalForcePainter,
@@ -64,7 +64,7 @@ from game.point_with_heading import PointWithHeading
 from game.radio.RadioFrequencyContainer import RadioFrequencyContainer
 from game.radio.radios import RadioFrequency, RadioRegistry
 from game.radio.tacan import TacanBand, TacanChannel, TacanRegistry, TacanUsage
-from game.runways import RunwayData
+from game.runways import RunwayAssigner, RunwayData
 from game.theater import (
     ControlPoint,
     Player,
@@ -88,6 +88,9 @@ if TYPE_CHECKING:
 
 FARP_FRONTLINE_DISTANCE = 10000
 AA_CP_MIN_DISTANCE = 40000
+
+# Offset (meters) from airport position to place the portable TACAN beacon
+_PORTABLE_TACAN_OFFSET_M = 50
 
 
 def farp_truck_types_for_country(
@@ -1367,6 +1370,112 @@ class GroundSpawnGenerator:
             self.ground_spawns = []
 
 
+class PortableTacanGenerator:
+    """Places a portable TACAN beacon at an airfield that lacks a built-in one."""
+
+    def __init__(
+        self,
+        mission: Mission,
+        game: Game,
+        airfield: Airfield,
+        country: Country,
+        tacan_registry: TacanRegistry,
+        runways: Dict[str, RunwayData],
+        used_callsigns: set[str],
+    ) -> None:
+        self.mission = mission
+        self.game = game
+        self.airfield = airfield
+        self.country = country
+        self.tacan_registry = tacan_registry
+        self.runways = runways
+        self.used_callsigns = used_callsigns
+
+    def generate(self) -> None:
+        """Place a portable TACAN at this airfield if it has no built-in one."""
+        airport = self.airfield.airport
+        if not airport.runways:
+            return
+
+        # Check whether any runway of this airport already has a TACAN beacon
+        # from the terrain data.
+        assigner = RunwayAssigner(self.game.conditions)
+        runway_data = assigner.get_preferred_runway(self.game.theater, airport)
+        if runway_data.tacan is not None:
+            return
+
+        # Allocate a TACAN channel from the X band.
+        try:
+            tacan = self.tacan_registry.alloc_for_band(
+                TacanBand.X, TacanUsage.TransmitReceive
+            )
+        except Exception:
+            logging.warning(
+                "No TACAN channels available for portable beacon at %s",
+                self.airfield.name,
+            )
+            return
+
+        callsign = self._derive_callsign(self.airfield.name)
+
+        # Place the portable TACAN beacon near the airport reference point.
+        position = airport.position.point_from_heading(
+            runway_data.runway_heading.degrees + 90, _PORTABLE_TACAN_OFFSET_M
+        )
+        group = self.mission.vehicle_group(
+            country=self.country,
+            name=f"{self.airfield.name} TACAN",
+            _type=VehicleFortification.TACAN_beacon,
+            position=position,
+            group_size=1,
+            heading=runway_data.runway_heading.degrees,
+            move_formation=PointAction.OffRoad,
+        )
+
+        # Activate the TACAN beacon on the unit.
+        group.points[0].tasks.append(
+            ActivateBeaconCommand(
+                channel=tacan.number,
+                modechannel=tacan.band.value,
+                callsign=callsign,
+                unit_id=group.units[0].id,
+                aa=False,
+            )
+        )
+
+        # Store enhanced RunwayData so kneeboard / Lua exports pick it up.
+        self.runways[self.airfield.full_name] = RunwayData(
+            airfield_name=runway_data.airfield_name,
+            runway_heading=runway_data.runway_heading,
+            runway_name=runway_data.runway_name,
+            atc=runway_data.atc,
+            tacan=tacan,
+            tacan_callsign=callsign,
+            ils=runway_data.ils,
+            icls=runway_data.icls,
+        )
+
+        logging.info(
+            "Placed portable TACAN %s (%s) at %s",
+            tacan,
+            callsign,
+            self.airfield.name,
+        )
+
+    def _derive_callsign(self, name: str) -> str:
+        """Derive a unique 3-letter TACAN callsign from an airfield name."""
+        alpha = "".join(c for c in name.upper() if c.isalpha())
+        base = alpha[:3] if len(alpha) >= 3 else alpha.ljust(3, "X")
+        callsign = base
+        suffix = 0
+        while callsign in self.used_callsigns:
+            suffix += 1
+            # Replace last char to make unique
+            callsign = base[:2] + chr(ord("A") + (suffix % 26))
+        self.used_callsigns.add(callsign)
+        return callsign
+
+
 class TgoGenerator:
     """Creates DCS groups and statics for the theater during mission generation.
 
@@ -1403,6 +1512,8 @@ class TgoGenerator:
             defaultdict(list)
         )
         self.mission_data = mission_data
+        self._portable_tacan_callsigns: set[str] = set()
+        self._portable_tacan_callsigns: set[str] = set()
 
     def generate(self) -> None:
         for cp in self.game.theater.controlpoints:
@@ -1488,4 +1599,23 @@ class TgoGenerator:
                         ground_object, country, self.game, self.m, self.unit_map
                     )
                 generator.generate()
+
+            # Place portable TACAN beacons at blue airfields without built-in
+            # TACAN, if the setting is enabled.
+            if (
+                self.game.settings.generate_portable_tacans
+                and isinstance(cp, Airfield)
+                and cp.captured.is_blue
+            ):
+                portable_tacan_gen = PortableTacanGenerator(
+                    self.m,
+                    self.game,
+                    cp,
+                    country,
+                    self.tacan_registry,
+                    self.runways,
+                    self._portable_tacan_callsigns,
+                )
+                portable_tacan_gen.generate()
+
         self.mission_data.runways = list(self.runways.values())

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -1513,7 +1513,6 @@ class TgoGenerator:
         )
         self.mission_data = mission_data
         self._portable_tacan_callsigns: set[str] = set()
-        self._portable_tacan_callsigns: set[str] = set()
 
     def generate(self) -> None:
         for cp in self.game.theater.controlpoints:

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -63,7 +63,13 @@ from game.missiongenerator.missiondata import CarrierInfo, MissionData
 from game.point_with_heading import PointWithHeading
 from game.radio.RadioFrequencyContainer import RadioFrequencyContainer
 from game.radio.radios import RadioFrequency, RadioRegistry
-from game.radio.tacan import TacanBand, TacanChannel, TacanRegistry, TacanUsage
+from game.radio.tacan import (
+    OutOfTacanChannelsError,
+    TacanBand,
+    TacanChannel,
+    TacanRegistry,
+    TacanUsage,
+)
 from game.runways import RunwayAssigner, RunwayData
 from game.theater import (
     ControlPoint,
@@ -1409,7 +1415,7 @@ class PortableTacanGenerator:
             tacan = self.tacan_registry.alloc_for_band(
                 TacanBand.X, TacanUsage.TransmitReceive
             )
-        except Exception:
+        except OutOfTacanChannelsError:
             logging.warning(
                 "No TACAN channels available for portable beacon at %s",
                 self.airfield.name,
@@ -1468,10 +1474,18 @@ class PortableTacanGenerator:
         base = alpha[:3] if len(alpha) >= 3 else alpha.ljust(3, "X")
         callsign = base
         suffix = 0
+        max_variants = 26 * 26  # two-letter space for last two characters
         while callsign in self.used_callsigns:
             suffix += 1
-            # Replace last char to make unique
-            callsign = base[:2] + chr(ord("A") + (suffix % 26))
+            if suffix > max_variants:
+                raise RuntimeError(
+                    f"Exhausted TACAN callsign variants for base '{base}'"
+                )
+            # Vary the last two characters deterministically over AA..ZZ
+            first_offset, second_offset = divmod(suffix - 1, 26)
+            callsign = (
+                base[0] + chr(ord("A") + first_offset) + chr(ord("A") + second_offset)
+            )
         self.used_callsigns.add(callsign)
         return callsign
 

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -822,6 +822,17 @@ class Settings:
         GAMEPLAY_SECTION,
         default=True,
     )
+    generate_portable_tacans: bool = boolean_option(
+        "Place portable TACAN beacons at blue airfields",
+        MISSION_GENERATOR_PAGE,
+        GAMEPLAY_SECTION,
+        default=False,
+        detail=(
+            "Automatically places a portable TACAN beacon at blue-captured "
+            "airfields that don't already have a built-in TACAN from the "
+            "terrain data. An unused X-band channel is assigned to each."
+        ),
+    )
     generate_marks: bool = boolean_option(
         "Put objective markers on the map",
         MISSION_GENERATOR_PAGE,

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1338,6 +1338,10 @@ class Airfield(ControlPoint, CTLD):
         conditions: Conditions,
         dynamic_runways: Dict[str, RunwayData],
     ) -> RunwayData:
+        # Check for a dynamic runway override first (e.g. portable TACAN).
+        if self.full_name in dynamic_runways:
+            return dynamic_runways[self.full_name]
+
         if not self.airport.runways:
             # Some airfields are heliports and don't have any runways. This isn't really
             # the best fix, since we should still try to generate partial data for TACAN

--- a/tests/test_portable_tacan.py
+++ b/tests/test_portable_tacan.py
@@ -8,6 +8,7 @@ import pytest
 
 from game.missiongenerator.tgogenerator import PortableTacanGenerator
 from game.radio.tacan import (
+    OutOfTacanChannelsError,
     TacanBand,
     TacanChannel,
     TacanRegistry,
@@ -79,6 +80,25 @@ class TestCallsignDerivation:
         assert cs != "KUT"
         assert len(cs) == 3
         assert cs in gen.used_callsigns
+
+    def test_duplicate_varies_two_chars(self) -> None:
+        """When base is taken, the new callsign keeps first char and varies last two."""
+        gen = self._make_generator(used={"KUT"})
+        cs = gen._derive_callsign("Kutaisi")
+        # First collision: suffix=1 -> divmod(0,26) -> (0,0) -> K + A + A
+        assert cs == "KAA"
+
+    def test_callsign_exhaustion_raises(self) -> None:
+        """RuntimeError should be raised when all 676 variants are exhausted."""
+        # Fill all possible 3-letter callsigns starting with 'K'
+        used: set[str] = set()
+        used.add("KUT")  # the base
+        for i in range(26):
+            for j in range(26):
+                used.add("K" + chr(ord("A") + i) + chr(ord("A") + j))
+        gen = self._make_generator(used=used)
+        with pytest.raises(RuntimeError, match="Exhausted TACAN callsign variants"):
+            gen._derive_callsign("Kutaisi")
 
     def test_callsign_added_to_used(self) -> None:
         gen = self._make_generator()

--- a/tests/test_portable_tacan.py
+++ b/tests/test_portable_tacan.py
@@ -1,0 +1,191 @@
+"""Tests for the PortableTacanGenerator feature."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from game.missiongenerator.tgogenerator import PortableTacanGenerator
+from game.radio.tacan import (
+    TacanBand,
+    TacanChannel,
+    TacanRegistry,
+    TacanUsage,
+)
+from game.runways import RunwayData
+from game.utils import Heading
+
+
+def _make_runway_data(
+    name: str = "TestAirfield",
+    heading: int = 90,
+    tacan: TacanChannel | None = None,
+    tacan_callsign: str | None = None,
+) -> RunwayData:
+    return RunwayData(
+        airfield_name=name,
+        runway_heading=Heading.from_degrees(heading),
+        runway_name="09",
+        tacan=tacan,
+        tacan_callsign=tacan_callsign,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Callsign derivation tests
+# ---------------------------------------------------------------------------
+
+
+class TestCallsignDerivation:
+    """Test _derive_callsign logic."""
+
+    @staticmethod
+    def _make_generator(
+        used: set[str] | None = None,
+    ) -> PortableTacanGenerator:
+        gen = PortableTacanGenerator.__new__(PortableTacanGenerator)
+        gen.used_callsigns = used or set()
+        return gen
+
+    def test_normal_name(self) -> None:
+        gen = self._make_generator()
+        assert gen._derive_callsign("Kutaisi") == "KUT"
+
+    def test_name_with_spaces(self) -> None:
+        gen = self._make_generator()
+        assert gen._derive_callsign("Al Dhafra") == "ALD"
+
+    def test_short_name(self) -> None:
+        gen = self._make_generator()
+        cs = gen._derive_callsign("AB")
+        assert len(cs) == 3
+        assert cs == "ABX"
+
+    def test_single_char_name(self) -> None:
+        gen = self._make_generator()
+        cs = gen._derive_callsign("X")
+        assert cs == "XXX"
+
+    def test_name_with_numbers(self) -> None:
+        gen = self._make_generator()
+        cs = gen._derive_callsign("H4")
+        assert len(cs) == 3
+        assert cs == "HXX"
+
+    def test_duplicate_avoidance(self) -> None:
+        gen = self._make_generator(used={"KUT"})
+        cs = gen._derive_callsign("Kutaisi")
+        assert cs != "KUT"
+        assert len(cs) == 3
+        assert cs in gen.used_callsigns
+
+    def test_callsign_added_to_used(self) -> None:
+        gen = self._make_generator()
+        cs = gen._derive_callsign("Batumi")
+        assert cs in gen.used_callsigns
+
+
+# ---------------------------------------------------------------------------
+# Generation skip-conditions tests (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestPortableTacanSkipsWhenAlreadyPresent:
+    """PortableTacanGenerator.generate() should skip airfields with existing TACAN."""
+
+    def test_skip_when_tacan_exists(self) -> None:
+        """No portable TACAN should be placed if the airfield already has one."""
+        existing_tacan = TacanChannel(25, TacanBand.X)
+        runway_with_tacan = _make_runway_data(
+            tacan=existing_tacan, tacan_callsign="BTM"
+        )
+
+        gen = PortableTacanGenerator.__new__(PortableTacanGenerator)
+        gen.airfield = MagicMock()
+        gen.airfield.airport.runways = [MagicMock()]  # has runways
+        gen.airfield.name = "Batumi"
+        gen.game = MagicMock()
+        gen.tacan_registry = TacanRegistry()
+        gen.runways = {}
+        gen.used_callsigns = set()
+        gen.mission = MagicMock()
+        gen.country = MagicMock()
+
+        with patch("game.missiongenerator.tgogenerator.RunwayAssigner") as MockAssigner:
+            mock_assigner = MockAssigner.return_value
+            mock_assigner.get_preferred_runway.return_value = runway_with_tacan
+            gen.generate()
+
+        # No TACAN should have been allocated, no runway stored
+        assert len(gen.runways) == 0
+
+    def test_skip_when_no_runways(self) -> None:
+        """Heliports without runways should be skipped."""
+        gen = PortableTacanGenerator.__new__(PortableTacanGenerator)
+        gen.airfield = MagicMock()
+        gen.airfield.airport.runways = []
+        gen.runways = {}
+        gen.generate()
+        assert len(gen.runways) == 0
+
+    def test_places_tacan_when_none_exists(self) -> None:
+        """A portable TACAN should be placed at an airfield without one."""
+        runway_no_tacan = _make_runway_data()
+        registry = TacanRegistry()
+
+        gen = PortableTacanGenerator.__new__(PortableTacanGenerator)
+        gen.airfield = MagicMock()
+        gen.airfield.airport.runways = [MagicMock()]
+        gen.airfield.airport.position = MagicMock()
+        gen.airfield.airport.position.point_from_heading.return_value = MagicMock()
+        gen.airfield.name = "TestAirfield"
+        gen.airfield.full_name = "TestAirfield"
+        gen.game = MagicMock()
+        gen.tacan_registry = registry
+        gen.runways = {}
+        gen.used_callsigns = set()
+        gen.mission = MagicMock()
+        gen.country = MagicMock()
+
+        mock_group = MagicMock()
+        gen.mission.vehicle_group.return_value = mock_group
+
+        with patch("game.missiongenerator.tgogenerator.RunwayAssigner") as MockAssigner:
+            mock_assigner = MockAssigner.return_value
+            mock_assigner.get_preferred_runway.return_value = runway_no_tacan
+            gen.generate()
+
+        assert "TestAirfield" in gen.runways
+        stored = gen.runways["TestAirfield"]
+        assert stored.tacan is not None
+        assert stored.tacan.band == TacanBand.X
+        assert stored.tacan_callsign == "TES"
+
+    def test_graceful_when_channels_exhausted(self) -> None:
+        """Should log a warning and skip if no channels are available."""
+        runway_no_tacan = _make_runway_data()
+        registry = TacanRegistry()
+
+        # Exhaust all valid X-band TransmitReceive channels
+        for ch in TacanBand.X.valid_channels(TacanUsage.TransmitReceive):
+            registry.mark_unavailable(ch)
+
+        gen = PortableTacanGenerator.__new__(PortableTacanGenerator)
+        gen.airfield = MagicMock()
+        gen.airfield.airport.runways = [MagicMock()]
+        gen.airfield.name = "ExhaustedAirfield"
+        gen.game = MagicMock()
+        gen.tacan_registry = registry
+        gen.runways = {}
+        gen.used_callsigns = set()
+        gen.mission = MagicMock()
+        gen.country = MagicMock()
+
+        with patch("game.missiongenerator.tgogenerator.RunwayAssigner") as MockAssigner:
+            mock_assigner = MockAssigner.return_value
+            mock_assigner.get_preferred_runway.return_value = runway_no_tacan
+            # Should not raise
+            gen.generate()
+
+        assert len(gen.runways) == 0


### PR DESCRIPTION
Added an option - When OWNFOR captures an airfield, if it doesn't normally have a TACAN, this will give it one.

- Implement PortableTacanGenerator to place TACAN beacons at airfields without built-in TACANs.
- Introduce a setting to enable automatic placement of portable TACANs at blue-captured airfields.
- Update control point logic to check for dynamic runway overrides.
- Add unit tests for PortableTacanGenerator, covering callsign derivation and generation conditions.