### PR TITLE
Highlight a SAM ring's emitter on hover

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * **[Modding]** Add support for Su-35S mod (v2.0.27b)
 * **[Plugins]** Update EW Script to version 2.1
 * **[Options]** New option to spawn TACAN beacons at captured airfields
+* **[Map]** Hovering a SAM threat or detection ring highlights its emitter — and hovering an emitter highlights its ring — making it easy to tell which site a ring belongs to. Can be disabled from the map's layer control.
 
 ## Fixes
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.

--- a/client/src/api/mapSlice.ts
+++ b/client/src/api/mapSlice.ts
@@ -1,20 +1,50 @@
 import { RootState } from "../app/store";
 import { gameLoaded, gameUnloaded } from "./actions";
-import { createSlice } from "@reduxjs/toolkit";
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { LatLngLiteral } from "leaflet";
+
+// Where a hover originated: the emitter's icon, or one of its range rings. The
+// highlight is symmetric (hovering either lights up the other), but hovering a
+// ring also marks its emitter with a blob so you can find it; hovering the
+// emitter does not blob the icon you're already pointing at.
+export type EmitterHoverSource = "emitter" | "ring";
 
 interface MapState {
   center: LatLngLiteral;
+  // Id of the TGO whose air-defense ring (or icon) is currently hovered, so its
+  // icon can be raised above overlapping ones while highlighted.
+  hoveredEmitterId: string | null;
+  // What was hovered to set hoveredEmitterId (icon vs. ring).
+  hoveredEmitterSource: EmitterHoverSource | null;
+  // Whether the hover highlight (ring <-> emitter) is enabled. Toggled from
+  // the map's layer control.
+  highlightEmitters: boolean;
 }
 
 const initialState: MapState = {
   center: { lat: 0, lng: 0 },
+  hoveredEmitterId: null,
+  hoveredEmitterSource: null,
+  highlightEmitters: true,
 };
 
 const mapSlice = createSlice({
   name: "map",
   initialState: initialState,
-  reducers: {},
+  reducers: {
+    setHoveredEmitter(
+      state,
+      action: PayloadAction<
+        { id: string; source: EmitterHoverSource } | null
+      >
+    ) {
+      state.hoveredEmitterId = action.payload?.id ?? null;
+      state.hoveredEmitterSource = action.payload?.source ?? null;
+    },
+    setHighlightEmitters(state, action: PayloadAction<boolean>) {
+      state.highlightEmitters = action.payload;
+    },
+  },
   extraReducers: (builder) => {
     builder.addCase(gameLoaded, (state, action) => {
       if (action.payload.map_center != null) {
@@ -23,10 +53,20 @@ const mapSlice = createSlice({
     });
     builder.addCase(gameUnloaded, (state) => {
       state.center = { lat: 0, lng: 0 };
+      state.hoveredEmitterId = null;
+      state.hoveredEmitterSource = null;
     });
   },
 });
 
+export const { setHoveredEmitter, setHighlightEmitters } = mapSlice.actions;
+
 export const selectMapCenter = (state: RootState) => state.map.center;
+export const selectHoveredEmitter = (state: RootState) =>
+  state.map.hoveredEmitterId;
+export const selectHoveredEmitterSource = (state: RootState) =>
+  state.map.hoveredEmitterSource;
+export const selectHighlightEmitters = (state: RootState) =>
+  state.map.highlightEmitters;
 
 export default mapSlice.reducer;

--- a/client/src/components/airdefenserangelayer/AirDefenseRangeLayer.test.tsx
+++ b/client/src/components/airdefenserangelayer/AirDefenseRangeLayer.test.tsx
@@ -102,7 +102,6 @@ describe("AirDefenseRangeLayer", () => {
         },
         radius: 10,
         color: colorFor(true, false),
-        interactive: false,
       })
     );
   });
@@ -142,7 +141,6 @@ describe("AirDefenseRangeLayer", () => {
         },
         radius: 20,
         color: colorFor(true, true),
-        interactive: false,
       })
     );
   });

--- a/client/src/components/airdefenserangelayer/AirDefenseRangeLayer.tsx
+++ b/client/src/components/airdefenserangelayer/AirDefenseRangeLayer.tsx
@@ -1,7 +1,14 @@
 import { Tgo } from "../../api/liberationApi";
 import { selectTgos } from "../../api/tgosSlice";
