### PR TITLE
Migrate legacy fast-forward settings on load

### DIFF
--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -1465,14 +1465,110 @@ class Settings:
     def deserialize_state_dict(state: dict[str, Any]) -> dict[str, Any]:
         # restore Enum & timedelta types
         s = Settings()
-        for key, value in state.items():
-            if isinstance(s.__dict__.get(key), timedelta) and isinstance(value, int):
+        Settings._migrate_legacy_fast_forward(state)
+        for key, value in list(state.items()):
+            default = s.__dict__.get(key)
+            if isinstance(default, Enum):
+                # Restore the stored member, falling back to the field default
+                # for any value that no longer resolves to a member of this
+                # field's enum -- a stale/renamed choice, or a legacy non-enum
+                # value such as None or a bool. Otherwise the bad value crashes
+                # the load and later the settings UI via text_for_value.
+                restored = Settings._restore_enum(value, type(default))
+                state[key] = restored if restored is not None else default
+            elif isinstance(default, timedelta) and isinstance(value, int):
                 state[key] = timedelta(minutes=value)
-            elif isinstance(s.__dict__.get(key), Enum) and isinstance(value, str):
-                state[key] = eval(value)
             elif isinstance(value, dict):
                 state[key] = s.obj_hook(value)
         return state
+
+    @staticmethod
+    def _restore_enum(value: Any, enum_cls: type[Enum]) -> Optional[Enum]:
+        """Resolve a serialized value to a member of enum_cls, or None if it no
+        longer maps to one (stale, renamed, or a legacy non-enum value)."""
+        if isinstance(value, enum_cls):
+            return value
+        # Accept the JSON form {"Enum": "EnumName.MEMBER"} and the bare
+        # "EnumName.MEMBER" string; ignore anything that does not eval to a
+        # member of this field's enum.
+        expr: Optional[str] = None
+        if isinstance(value, dict):
+            inner = value.get("Enum")
+            if isinstance(inner, str):
+                expr = inner
+        elif isinstance(value, str):
+            expr = value
+        if expr is not None:
+            try:
+                restored = eval(expr)
+            except Exception:
+                return None
+            if isinstance(restored, enum_cls):
+                return restored
+        return None
+
+    @staticmethod
+    def _migrate_legacy_fast_forward(state: dict[str, Any]) -> None:
+        """Map pre-#684 fast-forward settings onto the current enums.
+
+        Before #684 fast-forward was three separate fields::
+
+            fast_forward_to_first_contact: bool          # was it enabled
+            player_mission_interrupts_sim_at: Optional[StartType]
+                # None=Never, COLD=startup, WARM=taxi, RUNWAY=takeoff
+            auto_resolve_combat: bool
+
+        #684 replaced them with ``fast_forward_stop_condition`` /
+        ``combat_resolution_method``. Translate old saves so the user keeps an
+        equivalent setting instead of crashing on load, and normalize the legacy
+        "Never"/None sentinel (which has no enum member) to "no fast forward".
+        """
+        legacy_ff = state.pop("fast_forward_to_first_contact", None)
+        legacy_interrupt = state.pop("player_mission_interrupts_sim_at", None)
+        legacy_auto = state.pop("auto_resolve_combat", None)
+
+        if "fast_forward_stop_condition" not in state and legacy_ff is not None:
+            if not legacy_ff:
+                state["fast_forward_stop_condition"] = FastForwardStopCondition.DISABLED
+            else:
+                interrupt = Settings._resolve_start_type(legacy_interrupt)
+                if interrupt is None:
+                    state["fast_forward_stop_condition"] = (
+                        FastForwardStopCondition.FIRST_CONTACT
+                    )
+                else:
+                    state["fast_forward_stop_condition"] = {
+                        StartType.COLD: FastForwardStopCondition.PLAYER_STARTUP,
+                        StartType.WARM: FastForwardStopCondition.PLAYER_TAXI,
+                        StartType.RUNWAY: FastForwardStopCondition.PLAYER_TAKEOFF,
+                    }.get(interrupt, FastForwardStopCondition.FIRST_CONTACT)
+
+        if "combat_resolution_method" not in state and legacy_auto is not None:
+            state["combat_resolution_method"] = (
+                CombatResolutionMethod.RESOLVE
+                if legacy_auto
+                else CombatResolutionMethod.PAUSE
+            )
+
+        # A "none"/"Never"/None value stored directly under the new key has no
+        # matching enum member; treat that family as "no fast forward".
+        ff = state.get("fast_forward_stop_condition")
+        if ff is None and "fast_forward_stop_condition" in state:
+            state["fast_forward_stop_condition"] = FastForwardStopCondition.DISABLED
+        elif isinstance(ff, str) and ff.strip().lower() in {"none", "never", ""}:
+            state["fast_forward_stop_condition"] = FastForwardStopCondition.DISABLED
+
+    @staticmethod
+    def _resolve_start_type(value: Any) -> Optional[StartType]:
+        """Coerce a serialized legacy value to a StartType member, or None."""
+        if isinstance(value, StartType):
+            return value
+        if isinstance(value, str):
+            name = value.rsplit(".", 1)[-1]
+            for member in StartType:
+                if name == member.name or value == member.value:
+                    return member
+        return None
 
     @classmethod
     def _field_description(cls, settings_field: Field[Any]) -> OptionDescription:

--- a/tests/test_settings_fast_forward_migration.py
+++ b/tests/test_settings_fast_forward_migration.py
@@ -1,0 +1,165 @@
+"""Save-compat migration for the pre-#684 fast-forward settings.
+
+#684 replaced ``fast_forward_to_first_contact`` / ``player_mission_interrupts_sim_at``
+/ ``auto_resolve_combat`` with the ``FastForwardStopCondition`` and
+``CombatResolutionMethod`` enums. Loading an older save (or one holding the
+legacy ``None``/``"none"`` "Never" sentinel) must not crash.
+"""
+
+from typing import Any
+
+from game.ato.starttype import StartType
+from game.settings.settings import (
+    CombatResolutionMethod,
+    FastForwardStopCondition,
+    Settings,
+)
+
+
+def _deserialized(state: dict[str, Any]) -> dict[str, Any]:
+    return Settings.deserialize_state_dict(dict(state))
+
+
+def test_string_none_stop_condition_maps_to_disabled() -> None:
+    out = _deserialized({"fast_forward_stop_condition": "none"})
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.DISABLED
+
+
+def test_python_none_stop_condition_maps_to_disabled() -> None:
+    out = _deserialized({"fast_forward_stop_condition": None})
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.DISABLED
+
+
+def test_string_never_stop_condition_maps_to_disabled() -> None:
+    out = _deserialized({"fast_forward_stop_condition": "Never"})
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.DISABLED
+
+
+def test_valid_stop_condition_is_preserved() -> None:
+    out = _deserialized(
+        {"fast_forward_stop_condition": "FastForwardStopCondition.PLAYER_TAXI"}
+    )
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.PLAYER_TAXI
+
+
+def test_legacy_fields_disabled_maps_to_disabled() -> None:
+    out = _deserialized(
+        {
+            "fast_forward_to_first_contact": False,
+            "player_mission_interrupts_sim_at": StartType.COLD,
+        }
+    )
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.DISABLED
+    # Legacy keys are consumed, not left as junk attributes.
+    assert "fast_forward_to_first_contact" not in out
+    assert "player_mission_interrupts_sim_at" not in out
+
+
+def test_legacy_enabled_at_startup_maps_to_player_startup() -> None:
+    out = _deserialized(
+        {
+            "fast_forward_to_first_contact": True,
+            "player_mission_interrupts_sim_at": StartType.COLD,
+        }
+    )
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.PLAYER_STARTUP
+
+
+def test_legacy_enabled_at_taxi_maps_to_player_taxi() -> None:
+    out = _deserialized(
+        {
+            "fast_forward_to_first_contact": True,
+            "player_mission_interrupts_sim_at": StartType.WARM,
+        }
+    )
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.PLAYER_TAXI
+
+
+def test_legacy_enabled_at_takeoff_maps_to_player_takeoff() -> None:
+    out = _deserialized(
+        {
+            "fast_forward_to_first_contact": True,
+            "player_mission_interrupts_sim_at": StartType.RUNWAY,
+        }
+    )
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.PLAYER_TAKEOFF
+
+
+def test_legacy_enabled_never_interrupt_maps_to_first_contact() -> None:
+    out = _deserialized(
+        {
+            "fast_forward_to_first_contact": True,
+            "player_mission_interrupts_sim_at": None,
+        }
+    )
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.FIRST_CONTACT
+
+
+def test_legacy_start_type_stored_as_string_is_resolved() -> None:
+    out = _deserialized(
+        {
+            "fast_forward_to_first_contact": True,
+            "player_mission_interrupts_sim_at": "StartType.WARM",
+        }
+    )
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.PLAYER_TAXI
+
+
+def test_legacy_auto_resolve_combat_maps_to_resolve() -> None:
+    out = _deserialized({"auto_resolve_combat": True})
+    assert out["combat_resolution_method"] is CombatResolutionMethod.RESOLVE
+    assert "auto_resolve_combat" not in out
+
+
+def test_legacy_auto_resolve_combat_off_maps_to_pause() -> None:
+    out = _deserialized({"auto_resolve_combat": False})
+    assert out["combat_resolution_method"] is CombatResolutionMethod.PAUSE
+
+
+def test_setstate_yields_a_valid_member_for_legacy_none() -> None:
+    # __setstate__ is the real load path; the field must end as a usable member.
+    settings = Settings.__new__(Settings)
+    settings.__setstate__({"fast_forward_stop_condition": "none"})
+    assert isinstance(settings.fast_forward_stop_condition, FastForwardStopCondition)
+    assert settings.fast_forward_stop_condition is FastForwardStopCondition.DISABLED
+
+
+def test_python_none_combat_method_falls_back_to_default() -> None:
+    out = _deserialized({"combat_resolution_method": None})
+    assert out["combat_resolution_method"] is CombatResolutionMethod.PAUSE
+
+
+def test_string_none_combat_method_falls_back_to_default() -> None:
+    out = _deserialized({"combat_resolution_method": "none"})
+    assert out["combat_resolution_method"] is CombatResolutionMethod.PAUSE
+
+
+def test_legacy_bool_combat_method_falls_back_to_default() -> None:
+    # A leftover bool from the pre-#684 auto_resolve_combat field stored under
+    # the new key is not a member -> field default.
+    out = _deserialized({"combat_resolution_method": True})
+    assert out["combat_resolution_method"] is CombatResolutionMethod.PAUSE
+
+
+def test_valid_combat_method_is_preserved() -> None:
+    out = _deserialized({"combat_resolution_method": "CombatResolutionMethod.SKIP"})
+    assert out["combat_resolution_method"] is CombatResolutionMethod.SKIP
+
+
+def test_json_encoded_enum_is_restored() -> None:
+    out = _deserialized(
+        {"fast_forward_stop_condition": {"Enum": "FastForwardStopCondition.MANUAL"}}
+    )
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.MANUAL
+
+
+def test_json_encoded_stale_enum_falls_back_to_default() -> None:
+    out = _deserialized(
+        {"fast_forward_stop_condition": {"Enum": "FastForwardStopCondition.NEVER"}}
+    )
+    assert out["fast_forward_stop_condition"] is FastForwardStopCondition.PLAYER_STARTUP
+
+
+def test_already_resolved_enum_member_is_kept() -> None:
+    out = _deserialized({"combat_resolution_method": CombatResolutionMethod.RESOLVE})
+    assert out["combat_resolution_method"] is CombatResolutionMethod.RESOLVE


### PR DESCRIPTION
Resolves an issue when migrating campaigns from 1.5.0 to a commit after #684. That PR updated FastForwardStopCondition and CombatResolutionMethod enums but were missing migrations for existing saves. As a result loading from a save in the old format and trying to configure the campaign to update to the new settings would result in an error and the inability to change any settings. 

Complements #744, which solves an issue during take-off around the same circumstances. Both appear to be necessary.