### PR TITLE
Fix Anti-Ship flights not engaging carrier groups

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 
 ## Fixes
+* **[Mission Generation]** Anti-Ship flights now attack the carrier group the flight plan routes to instead of the control point's first ground object, so strikes against carrier groups no longer leave the AI without a target (it would fly to the ingress point and turn back without engaging).
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/game/missiongenerator/aircraft/waypoints/antishipingress.py
+++ b/game/missiongenerator/aircraft/waypoints/antishipingress.py
@@ -16,7 +16,10 @@ class AntiShipIngressBuilder(PydcsWaypointBuilder):
 
         target = self.package.target
         if isinstance(target, NavalControlPoint):
-            carrier_tgo = target.ground_objects[0]
+            # Use find_main_tgo() like the flight plan does: ground_objects[0]
+            # isn't necessarily the carrier (it may be a sunk, never-spawned
+            # group), which would leave the flight with no AttackGroup target.
+            carrier_tgo = target.find_main_tgo()
             for g in carrier_tgo.groups:
                 group_names.append(g.group_name)
         elif isinstance(target, TheaterGroundObject):
@@ -29,22 +32,36 @@ class AntiShipIngressBuilder(PydcsWaypointBuilder):
             )
             return
 
-        self.add_attack_group_tasks_for_ordnance(
-            waypoint, group_names, WeaponType.Antiship
-        )
-        self.add_attack_group_tasks_for_ordnance(
-            waypoint, group_names, WeaponType.Guided
-        )
-        self.add_attack_group_tasks_for_ordnance(
-            waypoint, group_names, WeaponType.Unguided
-        )
+        added = 0
+        for ordnance in (
+            WeaponType.Antiship,
+            WeaponType.Guided,
+            WeaponType.Unguided,
+        ):
+            added += self.add_attack_group_tasks_for_ordnance(
+                waypoint, group_names, ordnance
+            )
+
+        if not added:
+            # No AttackGroup task could be attached, so the AI would fly to the
+            # ingress point and turn back without engaging. Make this loud: it
+            # almost always means the target group(s) were never spawned (e.g.
+            # already destroyed) or the resolved name does not match a mission
+            # group.
+            logging.warning(
+                "Anti-Ship flight %s has no attackable target group "
+                "(resolved %s); it will not engage anything.",
+                self.flight,
+                group_names or "no groups",
+            )
 
     def add_attack_group_tasks_for_ordnance(
         self,
         waypoint: MovingPoint,
         group_names: List[str],
         ordnance: WeaponType,
-    ) -> None:
+    ) -> int:
+        added = 0
         for group_name in group_names:
             miz_group = self.mission.find_group(group_name)
             if miz_group is None:
@@ -55,3 +72,5 @@ class AntiShipIngressBuilder(PydcsWaypointBuilder):
 
             task = AttackGroup(miz_group.id, group_attack=True, weapon_type=ordnance)
             waypoint.tasks.append(task)
+            added += 1
+        return added

--- a/tests/missiongenerator/aircraft/test_antishipingress.py
+++ b/tests/missiongenerator/aircraft/test_antishipingress.py
@@ -1,0 +1,85 @@
+import logging
+from typing import Any, Callable
+from unittest.mock import MagicMock
+
+import pytest
+from dcs.task import AttackGroup
+
+from game.missiongenerator.aircraft.waypoints.antishipingress import (
+    AntiShipIngressBuilder,
+)
+from game.theater import NavalControlPoint, TheaterGroundObject
+
+
+def _model_group(name: str) -> MagicMock:
+    group = MagicMock()
+    group.group_name = name
+    return group
+
+
+def _build_builder(target: Any, find_group: Callable[[str], Any]) -> tuple[Any, Any]:
+    # Bypass __init__ (it needs a full mission/flight); only add_tasks() and the
+    # few collaborators it consults are exercised. Typed as Any so the mocks can
+    # stand in for the real, strongly-typed attributes.
+    builder: Any = object.__new__(AntiShipIngressBuilder)
+    builder.register_special_ingress_points = MagicMock()
+    builder.package = MagicMock()
+    builder.package.target = target
+    builder.flight = MagicMock()
+    builder.mission = MagicMock()
+    builder.mission.find_group.side_effect = find_group
+    waypoint = MagicMock()
+    waypoint.tasks = []
+    return builder, waypoint
+
+
+def test_naval_control_point_targets_main_tgo_not_first_ground_object() -> None:
+    """Regression test: the carrier group must come from find_main_tgo().
+
+    A NavalControlPoint can own several ground objects; ground_objects[0] is
+    not necessarily the carrier (it may be a sunk group that never spawns).
+    The attack task must target the group the flight plan routes to.
+    """
+    carrier_group = _model_group("carrier-group")
+    main_tgo = MagicMock()
+    main_tgo.groups = [carrier_group]
+
+    wrong_group = _model_group("wrong-group")
+    wrong_tgo = MagicMock()
+    wrong_tgo.groups = [wrong_group]
+
+    target = MagicMock(spec=NavalControlPoint)
+    target.find_main_tgo.return_value = main_tgo
+    target.ground_objects = [wrong_tgo]  # ground_objects[0] is the wrong group
+
+    miz_group = MagicMock()
+    miz_group.id = 42
+
+    def find_group(name: str) -> Any:
+        return miz_group if name == "carrier-group" else None
+
+    builder, waypoint = _build_builder(target, find_group)
+    builder.add_tasks(waypoint)
+
+    queried = [call.args[0] for call in builder.mission.find_group.call_args_list]
+    assert "carrier-group" in queried
+    assert "wrong-group" not in queried
+
+    attacks = [task for task in waypoint.tasks if isinstance(task, AttackGroup)]
+    assert attacks, "expected at least one AttackGroup task"
+    assert all(task.params["groupId"] == 42 for task in attacks)
+
+
+def test_warns_when_no_attackable_group(caplog: pytest.LogCaptureFixture) -> None:
+    """A target whose groups are not in the mission yields a clear warning."""
+    group = _model_group("missing-group")
+    target = MagicMock(spec=TheaterGroundObject)
+    target.groups = [group]
+
+    builder, waypoint = _build_builder(target, lambda name: None)
+
+    with caplog.at_level(logging.WARNING):
+        builder.add_tasks(waypoint)
+
+    assert not [t for t in waypoint.tasks if isinstance(t, AttackGroup)]
+    assert any("no attackable target group" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

Anti-Ship flights tasked against a carrier group never fired — the AI flew to the ingress point and turned back without launching a single missile.

## Cause

The flight plan routes the package to the carrier (`AntiShipFlightPlan` uses `NavalControlPoint.find_main_tgo()`), but the waypoint task builder resolved its target independently from `control_point.ground_objects[0]`. A naval control point can own several ground objects, and the first one isn't necessarily the carrier — it can be a different naval group that is already sunk and therefore never spawned into the mission. The resulting `AttackGroup` task referenced a group that doesn't exist in the `.miz`, so it was silently dropped and the flight had no target.

## Fix

Resolve the target the same way the flight plan does, via `find_main_tgo()`, so the `AttackGroup` task points at the carrier group that's actually generated. Also emit a warning when an Anti-Ship flight ends up with no attack task at all, so a future mismatch surfaces in the log instead of failing silently.