### PR TITLE
Make aircraft payload handling robust (skip unparseable files; write loadouts atomically)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,7 @@
 * **[AirWing]** Squadron list shows living-pilot, aircraft and unassigned counts; squadron dialog shows each pilot's experience level, lists killed-in-action pilots separately and hides the redundant "Active" status
 * **[AirWing]** Squadron dialog shows the aircraft type, an aircraft inventory (initial/current/destroyed/purchased), and buy/sell aircraft controls with price, on-order count and available parking slots
 * **[AirWing]** Air Wing list shows a "transfer ordered to X" indicator, and Airfield Command lists the units transferring into the base next turn
-* **[Mission Generation]** A malformed or unsupported aircraft payload file (e.g. from a third-party mod) no longer aborts turn generation; the affected aircraft falls back to an empty loadout and the error is logged.
+* **[Mission Generation]** A malformed or unsupported aircraft payload file (e.g. a hand-written third-party mod file) no longer hides every payload for that airframe: the unparseable file is skipped and the rest -- including your own Mission-Editor-saved loadouts -- still load and are selectable. If none can be read, the aircraft falls back to an empty loadout instead of aborting turn generation, and the error is logged.
 * **[UI]** Avoid a crash dialog ("'QWidgetItem' object has no attribute 'width'") when a list using the two-column row delegate relayouts with a malformed style option under PySide6 6.4.x.
 
 ## Fixes

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 
 ## Fixes
+* **[Mission Generation]** A malformed or unsupported aircraft payload file (e.g. from a third-party mod) no longer aborts turn generation; the affected aircraft falls back to an empty loadout and the error is logged.
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 * **[UI]** Avoid a crash dialog ("'QWidgetItem' object has no attribute 'width'") when a list using the two-column row delegate relayouts with a malformed style option under PySide6 6.4.x.
 
 ## Fixes
+* **[Mission Generation]** Loadout payloads are saved atomically (write to a temp file, then rename), so mission generation or the payload editor never reads a half-written payload file.
 * **[AirWing]** Squadron transfer-destination parking now accounts for already-ordered incoming transfers, matching the Airfield Command hangar count
 * **[Mission Generation]** Anti-Ship flights now attack the carrier group the flight plan routes to instead of the control point's first ground object, so strikes against carrier groups no longer leave the AI without a target (it would fly to the ingress point and turn back without engaging).
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.

--- a/game/ato/loadouts.py
+++ b/game/ato/loadouts.py
@@ -307,12 +307,20 @@ class Loadout:
         dcs_unit_type: Type[FlyingType],
         target: Optional[MissionTarget] = None,
     ) -> Loadout:
-        # Iterate through each possible payload type for a given aircraft.
-        # Some aircraft have custom loadouts that in aren't the standard set.
-        for name in cls.default_loadout_names_for(task):
-            # This operation is cached, but must be called before load_by_name will
-            # work.
+        try:
             dcs_unit_type.load_payloads()
+        except Exception:
+            logging.exception(
+                "Could not load payloads for %s; using an empty loadout. This is "
+                "usually a malformed or unsupported payload file, often from a "
+                "third-party mod.",
+                dcs_unit_type.id,
+            )
+            return cls.empty_loadout()
+
+        # Iterate through each possible payload type for a given aircraft.
+        # Some aircraft have custom loadouts that aren't in the standard set.
+        for name in cls.default_loadout_names_for(task):
             payload = dcs_unit_type.loadout_by_name(name)
             if payload is not None:
                 if target:

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -58,6 +58,12 @@ from game.utils import (
     kph,
     nautical_miles,
 )
+from game.dcs.payload_loading import install_resilient_payload_loading
+
+# Make pydcs tolerate a single unparseable payload .lua (common with hand-written
+# third-party mod files) instead of dropping every payload for the airframe.
+# Installed here because this module is imported before any payload is loaded.
+install_resilient_payload_loading()
 
 if TYPE_CHECKING:
     from game.missiongenerator.aircraft.flightdata import FlightData

