### PR TITLE
Assign per-weapon laser codes when assigning unique laser codes to planes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@
 ## Fixes
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
-
+* **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission
 
 # Retribution v1.5.0
 

--- a/game/data/weapons.py
+++ b/game/data/weapons.py
@@ -130,6 +130,17 @@ class Weapon:
         except Exception:
             return False
 
+    def accepts_laser_code(self) -> bool:
+        try:
+            settings = self.pydcs_data.get("settings")
+        except Exception:
+            return False
+        if not isinstance(settings, list):
+            return False
+        return any(
+            isinstance(s, dict) and s.get("id") == "laser_code" for s in settings
+        )
+
     def create_settings(
         self, initial_values: Optional[Dict[str, Any]] = None
     ) -> Optional[WeaponSettings]:

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -17,7 +17,7 @@ from dcs.unitgroup import FlyingGroup
 from game.ato import Flight, FlightType
 from game.ato.flightplans.shiprecoverytanker import RecoveryTankerFlightPlan
 from game.callsigns import callsign_for_support_unit
-from game.data.weapons import Pylon, Weapon, WeaponType
+from game.data.weapons import Pylon, WeaponType
 from game.lasercodes.lasercode import LaserCode
 from game.missiongenerator.logisticsgenerator import LogisticsGenerator
 from game.missiongenerator.missiondata import MissionData, AwacsInfo, TankerInfo
@@ -437,7 +437,7 @@ class FlightGroupConfigurator:
             pylon = Pylon.for_aircraft(self.flight.unit_type, pylon_number)
             settings = self._merge_laser_code(
                 loadout.pylon_settings.get(pylon_number),
-                weapon,
+                weapon.accepts_laser_code(),
                 member.weapon_laser_code,
             )
             pylon.equip(unit, weapon, settings)
@@ -445,10 +445,10 @@ class FlightGroupConfigurator:
     @staticmethod
     def _merge_laser_code(
         base: Optional[dict[str, Any]],
-        weapon: Weapon,
+        accepts_laser_code: bool,
         laser_code: Optional[LaserCode],
     ) -> Optional[dict[str, Any]]:
-        if laser_code is None or weapon.weapon_group.type is not WeaponType.LGB:
+        if laser_code is None or not accepts_laser_code:
             return base
         settings = dict(base or {})
         settings["laser_code"] = laser_code.code

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -17,7 +17,8 @@ from dcs.unitgroup import FlyingGroup
 from game.ato import Flight, FlightType
 from game.ato.flightplans.shiprecoverytanker import RecoveryTankerFlightPlan
 from game.callsigns import callsign_for_support_unit
-from game.data.weapons import Pylon, WeaponType
+from game.data.weapons import Pylon, Weapon, WeaponType
+from game.lasercodes.lasercode import LaserCode
 from game.missiongenerator.logisticsgenerator import LogisticsGenerator
 from game.missiongenerator.missiondata import MissionData, AwacsInfo, TankerInfo
 from game.radio.radios import RadioFrequency, RadioRegistry
@@ -434,9 +435,24 @@ class FlightGroupConfigurator:
             if weapon is None:
                 continue
             pylon = Pylon.for_aircraft(self.flight.unit_type, pylon_number)
-            # Get weapon settings for this pylon if they exist
-            settings = loadout.pylon_settings.get(pylon_number)
+            settings = self._merge_laser_code(
+                loadout.pylon_settings.get(pylon_number),
+                weapon,
+                member.weapon_laser_code,
+            )
             pylon.equip(unit, weapon, settings)
+
+    @staticmethod
+    def _merge_laser_code(
+        base: Optional[dict[str, Any]],
+        weapon: Weapon,
+        laser_code: Optional[LaserCode],
+    ) -> Optional[dict[str, Any]]:
+        if laser_code is None or weapon.weapon_group.type is not WeaponType.LGB:
+            return base
+        settings = dict(base or {})
+        settings["laser_code"] = laser_code.code
+        return settings
 
     def setup_fuel(self) -> None:
         fuel = self.flight.state.estimate_fuel()

--- a/resources/weapons/rockets/AGR-20 M282.yaml
+++ b/resources/weapons/rockets/AGR-20 M282.yaml
@@ -1,4 +1,5 @@
 name: LAU-131 7xMPP APKWS
+type: LGB
 year: 2012
 fallback: AGM-65E2/L
 clsids:

--- a/resources/weapons/rockets/AGR-20 M282.yaml
+++ b/resources/weapons/rockets/AGR-20 M282.yaml
@@ -1,5 +1,4 @@
 name: LAU-131 7xMPP APKWS
-type: LGB
 year: 2012
 fallback: AGM-65E2/L
 clsids:

--- a/resources/weapons/rockets/AGR-20A.yaml
+++ b/resources/weapons/rockets/AGR-20A.yaml
@@ -1,4 +1,5 @@
 name: LAU-131 7xHE APKWS
+type: LGB
 year: 2012
 fallback: AGM-65E2/L
 clsids:

