### PR TITLE
Added mid-campaign faction doctrine changing

### DIFF
--- a/qt_ui/windows/AirWingDialog.py
+++ b/qt_ui/windows/AirWingDialog.py
@@ -280,6 +280,7 @@ class AirWingTabs(QTabWidget):
             game_model.game.coalition_for(Player.BLUE).faction,
             self,
             show_jtac=True,
+            show_doctrine=True,
         )
         qfu_ownfor.preset_groups_changed.connect(self.preset_group_updated_ownfor)
         self.addTab(
@@ -290,6 +291,7 @@ class AirWingTabs(QTabWidget):
             game_model.game.coalition_for(Player.RED).faction,
             self,
             show_jtac=True,
+            show_doctrine=True,
         )
         qfu_opfor.preset_groups_changed.connect(self.preset_group_updated_opfor)
         self.addTab(

--- a/qt_ui/windows/newgame/WizardPages/QFactionSelection.py
+++ b/qt_ui/windows/newgame/WizardPages/QFactionSelection.py
@@ -26,6 +26,7 @@ from game import persistency
 from game.armedforces.forcegroup import ForceGroup
 from game.ato import FlightType
 from game.campaignloader import Campaign
+from game.data.doctrine import ALL_DOCTRINES
 from game.dcs.aircrafttype import AircraftType
 from game.dcs.groundunittype import GroundUnitType
 from game.dcs.shipunittype import ShipUnitType
@@ -38,15 +39,23 @@ from qt_ui.windows.newgame.jinja_env import jinja_env
 class QFactionUnits(QScrollArea):
     preset_groups_changed = Signal(Faction)
 
-    def __init__(self, faction: Faction, parent=None, show_jtac: bool = False):
+    def __init__(
+        self,
+        faction: Faction,
+        parent=None,
+        show_jtac: bool = False,
+        show_doctrine: bool = False,
+    ):
         super().__init__()
         self.setWidgetResizable(True)
         self.content = QWidget()
         self.setWidget(self.content)
         self.parent = parent
         self.faction = faction
-        self._create_checkboxes(show_jtac)
+        self.doctrine_combo: Optional[QComboBox] = None
+        self._create_checkboxes(show_jtac, show_doctrine)
         self.show_jtac = show_jtac
+        self.show_doctrine = show_doctrine
 
     def _add_checkboxes(
         self,
@@ -68,11 +77,26 @@ class QFactionUnits(QScrollArea):
         counter += 1
         return counter
 
-    def _create_checkboxes(self, show_jtac: bool) -> None:
+    def _create_checkboxes(self, show_jtac: bool, show_doctrine: bool) -> None:
         counter = 0
         self.checkboxes: dict[str, QCheckBox] = {}
         grid = QGridLayout()
         grid.setColumnStretch(1, 1)
+        if show_doctrine:
+            self.doctrine_combo = QComboBox()
+            doctrine_options = list(ALL_DOCTRINES)
+            if self.faction.doctrine not in doctrine_options:
+                doctrine_options.insert(0, self.faction.doctrine)
+
+            for doctrine in doctrine_options:
+                self.doctrine_combo.addItem(doctrine.name, doctrine)
+
+            self.doctrine_combo.setCurrentText(self.faction.doctrine.name)
+            self.doctrine_combo.currentIndexChanged.connect(self._set_doctrine)
+            grid.addWidget(QLabel("<strong>Doctrine:</strong>"), counter, 0)
+            grid.addWidget(self.doctrine_combo, counter, 1)
+            counter += 2
+
         self.add_ac_combo = QComboBox()
         hbox = self._create_aircraft_combobox(
             self.add_ac_combo,
@@ -216,6 +240,9 @@ class QFactionUnits(QScrollArea):
     def _set_jtac(self, state: bool) -> None:
         self.faction.has_jtac = state
 
+    def _set_doctrine(self, _: int) -> None:
+        self.faction.doctrine = self.doctrine_combo.currentData()
+
     def _aircraft_predicate(self, ac: AircraftType):
         if (
             FlightType.AEWC not in ac.task_priorities
@@ -309,7 +336,7 @@ class QFactionUnits(QScrollArea):
         self.faction = faction
         self.content = QWidget()
         self.setWidget(self.content)
-        self._create_checkboxes(self.show_jtac)
+        self._create_checkboxes(self.show_jtac, self.show_doctrine)
         self.update()
         if self.parent:
             self.parent.update()


### PR DESCRIPTION
This change allows the user to change the doctrine of a faction, mid-campaign. Because they might have picked the wrong one at the start.

<img width="1009" height="269" alt="image" src="https://github.com/user-attachments/assets/9e338789-4d15-4425-bdb6-096c2fb0a4af" />

Here is a table describing the doctrine settings that you might want to add to the wiki:

| Parameter | Modern | Cold War | WWII |
|---|---:|---:|---:|
| CAP Enabled | Yes | Yes | Yes |
| CAS Enabled | Yes | Yes | Yes |
| SEAD Enabled | Yes | Yes | No |
| Strike Enabled | Yes | Yes | Yes |
| Anti-ship Enabled | Yes | Yes | Yes |
| Hold Distance | 25 nm | 15 nm | 10 nm |
| Push Distance | 20 nm | 10 nm | 5 nm |
| Join Distance | 20 nm | 10 nm | 5 nm |
| Min Ingress Distance | 10 nm | 10 nm | 5 nm |
| Max Ingress Distance | 45 nm | 30 nm | 7 nm |
| Min Patrol Altitude | 15,000 ft | 10,000 ft | 4,000 ft |
| Max Patrol Altitude | 33,000 ft | 24,000 ft | 15,000 ft |
| Min Cruise Altitude | 10,000 ft | 10,000 ft | 5,000 ft |
| Max Cruise Altitude | 40,000 ft | 30,000 ft | 30,000 ft |
| Min Combat Altitude | 1,000 ft | 1,000 ft | 1,000 ft |
| Max Combat Altitude | 35,000 ft | 25,000 ft | 10,000 ft |
| CAP Duration | 30 min | 30 min | 30 min |
| CAP Min Track Length | 15 nm | 12 nm | 8 nm |
| CAP Max Track Length | 40 nm | 24 nm | 18 nm |
| CAP Min Distance from CP | 10 nm | 8 nm | 0 nm |
| CAP Max Distance from CP | 40 nm | 25 nm | 5 nm |
| CAP Engagement Range | 50 nm | 35 nm | 20 nm |
| CAS Duration | 30 min | 30 min | 30 min |
| Sweep Distance | 60 nm | 40 nm | 10 nm |
| RTB Speed | 500 kts | 450 kts | 300 kts |
| SEAD Escort Spacing | 1,000 ft | 500 ft | 100 ft |
| Escort Spacing | 2,000 ft | 1,000 ft | 200 ft |
| SEAD Escort Engagement Range | 40 nm | 25 nm | 10 nm |
| Escort Engagement Range | 30 nm | 20 nm | 5 nm |
| Procurement Ratio: TANK | 3 | 4 | 3 |
| Procurement Ratio: ATGM | 2 | 2 | 3 |
| Procurement Ratio: APC | 2 | 3 | 3 |
| Procurement Ratio: IFV | 3 | 2 | — |
| Procurement Ratio: ARTILLERY | 1 | 1 | 1 |
| Procurement Ratio: SHORAD | 2 | 2 | 3 |
| Procurement Ratio: RECON | 1 | 1 | 1 |