### PR TITLE
Fix duplicate SEAD Escort and missing SEAD task for carrier targets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 
 ## Fixes
+* **[Mission Planning]** Carrier/LHA targets now offer SEAD in the flight-task list and no longer list SEAD Escort twice (their escorts are SAM platforms, so they can be suppressed directly like any other naval group).
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1409,7 +1409,7 @@ class NavalControlPoint(
         else:
             yield from [
                 FlightType.ANTISHIP,
-                FlightType.SEAD_ESCORT,
+                FlightType.SEAD,
             ]
         yield from super().mission_types(for_player)
         if self.is_friendly(for_player):

--- a/tests/theater/test_mission_types_no_duplicates.py
+++ b/tests/theater/test_mission_types_no_duplicates.py
@@ -1,0 +1,48 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Importing these registers every concrete MissionTarget subclass (control
+# points, theater ground objects, transfers, front lines) so the
+# parametrization below discovers them all.
+import game.theater.controlpoint  # noqa: F401
+import game.theater.theatergroundobject  # noqa: F401
+from game.theater.missiontarget import MissionTarget
+
+
+def _concrete_mission_targets() -> list[type[MissionTarget]]:
+    found: set[type[MissionTarget]] = set()
+
+    def walk(cls: type[MissionTarget]) -> None:
+        for sub in cls.__subclasses__():
+            walk(sub)
+            if not getattr(sub, "__abstractmethods__", frozenset()):
+                found.add(sub)
+
+    walk(MissionTarget)
+    return sorted(found, key=lambda c: c.__name__)
+
+
+@pytest.mark.parametrize("cls", _concrete_mission_targets())
+@pytest.mark.parametrize("friendly", [True, False])
+def test_mission_types_have_no_duplicates(
+    cls: "type[MissionTarget]", friendly: bool
+) -> None:
+    """No mission target may offer the same FlightType twice.
+
+    mission_types() chains a subclass's own entries with the base mission
+    types; listing one the base already provides (as happened with
+    SEAD_ESCORT on carriers) produces a duplicate in the "Create flight" task
+    menu. Covers every concrete mission target, for either coalition.
+    """
+    # Built without running __init__ (it needs a full game); typed as Any so
+    # the mocks can stand in for the real, strongly-typed attributes. Only
+    # mission_types() and the two collaborators it consults are exercised.
+    target: Any = object.__new__(cls)
+    target.is_friendly = MagicMock(return_value=friendly)
+    target.total_aircraft_parking = MagicMock(return_value=1)
+
+    types = list(target.mission_types(MagicMock()))
+
+    assert len(types) == len(set(types)), f"{cls.__name__}: duplicates in {types}"


### PR DESCRIPTION
## Summary

When creating a flight against an enemy carrier/LHA, the task list showed SEAD Escort twice and offered no plain SEAD, unlike a regular naval group.

## Cause

`NavalControlPoint.mission_types()` yields `SEAD_ESCORT` for enemy targets, but the base `MissionTarget.mission_types()` already yields `SEAD_ESCORT` — so it appeared twice. It also never offered plain `SEAD`, even though a carrier group's escorts are SAM platforms (a regular naval group does offer SEAD).

## Fix

Yield `SEAD` instead of `SEAD_ESCORT` for enemy carrier/LHA targets, matching regular naval groups: SEAD becomes available and the duplicate disappears (`SEAD_ESCORT` still comes once from the base mission types).

Adds a test asserting that no mission target yields a duplicate `FlightType` from `mission_types()`, for either coalition (auto-discovers every concrete `MissionTarget` subclass — control points, ground objects, transfers, front lines — so new types are covered too).