### PR TITLE
post-mission/debriefing fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,8 @@
 * **[UX]** Show an "End of Mission Detected, processing Mission Data" busy dialog while turn results are processed, so the wait is not mistaken for a missed detection
 
 ## Fixes
-* **[Mission]** Reliably auto-detect end-of-mission state.json that DCS finished writing before the player returned to Retribution, so missions are no longer frequently missed by the waiting dialog (especially short ones, or when alt-tabbing back to Retribution after the mission ended)
+* **[Mission]** Reliably auto-detect end of mission, even when DCS wrote the final state.json before the wait dialog started watching
+* **[Performance]** Faster post-mission turn processing
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * **[Modding]** Add support for Su-35S mod (v2.0.27b)
 * **[Plugins]** Update EW Script to version 2.1
 * **[Options]** New option to spawn TACAN beacons at captured airfields
+* **[UX]** Show an "End of Mission Detected, processing Mission Data" busy dialog while turn results are processed, so the wait is not mistaken for a missed detection
 
 ## Fixes
 * **[Mission]** Reliably auto-detect end-of-mission state.json that DCS finished writing before the player returned to Retribution, so missions are no longer frequently missed by the waiting dialog (especially short ones, or when alt-tabbing back to Retribution after the mission ended)

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 
 ## Fixes
+* **[Mission]** Reliably auto-detect end-of-mission state.json that DCS finished writing before the player returned to Retribution, so missions are no longer frequently missed by the waiting dialog (especially short ones, or when alt-tabbing back to Retribution after the mission ended)
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -9,6 +9,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Optional,
     TYPE_CHECKING,
     Union,
 )
@@ -164,6 +165,12 @@ class Debriefing:
         self.ground_losses = self.dead_ground_units()
         self.base_captures = self.base_capture_events()
 
+        # Lazily-built {origin control point: front-line casualty count}.
+        # commit_front_line_battle_impact() calls casualty_count() twice per
+        # front-line pair; without this cache each call re-scans every
+        # front-line loss (O(pairs x losses), thousands of losses per mission).
+        self._casualties_by_origin: Optional[Dict[ControlPoint, int]] = None
+
     def merge_simulation_results(self, results: SimulationResults) -> None:
         for air_loss in results.air_losses:
             if air_loss.flight.squadron.player.is_blue:
@@ -207,7 +214,12 @@ class Debriefing:
         yield from self.ground_losses.enemy_airfields
 
     def casualty_count(self, control_point: ControlPoint) -> int:
-        return len([x for x in self.front_line_losses if x.origin == control_point])
+        if self._casualties_by_origin is None:
+            counts: Dict[ControlPoint, int] = defaultdict(int)
+            for loss in self.front_line_losses:
+                counts[loss.origin] += 1
+            self._casualties_by_origin = counts
+        return self._casualties_by_origin.get(control_point, 0)
 
     def front_line_losses_by_type(self, player: Player) -> dict[GroundUnitType, int]:
         losses_by_type: dict[GroundUnitType, int] = defaultdict(int)

--- a/game/polldebriefingfilethread.py
+++ b/game/polldebriefingfilethread.py
@@ -13,6 +13,12 @@ if TYPE_CHECKING:
     from game.sim import MissionSimulation
 
 
+#: How often (seconds) we check state.json. DCS' export hook rewrites the
+#: file every second once the mission has ended, so a short interval keeps
+#: end-of-mission detection responsive without burning CPU.
+POLL_INTERVAL_SECONDS = 2
+
+
 class PollDebriefingFileThread(Thread):
     """Thread class with a stop() method. The thread itself has to check
     regularly for the stopped() condition."""
@@ -34,10 +40,14 @@ class PollDebriefingFileThread(Thread):
         return self._stop_event.is_set()
 
     def run(self) -> None:
