### PR TITLE
Fix waypoint solver GeoJSON precision drift

### DIFF
--- a/game/flightplan/waypointsolver.py
+++ b/game/flightplan/waypointsolver.py
@@ -22,6 +22,8 @@ class NoSolutionsError(RuntimeError):
 
 
 class WaypointSolver:
+    GEOJSON_COORDINATE_PRECISION = 13
+
     def __init__(self) -> None:
         self.strategies: list[WaypointStrategy] = []
         self.debug_output_directory: Path | None = None
@@ -48,7 +50,12 @@ class WaypointSolver:
                 latlng = p.latlng()
                 # Longitude is unintuitively first because it's the "X" coordinate:
                 # https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1
-                ll_points.append([latlng.lng, latlng.lat])
+                ll_points.append(
+                    [
+                        round(latlng.lng, self.GEOJSON_COORDINATE_PRECISION),
+                        round(latlng.lat, self.GEOJSON_COORDINATE_PRECISION),
+                    ]
+                )
             return array(ll_points)
 
         transformed = transform(geometry, xy_to_ll)

--- a/tests/flightplan/test_waypointsolver.py
+++ b/tests/flightplan/test_waypointsolver.py
@@ -158,7 +158,7 @@ def test_no_solutions_dumps_inputs(tmp_path: Path) -> None:
                 "properties": {"description": "foo"},
                 "geometry": {
                     "type": "Point",
-                    "coordinates": [34.265515188456, 45.129497060328966],
+                    "coordinates": [34.265515188456, 45.129497060329],
                 },
             },
             {
@@ -166,7 +166,7 @@ def test_no_solutions_dumps_inputs(tmp_path: Path) -> None:
                 "properties": {"description": "bar"},
                 "geometry": {
                     "type": "Point",
-                    "coordinates": [34.265528100962584, 45.1295059189547],
+                    "coordinates": [34.2655281009626, 45.1295059189547],
                 },
             },
         ],
@@ -194,7 +194,7 @@ def test_solver_inputs_appear_in_strategy_features(tmp_path: Path) -> None:
                 "properties": {"description": "foo"},
                 "geometry": {
                     "type": "Point",
-                    "coordinates": [34.265515188456, 45.129497060328966],
+                    "coordinates": [34.265515188456, 45.129497060329],
                 },
             },
             {
@@ -202,14 +202,14 @@ def test_solver_inputs_appear_in_strategy_features(tmp_path: Path) -> None:
                 "properties": {"description": "bar"},
                 "geometry": {
                     "type": "Point",
-                    "coordinates": [34.265528100962584, 45.1295059189547],
+                    "coordinates": [34.2655281009626, 45.1295059189547],
                 },
             },
             {
                 "type": "Feature",
                 "properties": {"description": "solution"},
                 "geometry": {
-                    "coordinates": [34.265541013473154, 45.12951477757893],
+                    "coordinates": [34.2655410134732, 45.1295147775789],
                     "type": "Point",
                 },
             },
@@ -221,7 +221,7 @@ def test_to_geojson(tmp_path: Path) -> None:
     solver = WaypointSolver()
     solver.set_debug_properties(tmp_path, Caucasus())
     assert solver.to_geojson(Point(0, 0)) == {
-        "coordinates": [34.265515188456, 45.129497060328966],
+        "coordinates": [34.265515188456, 45.129497060329],
         "type": "Point",
     }
 


### PR DESCRIPTION
Summary:
- Stabilizes waypoint debug GeoJSON coordinate precision to prevent platform-specific floating-point drift.
- Applies the fix in game/flightplan/waypointsolver.py.
- Updates strict regression expectations in tests/flightplan/test_waypointsolver.py.
- Scope is intentionally waypoint-only (no UK/CurrentHill files, no changelog entry).

Validation:
- Waypoint-specific tests pass.
- Full suite result from the validation run: 553 passed, 2 skipped.