--- a/game/dcs/payload_loading.py
+++ b/game/dcs/payload_loading.py
@@ -1,0 +1,95 @@
+"""Resilient drop-in for pydcs' ``FlyingType.load_payloads``.
+
+pydcs parses every payload ``.lua`` that belongs to an aircraft type and aborts
+the *whole* type if any single file fails to parse: it only tolerates
+``SyntaxError`` per file, so a malformed number (``ValueError: could not convert
+string to float: ''``) or any other error propagates and the aircraft ends up
+with no selectable payloads at all.
+
+Third-party mods routinely ship hand-written payload files that use Lua locals,
+block comments and variable references (e.g. ``["num"] = WTL`` instead of
+``["num"] = 1``), which pydcs' minimal Lua reader cannot parse. One such file
+then hides every other payload for that airframe -- including the user's own
+payloads saved by the DCS Mission Editor, which parse fine.
+
+This installs a replacement that parses each file independently and keeps every
+payload it can read, skipping (and logging) only the files that fail. Behaviour
+is otherwise identical to pydcs, including the decreasing-preference ordering of
+the payload directories.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+_installed = False
+
+
+def install_resilient_payload_loading() -> None:
+    """Patch ``FlyingType.load_payloads`` to skip unparseable files per-file.
+
+    Idempotent: safe to call more than once. Must run before payloads are first
+    loaded (i.e. at startup) so every airframe benefits.
+    """
+    global _installed
+    if _installed:
+        return
+
+    from dcs import lua
+    from dcs.payloads import PayloadDirectories
+    from dcs.unittype import FlyingType
+
+    def load_payloads(cls: Any) -> Dict[str, Any]:
+        if FlyingType._UnitPayloadGlobals is None:
+            from dcs import task
+
+            FlyingType._UnitPayloadGlobals = {
+                v.internal_name: v.id for k, v in task.MainTask.map.items()
+            }
+
+        FlyingType.scan_payload_dir()
+        if cls.payloads is not None:
+            return cls.payloads
+        cls.payloads = {}
+
+        for payload_dir in PayloadDirectories.payload_dirs():
+            if not payload_dir.exists():
+                continue
+            for payload_path in payload_dir.glob("*.lua"):
+                # ``_payload_cache`` maps each file to the unit type it declares;
+                # only parse files that belong to this airframe.
+                if FlyingType._payload_cache.get(payload_path) != cls.id:
+                    continue
+                if not payload_path.exists():
+                    continue
+                try:
+                    payload_main = lua.loads(
+                        payload_path.read_text(),
+                        _globals=FlyingType._UnitPayloadGlobals,
+                    )
+                    pays = payload_main["unitPayloads"]
+                    if pays["unitType"] != cls.id:
+                        continue
+                    # Directories are iterated in decreasing order of
+                    # preference; keep the first occurrence of each name.
+                    for load in pays["payloads"].values():
+                        name = load["name"]
+                        if name not in cls.payloads:
+                            cls.payloads[name] = load
+                except Exception:
+                    logger.warning(
+                        "Skipping unparseable payload file %s for %s. This is "
+                        "usually a hand-written third-party mod payload file "
+                        "that pydcs cannot parse; its other payloads are kept.",
+                        payload_path,
+                        getattr(cls, "id", cls),
+                        exc_info=True,
+                    )
+                    continue
+        return cls.payloads
+
+    FlyingType.load_payloads = classmethod(load_payloads)  # type: ignore[method-assign,assignment]
+    _installed = True

--- a/qt_ui/windows/mission/flight/payload/QLoadoutEditor.py
+++ b/qt_ui/windows/mission/flight/payload/QLoadoutEditor.py
@@ -1,5 +1,8 @@
+import os
+import tempfile
 from collections.abc import Iterator
 from dataclasses import dataclass
+from pathlib import Path
 from shutil import copyfile
 from typing import Dict, Union, Any
 
@@ -24,6 +27,31 @@ from game.data.weapons import Pylon
 from game.persistency import payloads_dir
 from qt_ui.blocksignals import block_signals
 from qt_ui.windows.mission.flight.payload.QPylonEditor import QPylonEditor
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write text to path atomically.
+
+    A payload .lua is read by pydcs (during mission generation) at the same time
+    the user can save one here. Writing in place leaves a window where the file
+    is truncated, which makes the reader choke on a half-written number. Write to
+    a temp file in the same directory and os.replace() it into place so a reader
+    only ever sees the old or the new file, never a partial one.
+    """
+    directory = path.parent
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=f"{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 class QLoadoutEditor(QGroupBox):
@@ -119,24 +147,28 @@ class QLoadoutEditor(QGroupBox):
                 pdict[next_key] = DcsPayload.from_flight_member(
                     self.flight_member, payload_name
                 ).to_dict()