-        if os.path.isfile("state.json"):
-            last_modified = os.path.getmtime("state.json")
-        else:
-            last_modified = 0
+        # Treat any state.json newer than this mission's .miz as the current
+        # mission's result; an older file is a stale leftover from a previous
+        # mission and is ignored until DCS rewrites it.
+        last_modified = self.mission_sim.miz_generated_at
+        logging.info(
+            "Watching state.json for writes after mission launch (mtime > %s)",
+            last_modified,
+        )
         while not self.stopped():
             try:
                 if (
@@ -50,10 +60,13 @@ class PollDebriefingFileThread(Thread):
                     self.callback(debriefing)
                     last_modified = os.path.getmtime("state.json")
                     if debriefing.state_data.mission_ended:
+                        logging.info("Mission end detected; stopping poll")
                         break
             except (json.JSONDecodeError, OSError, ValueError, KeyError):
-                logging.warning(
-                    "Failed to read state.json. Probably attempted read while DCS "
-                    "was still writing the file. Will retry in 5 seconds."
+                logging.error(
+                    "Failed to read state.json (likely read while DCS was "
+                    "still writing it); will retry in %ss.",
+                    POLL_INTERVAL_SECONDS,
+                    exc_info=True,
                 )
-            time.sleep(5)
+            time.sleep(POLL_INTERVAL_SECONDS)

--- a/game/sim/missionresultsprocessor.py
+++ b/game/sim/missionresultsprocessor.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from game.debriefing import Debriefing
 from game.ground_forces.combat_stance import CombatStance
+from game.profiling import logged_duration
 from game.theater import ControlPoint
 from .gameupdateevents import GameUpdateEvents
 from ..ato.airtaaskingorder import AirTaskingOrder
@@ -23,18 +24,29 @@ class MissionResultsProcessor:
         self.game = game
 
     def commit(self, debriefing: Debriefing, events: GameUpdateEvents) -> None:
-        logging.info("Committing mission results")
-        self.commit_air_losses(debriefing)
-        self.commit_pilot_experience()
-        self.commit_front_line_losses(debriefing)
-        self.commit_convoy_losses(debriefing)
-        self.commit_cargo_ship_losses(debriefing)
-        self.commit_airlift_losses(debriefing)
-        self.commit_ground_losses(debriefing, events)
-        self.commit_damaged_runways(debriefing)
-        self.commit_captures(debriefing, events)
-        self.commit_front_line_battle_impact(debriefing, events)
-        self.record_carcasses(debriefing)
+        with logged_duration("Committing mission results"):
+            with logged_duration("commit_air_losses"):
+                self.commit_air_losses(debriefing)
+            with logged_duration("commit_pilot_experience"):
+                self.commit_pilot_experience()
+            with logged_duration("commit_front_line_losses"):
+                self.commit_front_line_losses(debriefing)
+            with logged_duration("commit_convoy_losses"):
+                self.commit_convoy_losses(debriefing)
+            with logged_duration("commit_cargo_ship_losses"):
+                self.commit_cargo_ship_losses(debriefing)
+            with logged_duration("commit_airlift_losses"):
+                self.commit_airlift_losses(debriefing)
+            with logged_duration("commit_ground_losses"):
+                self.commit_ground_losses(debriefing, events)
+            with logged_duration("commit_damaged_runways"):
+                self.commit_damaged_runways(debriefing)
+            with logged_duration("commit_captures"):
+                self.commit_captures(debriefing, events)
+            with logged_duration("commit_front_line_battle_impact"):
+                self.commit_front_line_battle_impact(debriefing, events)
+            with logged_duration("record_carcasses"):
+                self.record_carcasses(debriefing)
 
     def commit_air_losses(self, debriefing: Debriefing) -> None:
         for loss in debriefing.air_losses.losses:

--- a/game/sim/missionsimulation.py
+++ b/game/sim/missionsimulation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from datetime import timedelta
 from pathlib import Path
 from typing import Optional, TYPE_CHECKING
@@ -32,6 +33,7 @@ class MissionSimulation:
         self.aircraft_simulation = AircraftSimulation(self.game)
         self.completed = False
         self.time = self.game.conditions.start_time
+        self.miz_generated_at: float = 0.0
 
     def begin_simulation(self) -> None:
         self.time = self.game.conditions.start_time
@@ -48,6 +50,7 @@ class MissionSimulation:
     def generate_miz(self, output: Path) -> None:
         with logged_duration("Mission generation"):
             self.unit_map = MissionGenerator(self.game, self.time).generate_miz(output)
+        self.miz_generated_at = time.time()
 
     def debrief_current_state(
         self, state_path: Path, force_end: bool = False

--- a/qt_ui/windows/QWaitingForMissionResultWindow.py
+++ b/qt_ui/windows/QWaitingForMissionResultWindow.py
@@ -8,12 +8,14 @@ from PySide6 import QtCore
 from PySide6.QtCore import QObject, Signal
 from PySide6.QtGui import QIcon, QMovie, QPixmap
 from PySide6.QtWidgets import (
+    QApplication,
     QDialog,
     QFileDialog,
     QGridLayout,
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QProgressDialog,
     QPushButton,
     QTextBrowser,
     QWidget,
@@ -208,12 +210,33 @@ class QWaitingForMissionResultWindow(QDialog):
             logging.exception("Got an error while sending debriefing")
 
     def process_debriefing(self):
-        with logged_duration("Turn processing"):
-            self.sim_controller.process_results(self.debriefing)
-            self.game.pass_turn()
+        # Turn processing blocks the UI for a while; without feedback the user
+        # can't tell whether the mission end was missed or is just being
+        # processed. Show an indeterminate busy dialog meanwhile.
+        progress = QProgressDialog(
+            "End of Mission Detected, processing Mission Data",
+            "",
+            0,
+            0,
+            self,
+        )
+        progress.setWindowTitle("Processing")
+        progress.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+        progress.setCancelButton(None)
+        progress.setMinimumDuration(0)
+        progress.setAutoClose(False)
+        progress.setAutoReset(False)
+        progress.show()
+        QApplication.processEvents()
+        try:
+            with logged_duration("Turn processing"):
+                self.sim_controller.process_results(self.debriefing)
+                self.game.pass_turn()
 
-            GameUpdateSignal.get_instance().sendDebriefing(self.debriefing)
-            GameUpdateSignal.get_instance().updateGame(self.game)
+                GameUpdateSignal.get_instance().sendDebriefing(self.debriefing)
+                GameUpdateSignal.get_instance().updateGame(self.game)
+        finally:
+            progress.close()
         self.close()
 
     def closeEvent(self, evt):


### PR DESCRIPTION
## Improves end of mission detection reliability.
I noticed frequent cases on my campaign where the end of mission was not detected. I am not sure of the reason, I suspect Windows or DCS was not updating the mtime? (sorry, I am more of a Linux guy when talking about OS technical details) I changed the freshness check to consider the `.miz` generation time as the first mtime to compare to, and it seems to detect the end of mission every time (tested with around 10 real missions, both long and short).

## Fix for a performance issue with the post mission parsing

There was a huuuge performance problem with `commit_front_line_battle_impact()` forcing a rescan of every loss each time it calls `casualty_count`. Fixed by adding a `{origin control point: front-line casualty count}` cache. Now the post mission report loads noticeably faster for big reports. I also added logging to each parsing operation to simplify finding the slowest parts in the future.

## Add a progress dialog to the debriefing process

Just so the user knows it hasn't hanged even if it takes some time (also, Windows would produce a "Process unresponsive" warning if clicking on the UI during the debriefing process which the dialog avoids).