### PR TITLE
Air Wing dialog improvements: base PR (PR 1/6)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * **[Modding]** Add support for Su-35S mod (v2.0.27b)
 * **[Plugins]** Update EW Script to version 2.1
 * **[Options]** New option to spawn TACAN beacons at captured airfields
+* **[AirWing]** Track per-squadron campaign aircraft stats (initial/destroyed/purchased, save-compatible) and expose pilot experience level and living/dead pilot views for the UI
 
 ## Fixes
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -337,32 +337,11 @@ class FlightGroupConfigurator:
             unit.set_player()
 
     def skill_level_for(self, unit: FlyingUnit, pilot: Optional[Pilot]) -> Skill:
-        if self.flight.squadron.player.is_blue:
-            base_skill = Skill(self.game.settings.player_skill)
-        else:
-            base_skill = Skill(self.game.settings.enemy_skill)
-
+        squadron = self.flight.squadron
         if pilot is None:
             logging.error(f"Cannot determine skill level: {unit.name} has not pilot")
-            return base_skill
-
-        levels = [
-            Skill.Average,
-            Skill.Good,
-            Skill.High,
-            Skill.Excellent,
-        ]
-        current_level = levels.index(base_skill)
-        missions_for_skill_increase = 4
-        increase = pilot.record.missions_flown // missions_for_skill_increase
-        capped_increase = min(current_level + increase, len(levels) - 1)
-
-        if self.game.settings.ai_pilot_levelling:
-            new_level = capped_increase
-        else:
-            new_level = current_level
-
-        return levels[new_level]
+            return squadron.base_skill
+        return squadron.pilot_skill(pilot)
 
     def setup_props(self) -> None:
         unit: FlyingUnit

--- a/game/sim/missionresultsprocessor.py
+++ b/game/sim/missionresultsprocessor.py
@@ -55,6 +55,7 @@ class MissionResultsProcessor:
 
             logging.info(f"{aircraft} destroyed from {squadron}")
             squadron.owned_aircraft -= 1
+            squadron.destroyed_aircraft += 1
 
     @staticmethod
     def _commit_pilot_experience(ato: AirTaskingOrder) -> None:

--- a/game/squadrons/squadron.py
+++ b/game/squadrons/squadron.py
@@ -10,6 +10,7 @@ from typing import Optional, Sequence, TYPE_CHECKING
 from uuid import uuid4, UUID
 
 from dcs.country import Country
+from dcs.unit import Skill
 from faker import Faker
 
 from game.ato import Flight, FlightType, Package
@@ -71,6 +72,13 @@ class Squadron:
     untasked_aircraft: int = field(init=False, hash=False, compare=False, default=0)
     pending_deliveries: int = field(init=False, hash=False, compare=False, default=0)
 
+    #: Aircraft the squadron started the campaign with (set at turn 0).
+    initial_aircraft: int = field(init=False, hash=False, compare=False, default=0)
+    #: Cumulative aircraft lost in combat over the whole campaign.
+    destroyed_aircraft: int = field(init=False, hash=False, compare=False, default=0)
+    #: Cumulative aircraft purchased and delivered over the whole campaign.
+    purchased_aircraft: int = field(init=False, hash=False, compare=False, default=0)
+
     use_livery_set: bool = False  # if livery-set should be used when present
 
     def __setstate__(self, state: dict[str, Any]) -> None:
@@ -78,6 +86,14 @@ class Squadron:
             state["id"] = uuid4()
         if "use_livery_set" not in state:
             state["use_livery_set"] = len(state.get("livery_set", [])) > 0
+        if "initial_aircraft" not in state:
+            # Best-effort for campaigns started before this counter existed:
+            # approximate the starting force with the current owned count.
+            state["initial_aircraft"] = state.get("owned_aircraft", 0)
+        if "destroyed_aircraft" not in state:
+            state["destroyed_aircraft"] = 0
+        if "purchased_aircraft" not in state:
+            state["purchased_aircraft"] = 0
         self.__dict__.update(state)
 
     def __str__(self) -> str:
@@ -99,6 +115,37 @@ class Squadron:
     @property
     def player(self) -> Player:
         return self.coalition.player