--- a/resources/weapons/rockets/AGR-20A.yaml
+++ b/resources/weapons/rockets/AGR-20A.yaml
@@ -1,5 +1,4 @@
 name: LAU-131 7xHE APKWS
-type: LGB
 year: 2012
 fallback: AGM-65E2/L
 clsids:

--- a/tests/data/test_weapons.py
+++ b/tests/data/test_weapons.py
@@ -1,0 +1,38 @@
+import pytest
+
+from game.data.weapons import Weapon, WeaponGroup, WeaponType
+
+
+def _bare_weapon(clsid: str) -> Weapon:
+    group = WeaponGroup(
+        name=f"test-{clsid}",
+        type=WeaponType.UNKNOWN,
+        introduction_year=None,
+        fallback_name=None,
+    )
+    return Weapon(clsid=clsid, weapon_group=group)
+
+
+@pytest.mark.parametrize(
+    "clsid",
+    [
+        "{LAU-131 - 7 AGR-20A}",
+        "{LAU-131 - 7 AGR-20 M282}",
+        "{BRU-32 GBU-12}",
+        "DIS_GBU_12",
+    ],
+)
+def test_accepts_laser_code_true_for_laser_guided_weapons(clsid: str) -> None:
+    assert _bare_weapon(clsid).accepts_laser_code() is True
+
+
+@pytest.mark.parametrize(
+    "clsid",
+    [
+        "<CLEAN>",
+        "{AUF2_MK82}",
+        "definitely-not-a-real-clsid",
+    ],
+)
+def test_accepts_laser_code_false_for_non_laser_or_unknown(clsid: str) -> None:
+    assert _bare_weapon(clsid).accepts_laser_code() is False

--- a/tests/missiongenerator/aircraft/test_flightgroupconfigurator.py
+++ b/tests/missiongenerator/aircraft/test_flightgroupconfigurator.py
@@ -1,8 +1,7 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import pytest
 
