### PR TITLE
Air Wing improvements: transfer improvements (PR 1/2)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,8 +19,10 @@
 * **[AirWing]** Track per-squadron campaign aircraft stats (initial/destroyed/purchased, save-compatible) and expose pilot experience level and living/dead pilot views for the UI
 * **[AirWing]** Squadron list shows living-pilot, aircraft and unassigned counts; squadron dialog shows each pilot's experience level, lists killed-in-action pilots separately and hides the redundant "Active" status
 * **[AirWing]** Squadron dialog shows the aircraft type, an aircraft inventory (initial/current/destroyed/purchased), and buy/sell aircraft controls with price, on-order count and available parking slots
+* **[AirWing]** Air Wing list shows a "transfer ordered to X" indicator, and Airfield Command lists the units transferring into the base next turn
 
 ## Fixes
+* **[AirWing]** Squadron transfer-destination parking now accounts for already-ordered incoming transfers, matching the Airfield Command hangar count
 * **[Mission Generation]** Anti-Ship flights now attack the carrier group the flight plan routes to instead of the control point's first ground object, so strikes against carrier groups no longer leave the AI without a target (it would fly to the ingress point and turn back without engaging).
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.

--- a/qt_ui/windows/AirWingDialog.py
+++ b/qt_ui/windows/AirWingDialog.py
@@ -53,6 +53,11 @@ class SquadronDelegate(TwoColumnRowDelegate):
         elif (row, column) == (0, 1):
             return squadron.aircraft.display_name
         elif (row, column) == (1, 0):
+            if squadron.destination is not None:
+                return (
+                    f"{squadron.location.name} - transfer ordered to "
+                    f"{squadron.destination.name}"
+                )
             return squadron.location.name
         elif (row, column) == (1, 1):
             pilots = len(squadron.living_pilots)

--- a/qt_ui/windows/SquadronDialog.py
+++ b/qt_ui/windows/SquadronDialog.py
@@ -188,7 +188,13 @@ class SquadronDestinationComboBox(QComboBox):
             )
             free_ground_spawns = cp.total_aircraft_parking(parking_type)
 
-            for s in cp.squadrons:
+            # Squadrons that will actually occupy this base next turn:
+            # those staying here (not relocating away) plus any relocating in.
+            occupants = [s for s in cp.squadrons if s.destination is None]
+            occupants += [
+                s for s in cp.coalition.air_wing.iter_squadrons() if s.destination == cp
+            ]
+            for s in occupants:
                 for count in range(s.owned_aircraft):
                     is_heli = s.aircraft.helicopter
                     is_vtol = not is_heli and s.aircraft.lha_capable

--- a/qt_ui/windows/SquadronDialog.py
+++ b/qt_ui/windows/SquadronDialog.py
@@ -188,9 +188,11 @@ class SquadronDestinationComboBox(QComboBox):
             )
             free_ground_spawns = cp.total_aircraft_parking(parking_type)
 
-            # Squadrons that will actually occupy this base next turn:
-            # those staying here (not relocating away) plus any relocating in.
-            occupants = [s for s in cp.squadrons if s.destination is None]
+            # Squadrons whose parking must be reserved at this base next turn:
+            # every squadron currently based here (outgoing transfers included —
+            # they may need to return if the destination is captured this turn)
+            # plus any squadrons relocating in.
+            occupants = list(cp.squadrons)
             occupants += [
                 s for s in cp.coalition.air_wing.iter_squadrons() if s.destination == cp
             ]

--- a/qt_ui/windows/basemenu/airfield/QAircraftRecruitmentMenu.py
+++ b/qt_ui/windows/basemenu/airfield/QAircraftRecruitmentMenu.py
@@ -3,6 +3,7 @@ from typing import Set
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QGridLayout,
+    QGroupBox,
     QHBoxLayout,
     QLabel,
     QScrollArea,
@@ -60,6 +61,24 @@ class QAircraftRecruitmentMenu(UnitTransactionFrame[Squadron]):
         scroll.setWidget(scroll_content)
         main_layout.addLayout(self.hangar_status)
         main_layout.addWidget(scroll)
+
+        incoming = sorted(
+            (s for s in cp.coalition.air_wing.iter_squadrons() if s.destination == cp),
+            key=lambda s: (s.aircraft.display_name, s.name),
+        )
+        if incoming:
+            transfer_box = QGroupBox("Units transferring here in the next turn")
+            transfer_layout = QVBoxLayout()
+            for s in incoming:
+                transfer_layout.addWidget(
+                    QLabel(
+                        f"{s.name} ({s.aircraft.display_name}) - "
+                        f"{s.owned_aircraft} aircraft from {s.location.name}"
+                    )
+                )
+            transfer_box.setLayout(transfer_layout)
+            main_layout.addWidget(transfer_box)
+
         self.setLayout(main_layout)
 
     def sell_tooltip(self, is_enabled: bool) -> str:


### PR DESCRIPTION

## Description

Basically fixing some paper cuts on the UI of of squadron transfers.

## Changes

- Adds a "Transfer ordered to X" text on the Air Wing list window and the Air Field Command panel, if the unit is being transfered to another place.
- Airfield Command also shows the units being transferred into the current base.
- Fix: the transfer-destination parking figure now accounts for transfers already ordered into that base (it previously ignored them).