+
+    @property
+    def base_skill(self) -> Skill:
+        if self.player.is_blue:
+            return Skill(self.settings.player_skill)
+        return Skill(self.settings.enemy_skill)
+
+    def pilot_skill(self, pilot: Pilot) -> Skill:
+        """The effective DCS skill the pilot flies at.
+
+        Pilots level up one skill tier every few missions flown, starting from
+        the coalition's base skill and capped at the top tier. Levelling only
+        applies when the ``ai_pilot_levelling`` setting is enabled.
+        """
+        levels = [
+            Skill.Average,
+            Skill.Good,
+            Skill.High,
+            Skill.Excellent,
+        ]
+        current_level = levels.index(self.base_skill)
+        missions_for_skill_increase = 4
+        increase = pilot.record.missions_flown // missions_for_skill_increase
+        capped_increase = min(current_level + increase, len(levels) - 1)
+
+        if self.settings.ai_pilot_levelling:
+            new_level = capped_increase
+        else:
+            new_level = current_level
+
+        return levels[new_level]
 
     def assign_to_base(self, base: ControlPoint) -> None:
         self.location = base
@@ -199,6 +246,7 @@ class Squadron:
             self.owned_aircraft = min(
                 self.max_size, self.location.unclaimed_parking(parking_type)
             )
+        self.initial_aircraft = self.owned_aircraft
 
     def end_turn(self) -> None:
         if self.destination is not None:
@@ -261,6 +309,14 @@ class Squadron:
     @property
     def number_of_pilots_including_inactive(self) -> int:
         return len(self.current_roster)
+
+    @property
+    def living_pilots(self) -> list[Pilot]:
+        return self._pilots_without_status(PilotStatus.Dead)
+
+    @property
+    def dead_pilots(self) -> list[Pilot]:
+        return self._pilots_with_status(PilotStatus.Dead)
 
     @property
     def _number_of_unfilled_pilot_slots(self) -> int:
@@ -373,6 +429,7 @@ class Squadron:
 
     def deliver_orders(self) -> None:
         self.cancel_overflow_orders()
+        self.purchased_aircraft += self.pending_deliveries
         self.owned_aircraft += self.pending_deliveries
         self.pending_deliveries = 0
 

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -479,12 +479,14 @@ class SquadronModel(QAbstractListModel):
 
     PilotRole = Qt.ItemDataRole.UserRole
 
-    def __init__(self, squadron: Squadron) -> None:
+    def __init__(self, squadron: Squadron, pilot_filter: str = "all") -> None:
         super().__init__()
         self.squadron = squadron
+        #: Which pilots this model exposes: "all", "living", or "dead".
+        self.pilot_filter = pilot_filter
 
     def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
-        return self.squadron.number_of_pilots_including_inactive
+        return len(self._filtered_pilots())
 
     def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
         if not index.isValid():
@@ -508,9 +510,22 @@ class SquadronModel(QAbstractListModel):
         """Returns the icon that should be displayed for the pilot."""
         return None
 
+    def _filtered_pilots(self) -> list[Pilot]:
+        """Roster subset this model exposes, preserving roster order.
+
+        "living" excludes dead pilots, "dead" keeps only them, "all" lists
+        everyone with living pilots first (stable within each group).
+        """
+        roster = self.squadron.current_roster
+        if self.pilot_filter == "living":
+            return [p for p in roster if p.alive]
+        if self.pilot_filter == "dead":
+            return [p for p in roster if not p.alive]
+        return sorted(roster, key=lambda p: not p.alive)
+
     def pilot_at_index(self, index: QModelIndex) -> Pilot:
         """Returns the pilot located at the given index."""
-        return self.squadron.pilot_at_index(index.row())
+        return self._filtered_pilots()[index.row()]
 
     def toggle_ai_state(self, index: QModelIndex) -> None:
         pilot = self.pilot_at_index(index)


### PR DESCRIPTION
## Description

First contrib to this repo, so tell me if I am doing something wrong.

This is mostly foundational groundwork for the Air Wing UI improvements which will be coming in next PRs making some UI improvements to the air wings, air command and squadron dialogs. 

I have splitted this into 6 PRs to make it easier to review.

## Changes

- Squadron tracks campaign aircraft history (initial/destroyed/purchased) with `__setstate__` backward compatibility for existing saves.
- The pilot skill-level formula is extracted into `Squadron.pilot_skill / base_skill` and `flightgroupconfigurator` delegates to it (no behaviour change), so the UI can show the same level the game uses.
- `Squadron.living_pilots / dead_pilots` and a `SquadronModel` pilot filter so the UI can present living vs killed pilots separately.
