### PR TITLE
Fix Take Off hang when fast-forward stop condition is unreachable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 
 ## Fixes
-* **[Fast-forward]** Detect when the configured "Fast forward until" stop condition is unreachable for a player flight's start type (e.g. "Player startup time" with a runway or air start, which skip the Startup state) and prompt before launching the mission: per mismatched flight, the user can either downgrade the flight's start type to match the setting, or halt fast-forward at the flight's actual spawn instead, for this mission only. A hard tick ceiling also caps any remaining unreachable case as a back-stop, so the app can no longer hang on Take Off.
+* **[Fast-forward]** Fix Take Off hang when the configured "Fast forward until" state is one the player flight will skip (e.g. "Player startup time" with a runway start); the user is now prompted to resolve the mismatch before launch.
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 
 ## Fixes
-* **[Fast-forward]** Bound fast-forward-to-first-contact by a hard tick ceiling so it cannot hang the app when the configured stop condition is unreachable (e.g. "Player startup time" with a player flight that starts on the runway or in the air, which skip the Startup state)
+* **[Fast-forward]** Detect when the configured "Fast forward until" stop condition is unreachable for a player flight's start type (e.g. "Player startup time" with a runway or air start, which skip the Startup state) and prompt before launching the mission: per mismatched flight, the user can either downgrade the flight's start type to match the setting, or halt fast-forward at the flight's actual spawn instead, for this mission only. A hard tick ceiling also caps any remaining unreachable case as a back-stop, so the app can no longer hang on Take Off.
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 
 ## Fixes
 * **[Fast-forward]** Fix Take Off hang when the configured "Fast forward until" state is one the player flight will skip (e.g. "Player startup time" with a runway start); the user is now prompted to resolve the mismatch before launch.
+* **[Mission]** Fix a crash when choosing "Fix TOTs automatically" in the past-start-times dialog at Take Off: the automatic fix called `TotEstimator.earliest_tot()` without the required current-time argument and raised a `TypeError`.
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 
 ## Fixes
+* **[Fast-forward]** Bound fast-forward-to-first-contact by a hard tick ceiling so it cannot hang the app when the configured stop condition is unreachable (e.g. "Player startup time" with a player flight that starts on the runway or in the air, which skip the Startup state)
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/changelog.md
+++ b/changelog.md
@@ -14,19 +14,16 @@
 * **[UX]** Show an "End of Mission Detected, processing Mission Data" busy dialog while turn results are processed, so the wait is not mistaken for a missed detection
 
 ## Fixes
-<<<<<<< HEAD
-* **[Fast-forward]** Fix Take Off hang when the configured "Fast forward until" state is one the player flight will skip (e.g. "Player startup time" with a runway start); the user is now prompted to resolve the mismatch before launch.
-* **[Mission]** Fix a crash when choosing "Fix TOTs automatically" in the past-start-times dialog at Take Off: the automatic fix called `TotEstimator.earliest_tot()` without the required current-time argument and raised a `TypeError`.
-=======
 * **[Mission]** Reliably auto-detect end of mission, even when DCS wrote the final state.json before the wait dialog started watching
 * **[Performance]** Faster post-mission turn processing
 * **[AirWing]** Track per-squadron campaign aircraft stats (initial/destroyed/purchased, save-compatible) and expose pilot experience level and living/dead pilot views for the UI
 * **[AirWing]** Squadron list shows living-pilot, aircraft and unassigned counts; squadron dialog shows each pilot's experience level, lists killed-in-action pilots separately and hides the redundant "Active" status
 * **[AirWing]** Squadron dialog shows the aircraft type, an aircraft inventory (initial/current/destroyed/purchased), and buy/sell aircraft controls with price, on-order count and available parking slots
+* **[Fast-forward]** Fix Take Off hang when the configured "Fast forward until" state is one the player flight will skip (e.g. "Player startup time" with a runway start); the user is now prompted to resolve the mismatch before launch.
+* **[Mission]** Fix a crash when choosing "Fix TOTs automatically" in the past-start-times dialog at Take Off: the automatic fix called `TotEstimator.earliest_tot()` without the required current-time argument and raised a `TypeError`.
 
 ## Fixes
 * **[Mission Generation]** Anti-Ship flights now attack the carrier group the flight plan routes to instead of the control point's first ground object, so strikes against carrier groups no longer leave the AI without a target (it would fly to the ingress point and turn back without engaging).
