### PR TITLE
remove unnecessary explicit dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,6 @@ types-MarkupSafe==1.1.10
 types-Pillow==10.2.0.20240822
 types-PyYAML==6.0.12.20241230
 types-tabulate==0.9.0.20241207
-typing_extensions==4.13.0rc1
 uvicorn==0.34.0
 virtualenv==20.36.1
 watchgod==0.8.2


### PR DESCRIPTION
Remove typing_extensions explicit dependency to let pip deconflict the dependencies.

Error:
```
The conflict is caused by:
    The user requested typing_extensions==4.13.0rc1
    asgiref 3.8.1 depends on typing-extensions>=4; python_version < "3.11"
    black 26.1.0 depends on typing-extensions>=4.0.1; python_version < "3.11"
    fastapi 0.124.4 depends on typing-extensions>=4.8.0
    mypy 1.15.0 depends on typing_extensions>=4.6.0
    pydantic 2.11.0b2 depends on typing-extensions>=4.12.2
    starlette 0.49.1 depends on typing-extensions>=4.10.0; python_version < "3.13"
    uvicorn 0.34.0 depends on typing-extensions>=4.0; python_version < "3.11"
    virtualenv 20.36.1 depends on typing-extensions>=4.13.2; python_version < "3.11"
```