-from game.data.weapons import Weapon, WeaponGroup, WeaponType
 from game.lasercodes.ilasercoderegistry import ILaserCodeRegistry
 from game.lasercodes.lasercode import LaserCode
 from game.missiongenerator.aircraft.flightgroupconfigurator import (
@@ -18,75 +17,53 @@ class _StubRegistry(ILaserCodeRegistry):
         pass
 
 
-def _weapon(weapon_type: WeaponType) -> Weapon:
-    group = WeaponGroup(
-        name=f"test-{weapon_type.value}",
-        type=weapon_type,
-        introduction_year=None,
-        fallback_name=None,
-    )
-    return Weapon(clsid=f"test-clsid-{weapon_type.value}", weapon_group=group)
-
-
 @pytest.fixture(name="laser_code")
 def laser_code_fixture() -> LaserCode:
     return LaserCode(1511, _StubRegistry())
 
 
-def test_merge_inserts_laser_code_when_lgb_and_no_existing_settings(
+def test_merge_inserts_laser_code_when_accepted_and_no_existing_settings(
     laser_code: LaserCode,
 ) -> None:
-    result = FlightGroupConfigurator._merge_laser_code(
-        None, _weapon(WeaponType.LGB), laser_code
-    )
+    result = FlightGroupConfigurator._merge_laser_code(None, True, laser_code)
     assert result == {"laser_code": 1511}
 
 
-def test_merge_preserves_other_settings_when_lgb(laser_code: LaserCode) -> None:
+def test_merge_preserves_other_settings_when_accepted(laser_code: LaserCode) -> None:
     base: Dict[str, Any] = {"fuze_setting": "instant"}
-    result = FlightGroupConfigurator._merge_laser_code(
-        base, _weapon(WeaponType.LGB), laser_code
-    )
+    result = FlightGroupConfigurator._merge_laser_code(base, True, laser_code)
     assert result == {"fuze_setting": "instant", "laser_code": 1511}
 
 
-def test_merge_overrides_existing_laser_code_when_lgb(
+def test_merge_overrides_existing_laser_code_when_accepted(
     laser_code: LaserCode,
 ) -> None:
     base: Dict[str, Any] = {"laser_code": 1688}
-    result = FlightGroupConfigurator._merge_laser_code(
-        base, _weapon(WeaponType.LGB), laser_code
-    )
+    result = FlightGroupConfigurator._merge_laser_code(base, True, laser_code)
     assert result == {"laser_code": 1511}
 
 
-def test_merge_returns_base_unchanged_for_non_lgb(laser_code: LaserCode) -> None:
+def test_merge_returns_base_unchanged_when_not_accepted(
+    laser_code: LaserCode,
+) -> None:
     base: Dict[str, Any] = {"fuze_setting": "instant"}
-    result = FlightGroupConfigurator._merge_laser_code(
-        base, _weapon(WeaponType.ARM), laser_code
-    )
+    result = FlightGroupConfigurator._merge_laser_code(base, False, laser_code)
     assert result is base
 
 
 def test_merge_returns_base_unchanged_when_no_laser_code() -> None:
     base: Dict[str, Any] = {"fuze_setting": "instant"}
-    result = FlightGroupConfigurator._merge_laser_code(
-        base, _weapon(WeaponType.LGB), None
-    )
+    result = FlightGroupConfigurator._merge_laser_code(base, True, None)
     assert result is base
 
 
 def test_merge_returns_none_when_no_laser_code_and_no_base() -> None:
-    result = FlightGroupConfigurator._merge_laser_code(
-        None, _weapon(WeaponType.LGB), None
-    )
+    result = FlightGroupConfigurator._merge_laser_code(None, True, None)
     assert result is None
 
 
 def test_merge_does_not_mutate_input_base(laser_code: LaserCode) -> None:
     base: Dict[str, Any] = {"laser_code": 1688, "fuze_setting": "instant"}
     snapshot = dict(base)
-    FlightGroupConfigurator._merge_laser_code(
-        base, _weapon(WeaponType.LGB), laser_code
-    )
+    FlightGroupConfigurator._merge_laser_code(base, True, laser_code)
     assert base == snapshot

--- a/tests/missiongenerator/aircraft/test_flightgroupconfigurator.py
+++ b/tests/missiongenerator/aircraft/test_flightgroupconfigurator.py
@@ -1,0 +1,92 @@
+from typing import Any, Dict, Optional
+
+import pytest
+
+from game.data.weapons import Weapon, WeaponGroup, WeaponType
+from game.lasercodes.ilasercoderegistry import ILaserCodeRegistry
+from game.lasercodes.lasercode import LaserCode
+from game.missiongenerator.aircraft.flightgroupconfigurator import (
+    FlightGroupConfigurator,
+)
+
+
+class _StubRegistry(ILaserCodeRegistry):
+    def alloc_laser_code(self) -> LaserCode:
+        raise NotImplementedError
+
+    def release_code(self, code: LaserCode) -> None:
+        pass
+
+
+def _weapon(weapon_type: WeaponType) -> Weapon:
+    group = WeaponGroup(
+        name=f"test-{weapon_type.value}",
+        type=weapon_type,
+        introduction_year=None,
+        fallback_name=None,
+    )
+    return Weapon(clsid=f"test-clsid-{weapon_type.value}", weapon_group=group)
+
+
+@pytest.fixture(name="laser_code")
+def laser_code_fixture() -> LaserCode:
+    return LaserCode(1511, _StubRegistry())
+
+
+def test_merge_inserts_laser_code_when_lgb_and_no_existing_settings(
+    laser_code: LaserCode,
+) -> None:
+    result = FlightGroupConfigurator._merge_laser_code(
+        None, _weapon(WeaponType.LGB), laser_code
+    )
+    assert result == {"laser_code": 1511}
+
+
+def test_merge_preserves_other_settings_when_lgb(laser_code: LaserCode) -> None:
+    base: Dict[str, Any] = {"fuze_setting": "instant"}
+    result = FlightGroupConfigurator._merge_laser_code(
+        base, _weapon(WeaponType.LGB), laser_code
+    )
+    assert result == {"fuze_setting": "instant", "laser_code": 1511}
+
+
+def test_merge_overrides_existing_laser_code_when_lgb(
+    laser_code: LaserCode,
+) -> None:
+    base: Dict[str, Any] = {"laser_code": 1688}
+    result = FlightGroupConfigurator._merge_laser_code(
+        base, _weapon(WeaponType.LGB), laser_code
+    )
+    assert result == {"laser_code": 1511}
+
+
+def test_merge_returns_base_unchanged_for_non_lgb(laser_code: LaserCode) -> None:
+    base: Dict[str, Any] = {"fuze_setting": "instant"}
+    result = FlightGroupConfigurator._merge_laser_code(
+        base, _weapon(WeaponType.ARM), laser_code
+    )
+    assert result is base
+
+
+def test_merge_returns_base_unchanged_when_no_laser_code() -> None:
+    base: Dict[str, Any] = {"fuze_setting": "instant"}
+    result = FlightGroupConfigurator._merge_laser_code(
+        base, _weapon(WeaponType.LGB), None
+    )
+    assert result is base
+
+
+def test_merge_returns_none_when_no_laser_code_and_no_base() -> None:
+    result = FlightGroupConfigurator._merge_laser_code(
+        None, _weapon(WeaponType.LGB), None
+    )
+    assert result is None
+
+
+def test_merge_does_not_mutate_input_base(laser_code: LaserCode) -> None:
+    base: Dict[str, Any] = {"laser_code": 1688, "fuze_setting": "instant"}
+    snapshot = dict(base)
+    FlightGroupConfigurator._merge_laser_code(
+        base, _weapon(WeaponType.LGB), laser_code
+    )
+    assert base == snapshot


### PR DESCRIPTION
Updates flightgroupconfigurator to apply plane-specific laser codes to weapons with the LGB tag, to ensure they are pre-set correctly when loading planes where they're only configurable when adding munitions on the ground such as the F16/A10. 