-                with payload_file.open("w", encoding="utf-8") as f:
-                    f.write("local unitPayloads = ")
-                    f.write(lua.dumps(payloads["unitPayloads"], indent=1))
-                    f.write("\nreturn unitPayloads")
+                _atomic_write_text(
+                    payload_file,
+                    "local unitPayloads = "
+                    + lua.dumps(payloads["unitPayloads"], indent=1)
+                    + "\nreturn unitPayloads",
+                )
         else:
-            with payload_file.open("w", encoding="utf-8") as f:
-                payloads = {
-                    "name": f"{self.flight.unit_type.dcs_unit_type.id}",
-                    "payloads": {
-                        1: DcsPayload.from_flight_member(
-                            self.flight_member, payload_name
-                        ).to_dict(),
-                    },
-                    "unitType": f"{self.flight.unit_type.dcs_unit_type.id}",
-                }
-                f.write("local unitPayloads = ")
-                f.write(lua.dumps(payloads, indent=1))
-                f.write("\nreturn unitPayloads")
+            payloads = {
+                "name": f"{self.flight.unit_type.dcs_unit_type.id}",
+                "payloads": {
+                    1: DcsPayload.from_flight_member(
+                        self.flight_member, payload_name
+                    ).to_dict(),
+                },
+                "unitType": f"{self.flight.unit_type.dcs_unit_type.id}",
+            }
+            _atomic_write_text(
+                payload_file,
+                "local unitPayloads = "
+                + lua.dumps(payloads, indent=1)
+                + "\nreturn unitPayloads",
+            )
             self.flight.unit_type.dcs_unit_type.add_to_payload_cache(payload_file)
         self.saved.emit(payload_name)
         QMessageBox.information(

--- a/tests/ato/test_loadouts.py
+++ b/tests/ato/test_loadouts.py
@@ -1,8 +1,12 @@
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from game.ato.flighttype import FlightType
 from game.ato.loadouts import Loadout
+from game.dcs.payload_loading import install_resilient_payload_loading
 
 
 def test_default_loadout_falls_back_when_payloads_fail_to_load() -> None:
@@ -23,3 +27,80 @@ def test_default_loadout_falls_back_when_payloads_fail_to_load() -> None:
 
     assert loadout.name == "Empty"
     assert loadout.pylons == {}
+
+
+_GOOD_PAYLOAD = """\
+local unitPayloads = {
+\t["name"] = "ResilientTestJet",
+\t["payloads"] = {
+\t\t[1] = {
+\t\t\t["name"] = "Good Loadout",
+\t\t\t["pylons"] = {
+\t\t\t\t[1] = { ["CLSID"] = "{GOOD-WEAPON}", ["num"] = 1 },
+\t\t\t},
+\t\t\t["tasks"] = { [1] = 31 },
+\t\t},
+\t},
+\t["unitType"] = "ResilientTestJet",
+}
+return unitPayloads
+"""
+
+# Mirrors a hand-written mod payload that pydcs' minimal Lua reader chokes on:
+# a numeric field that resolves to an empty token (the real-world
+# "could not convert string to float: ''").
+_BAD_PAYLOAD = """\
+local unitPayloads = {
+\t["name"] = "ResilientTestJet",
+\t["payloads"] = {
+\t\t[1] = {
+\t\t\t["name"] = "Bad Loadout",
+\t\t\t["pylons"] = {
+\t\t\t\t[1] = { ["CLSID"] = "{BAD-WEAPON}", ["num"] = - },
+\t\t\t},
+\t\t\t["tasks"] = { [1] = 31 },
+\t\t},
+\t},
+\t["unitType"] = "ResilientTestJet",
+}
+return unitPayloads
+"""
+
+
+def test_load_payloads_skips_unparseable_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One unparseable payload file must not hide the rest for an airframe.
+
+    A hand-written mod payload file makes pydcs raise while parsing it (here a
+    numeric field that resolves to an empty token). The resilient loader should
+    skip just
+    that file and still return every payload it can read -- e.g. the user's
+    own Mission-Editor-saved loadouts.
+    """
+    from dcs import lua
+    from dcs.payloads import PayloadDirectories
+    from dcs.unittype import FlyingType
+
+    (tmp_path / "good.lua").write_text(_GOOD_PAYLOAD, encoding="utf-8")
+    (tmp_path / "bad.lua").write_text(_BAD_PAYLOAD, encoding="utf-8")
+
+    # Sanity check: the bad file really is unparseable by pydcs, so the test
+    # actually exercises the skip path rather than passing trivially.
+    with pytest.raises(Exception):
+        lua.loads(_BAD_PAYLOAD)
+
+    class _ResilientTestType(FlyingType):
+        id = "ResilientTestJet"
+        payloads = None
+
+    # Isolate pydcs from the real payload directories and its global scan cache.
+    monkeypatch.setattr(
+        PayloadDirectories, "payload_dirs", classmethod(lambda cls: iter([tmp_path]))
+    )
+    monkeypatch.setattr(FlyingType, "_payload_cache", None)
+
+    install_resilient_payload_loading()
+    payloads = _ResilientTestType.load_payloads()
+
+    assert set(payloads) == {"Good Loadout"}

--- a/tests/ato/test_loadouts.py
+++ b/tests/ato/test_loadouts.py
@@ -1,0 +1,25 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+from game.ato.flighttype import FlightType
+from game.ato.loadouts import Loadout
+
+
+def test_default_loadout_falls_back_when_payloads_fail_to_load() -> None:
+    """A payload file that pydcs can't parse must not abort mission planning.
+
+    Some third-party mods ship payload .lua files pydcs chokes on (e.g. a
+    numeric field that ends up empty). load_payloads() then raises; the default
+    loadout lookup should swallow that and return an empty loadout instead of
+    letting the exception propagate through turn generation.
+    """
+    unit_type: Any = MagicMock()
+    unit_type.id = "BrokenMod"
+    unit_type.load_payloads.side_effect = ValueError(
+        "could not convert string to float: ''"
+    )
+
+    loadout = Loadout.default_for_task_and_aircraft(FlightType.ANTISHIP, unit_type)
+
+    assert loadout.name == "Empty"
+    assert loadout.pylons == {}


### PR DESCRIPTION
Two related robustness fixes for how aircraft payload `.lua` files are handled:

- **Reading:** an unparseable payload file (e.g. a hand-written third-party mod file like the CJS Super Hornet's FA-18E / EA-18G) no longer leaves the airframe with **no selectable payloads** — only the bad file is skipped, the rest (including your own Mission-Editor-saved loadouts) still load. If none can be read, the aircraft falls back to an empty loadout instead of aborting turn generation.
- **Writing:** loadouts are saved atomically (temp file + `os.replace`), so a reader never sees a half-written file.

Supersedes #796 (folded in here).
