### PR TITLE
Allow A-6 Intruder to fill tanker/recovery role

### DIFF
--- a/resources/units/aircraft/A6E.yaml
+++ b/resources/units/aircraft/A6E.yaml
@@ -24,3 +24,5 @@ tasks:
   SEAD: 120
   SEAD Escort: 120
   Strike: 360
+  Refueling: 0
+  Recovery: 0


### PR DESCRIPTION
The tanker and recovery mission types are not auto-selected under Auto-Assigned mission types, which I am assuming is due to their aircraft role (Carrier-based Attack rather than Carrier-based Tanker?). That will still have to be fixed.