### PR TITLE
Fix weapons introduction year handling in factions

### DIFF
--- a/game/data/weapons.py
+++ b/game/data/weapons.py
@@ -104,8 +104,11 @@ class Weapon:
 
     def available_on(self, date: datetime.date, faction: Faction) -> bool:
         introduction_year = self.weapon_group.introduction_year
-        if self.weapon_group.name in faction.weapons_introduction_year_overrides:
-            introduction_year = faction.weapons_introduction_year_overrides[
+        faction_introduction_year_overrides = getattr(
+            faction, "weapons_introduction_year_overrides", {}
+        )
+        if self.weapon_group.name in faction_introduction_year_overrides:
+            introduction_year = faction_introduction_year_overrides[
                 self.weapon_group.name
             ]
         if introduction_year is None:

--- a/game/factions/faction.py
+++ b/game/factions/faction.py
@@ -134,6 +134,11 @@ class Faction:
     #: weapons groups to their introduction years.
     weapons_introduction_year_overrides: Dict[str, int] = field(default_factory=dict)
 
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        if not hasattr(self, "weapons_introduction_year_overrides"):
+            self.weapons_introduction_year_overrides = {}
+
     def has_access_to_dcs_type(self, unit_type: Type[DcsUnitType]) -> bool:
         # Vehicle and Ship Units
         if any(unit_type == u.dcs_unit_type for u in self.accessible_units):


### PR DESCRIPTION
This will fix older missions with factions that didn't include years.

Added pickle migration handling in [faction.py:137](vscode-file://vscode-app/c:/Users/bob/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so unpickled legacy [Faction](vscode-file://vscode-app/c:/Users/bob/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instances always get [weapons_introduction_year_overrides = {}](vscode-file://vscode-app/c:/Users/bob/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) when missing.
Hardened lookup in [weapons.py:107](vscode-file://vscode-app/c:/Users/bob/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use a safe fallback if that attribute is absent on a faction object.

```
'Faction' object has no attribute 'weapons_introduction_year_overrides'

Traceback (most recent call last):
  File "Z:\code\dcs-retribution\qt_ui\widgets\ato.py", line 125, in on_double_click
    self.edit_flight(index)
  File "Z:\code\dcs-retribution\qt_ui\widgets\ato.py", line 130, in edit_flight
    Dialog.open_edit_flight_dialog(
  File "Z:\code\dcs-retribution\qt_ui\dialogs.py", line 56, in open_edit_flight_dialog
    cls.edit_flight_dialog = QEditFlightDialog(
                             ^^^^^^^^^^^^^^^^^^
  File "Z:\code\dcs-retribution\qt_ui\windows\mission\QEditFlightDialog.py", line 39, in __init__
    self.flight_planner = QFlightPlanner(package_model, flight, game_model)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Z:\code\dcs-retribution\qt_ui\windows\mission\flight\QFlightPlanner.py", line 19, in __init__
    self.payload_tab = QFlightPayloadTab(flight, gm.game)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Z:\code\dcs-retribution\qt_ui\windows\mission\flight\payload\QFlightPayloadTab.py", line 120, in __init__
    self.payload_editor = QLoadoutEditor(
                          ^^^^^^^^^^^^^^^
  File "Z:\code\dcs-retribution\qt_ui\windows\mission\flight\payload\QLoadoutEditor.py", line 49, in __init__
    layout.addWidget(QPylonEditor(game, flight, flight_member, pylon), i, 1)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Z:\code\dcs-retribution\qt_ui\windows\mission\flight\payload\QPylonEditor.py", line 34, in __init__
    allowed = sorted(weapons, key=operator.attrgetter("name"))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Z:\code\dcs-retribution\game\data\weapons.py", line 297, in available_on
    if weapon.available_on(date, faction):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Z:\code\dcs-retribution\game\data\weapons.py", line 107, in available_on
    if self.weapon_group.name in faction.weapons_introduction_year_overrides:
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Faction' object has no attribute 'weapons_introduction_year_overrides'
```
