### PR TITLE
fix live state tracking wrt TGO and trigger zones

### DIFF
--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -458,7 +458,9 @@ class GroundObjectGenerator:
         # map objects and add them to the state.json with a DoScript
         t = TriggerOnce(Event.NoEvent, f"MapObjectIsDead Trigger {trigger_zone.id}")
         t.add_condition(MapObjectIsDead(trigger_zone.id))
-        script_string = String(f'dead_events[#dead_events + 1] = "{trigger_zone.name}"')
+        script_string = String(
+            f'dead_events[#dead_events + 1] = "{trigger_zone.name}"\ndirty_state = true'
+        )
         t.actions.append(DoScript(script_string))
         self.m.triggerrules.triggers.append(t)
 

--- a/game/missiongenerator/triggergenerator.py
+++ b/game/missiongenerator/triggergenerator.py
@@ -211,7 +211,7 @@ class TriggerGenerator:
             trigger.add_action(SetFlag(flag=flag))
 
         script_string = String(
-            f'base_capture_events[#base_capture_events + 1] = "{cp.id}||{capturing_coalition_int}||{cp.full_name}"'
+            f'base_capture_events[#base_capture_events + 1] = "{cp.id}||{capturing_coalition_int}||{cp.full_name}"\ndirty_state = true'
         )
         trigger.add_action(DoScript(script_string))
         return trigger


### PR DESCRIPTION
This fixes a bug where some events created by triggers don't set the dirty state flag so they are not being written to the state file until the end of the mission.