-import { useAppSelector } from "../../app/hooks";
-import { Circle, LayerGroup } from "react-leaflet";
+import {
+  selectHighlightEmitters,
+  selectHoveredEmitter,
+  selectHoveredEmitterSource,
+  setHoveredEmitter,
+} from "../../api/mapSlice";
+import { useAppDispatch, useAppSelector } from "../../app/hooks";
+import { Fragment } from "react";
+import { Circle, CircleMarker, LayerGroup } from "react-leaflet";
 
 interface TgoRangeCirclesProps {
   tgo: Tgo;
@@ -16,28 +23,88 @@ export function colorFor(blue: boolean, detection: boolean) {
   return detection ? "#eee17b" : "#c85050";
 }
 
+// Bright colour used to mark the hovered ring and its emitter.
+const HIGHLIGHT_COLOR = "#ffff00";
+
 const TgoRangeCircles = (props: TgoRangeCirclesProps) => {
   const radii = props.detection
     ? props.tgo.detection_ranges
     : props.tgo.threat_ranges;
   const color = colorFor(props.blue, props.detection === true);
-  const weight = props.detection ? 1 : 2;
+  const baseWeight = props.detection ? 1 : 2;
+  const dispatch = useAppDispatch();
+
+  // Highlight when the feature is enabled and this emitter is the hovered one.
+  // It is driven by shared state, so hovering either the ring or the emitter's
+  // icon lights up the other (and the icon is raised, see Tgo).
+  const highlighted = useAppSelector(
+    (state) =>
+      selectHighlightEmitters(state) &&
+      selectHoveredEmitter(state) === props.tgo.id
+  );
+  // Mark the emitter with a blob only when the hover came from a ring, to help
+  // locate it (associating ring <-> emitter). When the emitter icon itself is
+  // hovered we don't blob it, since we're already pointing at it. The ring
+  // itself always lights up while highlighted, in either direction.
+  const markEmitter = useAppSelector(
+    (state) => highlighted && selectHoveredEmitterSource(state) === "ring"
+  );
+
+  const hover = {
+    mouseover: () =>
+      dispatch(setHoveredEmitter({ id: props.tgo.id, source: "ring" })),
+    mouseout: () => dispatch(setHoveredEmitter(null)),
+  };
 
   return (
     <>
-      {radii.map((radius, idx) => {
-        return (
+      {radii.map((radius, idx) => (
+        <Fragment key={idx}>
           <Circle
-            key={idx}
+            center={props.tgo.position}
+            radius={radius}
+            // Style goes through pathOptions (not bare color/weight props):
+            // react-leaflet only re-applies setStyle when pathOptions changes,
+            // so bare props would be set once at creation and never update when
+            // the highlight toggles.
+            pathOptions={{
+              color: highlighted ? HIGHLIGHT_COLOR : color,
+              weight: highlighted ? baseWeight + 2 : baseWeight,
+              fill: false,
+            }}
+            interactive={false}
+          />
+          {/* Invisible wide ring that catches the hover. The visible stroke is
+              a fixed pixel width so it gets hard to hit when zoomed out; this
+              18px transparent band (pointer-events: stroke via the className,
+              so it works despite being invisible) gives a comfortable target
+              along the perimeter without filling the disc. */}
+          <Circle
             center={props.tgo.position}
             radius={radius}
             color={color}
             fill={false}
-            weight={weight}
-            interactive={false}
+            opacity={0}
+            weight={18}
+            className="air-defense-ring-hit"
+            eventHandlers={hover}
           />
-        );
-      })}
+        </Fragment>
+      ))}
+      {markEmitter && (
+        <CircleMarker
+          center={props.tgo.position}
+          radius={20}
+          color={HIGHLIGHT_COLOR}
+          fillColor={HIGHLIGHT_COLOR}
+          fillOpacity={0.5}
+          weight={4}
+          interactive={false}
+          // Draw above the marker icons (markerPane, z 600) so the highlight is
+          // not buried under a cluster of overlapping unit icons.
+          pane="tooltipPane"
+        />
+      )}
     </>
   );
 };

--- a/client/src/components/airdefenserangelayer/EmitterHighlightToggle.tsx
+++ b/client/src/components/airdefenserangelayer/EmitterHighlightToggle.tsx
@@ -1,0 +1,18 @@
+import { setHighlightEmitters } from "../../api/mapSlice";
+import { useAppDispatch } from "../../app/hooks";
+import { LayerGroup } from "react-leaflet";
+
+// Empty layer wrapped in a LayersControl.Overlay. Toggling the overlay adds or
+// removes this (otherwise invisible) layer, which we use to enable/disable the
+// "highlight radar emitter on hover" behaviour.
+export default function EmitterHighlightToggle() {
+  const dispatch = useAppDispatch();
+  return (
+    <LayerGroup
+      eventHandlers={{
+        add: () => dispatch(setHighlightEmitters(true)),
+        remove: () => dispatch(setHighlightEmitters(false)),
+      }}
+    />
+  );
+}

--- a/client/src/components/liberationmap/LiberationMap.tsx
+++ b/client/src/components/liberationmap/LiberationMap.tsx
@@ -2,6 +2,7 @@ import { selectMapCenter } from "../../api/mapSlice";
 import { useAppSelector } from "../../app/hooks";
 import AircraftLayer from "../aircraftlayer";
 import AirDefenseRangeLayer from "../airdefenserangelayer";
+import EmitterHighlightToggle from "../airdefenserangelayer/EmitterHighlightToggle";
 import CombatLayer from "../combatlayer";
 import ControlPointsLayer from "../controlpointslayer";
 import CullingExclusionZones from "../cullingexclusionzones/CullingExclusionZones";
@@ -94,6 +95,9 @@ export default function LiberationMap() {
         </LayersControl.Overlay>
         <LayersControl.Overlay name="Allied SAM detection range">
           <AirDefenseRangeLayer blue={true} detection />
+        </LayersControl.Overlay>
+        <LayersControl.Overlay name="Highlight radar emitter on hover" checked>
+          <EmitterHighlightToggle />
         </LayersControl.Overlay>
         <LayersControl.Overlay name="Allied IADS Network">
           <Iadsnetworklayer blue={true} />

--- a/client/src/components/tgos/Tgo.tsx
+++ b/client/src/components/tgos/Tgo.tsx
@@ -3,6 +3,12 @@ import {
   useOpenTgoInfoDialogMutation,
 } from "../../api/liberationApi";
 import { Tgo as TgoModel } from "../../api/liberationApi";
+import {
+  selectHighlightEmitters,
+  selectHoveredEmitter,
+  setHoveredEmitter,
+} from "../../api/mapSlice";
+import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import SplitLines from "../splitlines/SplitLines";
 import { Icon, Point } from "leaflet";
 import ms from "milsymbol";
@@ -26,10 +32,18 @@ interface TgoProps {
 export default function Tgo(props: TgoProps) {
   const [openNewPackageDialog] = useOpenNewTgoPackageDialogMutation();
   const [openInfoDialog] = useOpenTgoInfoDialogMutation();
+  const dispatch = useAppDispatch();
+  // Raised above other icons while this emitter (or its ring) is hovered.
+  const raised = useAppSelector(
+    (state) =>
+      selectHighlightEmitters(state) &&
+      selectHoveredEmitter(state) === props.tgo.id
+  );
   return (
     <Marker
       position={props.tgo.position}
       icon={iconForTgo(props.tgo)}
+      zIndexOffset={raised ? 10000 : 0}
       eventHandlers={{
         click: () => {
           openInfoDialog({ tgoId: props.tgo.id });
@@ -37,6 +51,10 @@ export default function Tgo(props: TgoProps) {
         contextmenu: () => {
           openNewPackageDialog({ tgoId: props.tgo.id });
         },
+        // Hovering the emitter highlights its ring (and vice versa).
+        mouseover: () =>
+          dispatch(setHoveredEmitter({ id: props.tgo.id, source: "emitter" })),
+        mouseout: () => dispatch(setHoveredEmitter(null)),
       }}
     >
       <Tooltip>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,3 +11,10 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+/* Wide, invisible hover target for SAM threat/detection rings. pointer-events:
+   stroke lets the transparent stroke catch the mouse along the perimeter even
+   though it is not painted, so the ring is easy to hover when zoomed out. */
+.air-defense-ring-hit {
+  pointer-events: stroke !important;
+}


### PR DESCRIPTION
## Summary

Air-defense rings overlap heavily on busy maps, so it's hard to tell which site a given ring belongs to — sometimes you almost need a ruler. Hovering a threat or detection ring (ally or enemy) now highlights its emitter while the cursor is on it: the whole ring turns yellow, a bright marker is drawn on the emitter, and the emitter's icon is raised above any icons stacked on top of it. Everything reverts when the cursor leaves.

## Notes

- Each ring also gets a wide, invisible hover band (`pointer-events: stroke`), so the thin fixed-pixel stroke is easy to hit at any zoom level without filling the whole disc.
- The highlight marker is drawn in the tooltip pane so it sits above the unit icons.
- A transient `hoveredEmitterId` in the map slice lets the emitter's icon raise its z-index while its ring is hovered.

Frontend-only. (Carrier/LHA rings come from a separate change; raising their icons can follow once that lands.)