->>>>>>> origin/dev
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -83,6 +83,13 @@ class Flight(
         self.custom_name = custom_name
         self.group_id: int = 0
 
+        # Transient (not persisted): when set, the next time this flight
+        # transitions out of WaitingForStart the simulation halts. Used by
+        # the pre-launch mismatch dialog so the user can opt to "halt
+        # fast-forward at this flight's start" when the configured stop
+        # condition targets a state this flight's start type would skip.
+        self.halt_sim_on_spawn = False
+
         self.frequency = frequency
         if self.unit_type.dcs_unit_type.tacan:
             self.tacan = channel
@@ -164,12 +171,16 @@ class Flight(
         # we will need to persist the flight state, but for now keep it out of save
         # compat (it also contains a generator that cannot be pickled).
         del state["state"]
+        # halt_sim_on_spawn is a transient per-mission opt-in; never persist
+        # so that an old save can't carry a stale halt request into a new run.
+        state.pop("halt_sim_on_spawn", None)
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         state["state"] = Uninitialized(self, state["squadron"].settings)
         if "use_same_loadout_for_all_members" not in state:
             state["use_same_loadout_for_all_members"] = True
+        state.setdefault("halt_sim_on_spawn", False)
         self.__dict__.update(state)
         if isinstance(self.roster, FlightRoster):
             self.roster = FlightMembers.from_roster(self, self.roster)

--- a/game/ato/flightstate/waitingforstart.py
+++ b/game/ato/flightstate/waitingforstart.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -47,6 +48,21 @@ class WaitingForStart(AtDeparture):
         else:
             new_state = Navigating(self.flight, self.settings, waypoint_index=0)
         self.flight.set_state(new_state)
+
+        # Opt-in halt requested before run_to_first_contact (set by the
+        # pre-launch mismatch dialog when the user chose "halt at this
+        # flight's start" instead of changing the flight's start_type).
+        # Halt now that the flight has reached its actual spawn state.
+        if getattr(self.flight, "halt_sim_on_spawn", False):
+            self.flight.halt_sim_on_spawn = False
+            logging.info(
+                "Halting fast-forward at %s spawn for %s (start type %s) "
+                "as requested by the pre-launch mismatch dialog.",
+                new_state.description,
+                self.flight,
+                self.start_type.name,
+            )
+            events.complete_simulation()
 
     @property
     def is_waiting_for_start(self) -> bool:

--- a/game/sim/gameloop.py
+++ b/game/sim/gameloop.py
@@ -58,13 +58,9 @@ class GameLoop:
         with self.timer.locked_pause():
             yield
 
-    #: Hard ceiling on fast-forward ticks (1 tick = 1 sim-second) used to
-    #: bound run_to_first_contact when the configured stop condition can
-    #: never fire - e.g. "Player startup time" combined with a player
-    #: flight whose start type is runway or air, which skips the Startup
-    #: state entirely. Four sim-hours is well past any reasonable mission
-    #: pre-engagement window; if we hit it, the user is misconfigured and
-    #: we abort fast-forward rather than spin forever.
+    #: Back-stop ceiling for run_to_first_contact (1 tick = 1 sim-second).
+    #: Four sim-hours is past any reasonable pre-engagement window; hitting
+    #: it means the stop condition is unreachable, so we abort.
     MAX_FAST_FORWARD_TICKS = 4 * 60 * 60
 
     def run_to_first_contact(self) -> None:
@@ -78,15 +74,9 @@ class GameLoop:
             ticks += 1
             if ticks >= self.MAX_FAST_FORWARD_TICKS:
                 logging.warning(
-                    "Fast-forward aborted after %s sim-ticks without the "
-                    "configured stop condition firing. The mission will be "
-                    "generated without fast-forward applied. This usually "
-                    "means the chosen 'Fast forward until' setting is "
-                    "unreachable for the current package - for example "
-                    "'Player startup time' with a player flight that "
-                    "starts on the runway or in the air (which skip the "
-                    "Startup state). Consider switching to 'Player takeoff "
-                    "time', 'First contact', 'Manual', or 'No fast forward'.",
+                    "Fast-forward aborted after %s sim-ticks; configured "
+                    "stop condition appears unreachable. Mission generated "
+                    "without fast-forward applied.",
                     ticks,
                 )
                 break

--- a/game/sim/gameloop.py
+++ b/game/sim/gameloop.py
@@ -58,13 +58,38 @@ class GameLoop:
         with self.timer.locked_pause():
             yield
 
+    #: Hard ceiling on fast-forward ticks (1 tick = 1 sim-second) used to
+    #: bound run_to_first_contact when the configured stop condition can
+    #: never fire - e.g. "Player startup time" combined with a player
+    #: flight whose start type is runway or air, which skips the Startup
+    #: state entirely. Four sim-hours is well past any reasonable mission
+    #: pre-engagement window; if we hit it, the user is misconfigured and
+    #: we abort fast-forward rather than spin forever.
+    MAX_FAST_FORWARD_TICKS = 4 * 60 * 60
+
     def run_to_first_contact(self) -> None:
         self.pause()
         if not self.started:
             self.start()
         logging.info("Running sim to first contact")
+        ticks = 0
         while not self.completed:
             self.tick(suppress_events=False)
+            ticks += 1
+            if ticks >= self.MAX_FAST_FORWARD_TICKS:
+                logging.warning(
+                    "Fast-forward aborted after %s sim-ticks without the "
+                    "configured stop condition firing. The mission will be "
+                    "generated without fast-forward applied. This usually "
+                    "means the chosen 'Fast forward until' setting is "
+                    "unreachable for the current package - for example "
+                    "'Player startup time' with a player flight that "
+                    "starts on the runway or in the air (which skip the "
+                    "Startup state). Consider switching to 'Player takeoff "
+                    "time', 'First contact', 'Manual', or 'No fast forward'.",
+                    ticks,
+                )
+                break
 
     def pause_and_generate_miz(self, output: Path) -> None:
         self.pause()

--- a/qt_ui/widgets/QTopPanel.py
+++ b/qt_ui/widgets/QTopPanel.py
@@ -12,8 +12,10 @@ from PySide6.QtWidgets import (
 
 import qt_ui.uiconstants as CONST
 from game import Game, persistency
+from game.ato.flight import Flight
 from game.ato.flightstate import Uninitialized
 from game.ato.package import Package
+from game.ato.starttype import StartType
 from game.ato.traveltime import TotEstimator
 from game.profiling import logged_duration
 from game.settings.settings import FastForwardStopCondition
@@ -293,6 +295,108 @@ class QTopPanel(QFrame):
         mbox.exec_()
         return True
 
+    # Lowest start_type compatible with each player-targeted fast-forward
+    # stop condition. If a player flight's start_type is "later" (skips
+    # earlier states), the stop condition never fires for that flight.
+    # Ordering of states the flight passes through:
+    #   COLD -> StartUp -> Taxi -> Takeoff -> Navigating
+    #   WARM ->           Taxi -> Takeoff -> Navigating
+    #   RUNWAY ->                 Takeoff -> Navigating
+    #   IN_FLIGHT ->                         Navigating
+    _STOP_CONDITION_REQUIRED_START: dict[
+        FastForwardStopCondition, frozenset[StartType]
+    ] = {
+        FastForwardStopCondition.PLAYER_STARTUP: frozenset({StartType.COLD}),
+        FastForwardStopCondition.PLAYER_TAXI: frozenset(
+            {StartType.COLD, StartType.WARM}
+        ),
+        FastForwardStopCondition.PLAYER_TAKEOFF: frozenset(
+            {StartType.COLD, StartType.WARM, StartType.RUNWAY}
+        ),
+    }
+
+    def _mismatched_player_flights(self) -> List[Flight]:
+        """Return player flights whose start_type would skip the configured
+        fast-forward stop condition (so the sim would never halt for them)."""
+        cond = self.game.settings.fast_forward_stop_condition
+        compatible = self._STOP_CONDITION_REQUIRED_START.get(cond)
+        if compatible is None:
+            return []
+        mismatched: List[Flight] = []
+        for package in self.game.blue.ato.packages:
+            for flight in package.flights:
+                if flight.client_count <= 0:
+                    continue
+                if flight.start_type not in compatible:
+                    mismatched.append(flight)
+        return mismatched
+
+    @staticmethod
+    def _matching_start_type_for_condition(
+        cond: FastForwardStopCondition,
+    ) -> StartType:
+        """Earliest-state start_type compatible with cond. Picking the
+        earliest preserves the user's intent ('halt at startup' means
+        actually go through startup), at the cost of a longer pre-mission
+        spool. Users who want a shorter spool can instead pick the
+        'halt at this flight's start' branch."""
+        if cond is FastForwardStopCondition.PLAYER_STARTUP:
+            return StartType.COLD
+        if cond is FastForwardStopCondition.PLAYER_TAXI:
+            return StartType.WARM
+        if cond is FastForwardStopCondition.PLAYER_TAKEOFF:
+            return StartType.RUNWAY
+        # Caller ensures cond targets a player-flight state.
+        raise ValueError(f"No matching start type for {cond}")
+
+    def resolve_start_type_mismatches(self) -> bool:
+        """For every player flight whose start_type makes the configured
+        fast-forward stop condition unreachable, ask the user to choose:
+        adjust the flight or override the stop condition (both
+        mission-only). Returns False if the user cancelled."""
+        mismatches = self._mismatched_player_flights()
+        if not mismatches:
+            return True
+
+        cond = self.game.settings.fast_forward_stop_condition
+        matching = self._matching_start_type_for_condition(cond)
+
+        for flight in mismatches:
+            mbox = QMessageBox(self)
+            mbox.setIcon(QMessageBox.Icon.Question)
+            mbox.setWindowTitle("Fast-forward / start-type mismatch")
+            mbox.setText(
+                f"<b>{flight}</b> starts <b>{flight.start_type.value}</b>, but "
+                f"<i>Fast forward until</i> is set to "
+                f"<b>{cond.value}</b>, which is a state this flight will "
+                f"skip.<br /><br />"
+                f"Where would you like fast-forward to stop for this "
+                f"flight?"
+            )
+            mbox.setInformativeText(
+                "Both choices apply to <i>this mission only</i> and do not "
+                "modify your saved settings."
+            )
+            change_flight_btn = mbox.addButton(
+                f"Change this flight to {matching.value}",
+                QMessageBox.ButtonRole.AcceptRole,
+            )
+            halt_at_spawn_btn = mbox.addButton(
+                f"Halt at this flight's start ({flight.start_type.value})",
+                QMessageBox.ButtonRole.AcceptRole,
+            )
+            cancel_btn = mbox.addButton(QMessageBox.StandardButton.Cancel)
+            mbox.setEscapeButton(cancel_btn)
+            mbox.exec_()
+            clicked = mbox.clickedButton()
+            if clicked is change_flight_btn:
+                flight.start_type = matching
+            elif clicked is halt_at_spawn_btn:
+                flight.halt_sim_on_spawn = True
+            else:
+                return False
+        return True
+
     def launch_mission(self):
         """Finishes planning and waits for mission completion."""
         if not self.ato_has_clients() and not self.confirm_no_client_launch():
@@ -312,6 +416,8 @@ class QTopPanel(QFrame):
             FastForwardStopCondition.DISABLED,
             FastForwardStopCondition.MANUAL,
         ]:
+            if not self.resolve_start_type_mismatches():
+                return
             with logged_duration("Simulating to first contact"):
                 self.sim_controller.run_to_first_contact()
         self.sim_controller.generate_miz(

--- a/qt_ui/widgets/QTopPanel.py
+++ b/qt_ui/widgets/QTopPanel.py
@@ -189,10 +189,10 @@ class QTopPanel(QFrame):
         return packages
 
     @staticmethod
-    def fix_tots(packages: List[Package]) -> None:
+    def fix_tots(packages: List[Package], now: datetime) -> None:
         for package in packages:
             estimator = TotEstimator(package)
-            package.time_over_target = estimator.earliest_tot()
+            package.time_over_target = estimator.earliest_tot(now)
 
     def ato_has_clients(self) -> bool:
         for package in self.game.blue.ato.packages:
@@ -224,7 +224,9 @@ class QTopPanel(QFrame):
         )
         return result == QMessageBox.StandardButton.Yes
 
-    def confirm_negative_start_time(self, negative_starts: List[Package]) -> bool:
+    def confirm_negative_start_time(
+        self, negative_starts: List[Package], now: datetime
+    ) -> bool:
         formatted = "<br />".join(
             [f"{p.primary_task} {p.target.name}" for p in negative_starts]
         )
@@ -259,7 +261,7 @@ class QTopPanel(QFrame):
         mbox.exec_()
         clicked = mbox.clickedButton()
         if clicked == auto:
-            self.fix_tots(negative_starts)
+            self.fix_tots(negative_starts, now)
             return True
         elif clicked == ignore:
             return True
@@ -405,11 +407,10 @@ class QTopPanel(QFrame):
         if self.check_no_missing_pilots():
             return
 
-        negative_starts = self.negative_start_packages(
-            self.sim_controller.current_time_in_sim
-        )
+        now = self.sim_controller.current_time_in_sim
+        negative_starts = self.negative_start_packages(now)
         if negative_starts:
-            if not self.confirm_negative_start_time(negative_starts):
+            if not self.confirm_negative_start_time(negative_starts, now):
                 return
 
         if self.game.settings.fast_forward_stop_condition not in [


### PR DESCRIPTION
## Summary

Clicking "Take off" hangs the app forever when the configured "Fast forward until..." state is one the player flight will skip — e.g. "Startup time" with a runway start.

## Fix

Detect the mismatch before fast-forwarding and ask the user, per flight: change the flight's start type, or halt fast-forward at the flight's actual start instead. Both choices are mission-only.

A hard tick ceiling on the fast-forward loop catches any other unreachable case as a back-stop.