### PR TITLE
Fix two-column delegate crash in sizeHint under PySide6 6.4.x

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 
 ## Fixes
+* **[UI]** Avoid a crash dialog ("'QWidgetItem' object has no attribute 'width'") when a list using the two-column row delegate relayouts with a malformed style option under PySide6 6.4.x.
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/qt_ui/delegates.py
+++ b/qt_ui/delegates.py
@@ -96,10 +96,12 @@ class TwoColumnRowDelegate(QStyledItemDelegate):
     @staticmethod
     def icon_size(option: QStyleOptionViewItem) -> QSize:
         icon_size: Optional[QSize] = option.decorationSize
-        if icon_size is None:
+        # Under PySide6 6.4.x the option passed to sizeHint() can carry a
+        # decorationSize that isn't a QSize (e.g. a QWidgetItem); treat
+        # anything unexpected as "no icon" instead of crashing on .width().
+        if not isinstance(icon_size, QSize):
             return QSize(0, 0)
-        else:
-            return icon_size
+        return icon_size
 
     def sizeHint(self, option: QStyleOptionViewItem, index: QModelIndex) -> QSize:
         metrics = QFontMetrics(self.get_font(option))


### PR DESCRIPTION
## Summary

A crash dialog — `'PySide6.QtWidgets.QWidgetItem' object has no attribute 'width'` — could pop up when a list backed by `TwoColumnRowDelegate` (Air Wing / ATO panels, etc.) relayouts, for example while the post-mission debriefing window is open.

## Cause

`TwoColumnRowDelegate.sizeHint()` reads `option.decorationSize` and calls `.width()`/`.height()` on it. Under PySide6 6.4.x the option handed to `sizeHint()` during some relayouts carries a `decorationSize` that isn't a `QSize` (it can be a `QWidgetItem`), so the attribute access raises.

## Fix

Guard `icon_size()`: if `decorationSize` isn't a `QSize`, treat it as "no icon" (`QSize(0, 0)`) instead of crashing. Behaviour is unchanged in the normal case.