### PR TITLE
Show per-side (OwnFor/OpFor) losses in mission status window (#629)

### DIFF
--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -91,6 +91,18 @@ class BaseCaptureEvent:
 
 
 @dataclass(frozen=True)
+class SideLossCounts:
+    aircraft: int
+    front_line: int
+    convoy: int
+    cargo_ships: int
+    airlift_cargo: int
+    ground_objects: int
+    scenery: int
+    bases_lost: int
+
+
+@dataclass(frozen=True)
 class StateData:
     #: True if the mission ended. If False, the mission exited abnormally.
     mission_ended: bool
@@ -270,6 +282,39 @@ class Debriefing:
         for loss in losses:
             losses_by_type[loss.trigger_zone.name] += 1
         return losses_by_type
+
+    def loss_counts(self, player: Player) -> SideLossCounts:
+        gl = self.ground_losses
+        if player.is_blue:
+            air = self.air_losses.player
+            front_line = gl.player_front_line
+            convoy = gl.player_convoy
+            cargo_ships = gl.player_cargo_ships
+            airlifts = gl.player_airlifts
+            ground_objects = gl.player_ground_objects
+            scenery = gl.player_scenery
+        else:
+            air = self.air_losses.enemy
+            front_line = gl.enemy_front_line
+            convoy = gl.enemy_convoy
+            cargo_ships = gl.enemy_cargo_ships
+            airlifts = gl.enemy_airlifts
+            ground_objects = gl.enemy_ground_objects
+            scenery = gl.enemy_scenery
+        return SideLossCounts(
+            aircraft=len(air),
+            front_line=len(front_line),
+            convoy=len(convoy),
+            cargo_ships=len(cargo_ships),
+            airlift_cargo=sum(len(loss.cargo) for loss in airlifts),
+            ground_objects=len(ground_objects),
+            scenery=len(scenery),
+            bases_lost=sum(
+                1
+                for capture in self.base_captures
+                if capture.captured_by_player == player.opponent
+            ),
+        )
 
     def dead_aircraft(self) -> AirLosses:
         player_losses = []

--- a/qt_ui/windows/QWaitingForMissionResultWindow.py
+++ b/qt_ui/windows/QWaitingForMissionResultWindow.py
@@ -23,6 +23,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from game import Game
 from game.ato.flightstate import Uninitialized
 from game.debriefing import Debriefing
+from game.theater import Player
 from game.profiling import logged_duration
 from game.server import EventStream
 from game.sim import GameUpdateEvents
@@ -136,10 +137,13 @@ class QWaitingForMissionResultWindow(QDialog):
         self.setLayout(self.layout)
 
     @staticmethod
-    def add_update_row(description: str, count: int, layout: QGridLayout) -> None:
+    def add_update_row(
+        description: str, blue: int, red: int, layout: QGridLayout
+    ) -> None:
         row = layout.rowCount()
         layout.addWidget(QLabel(f"<b>{description}</b>"), row, 0)
-        layout.addWidget(QLabel(f"{count}"), row, 1)
+        layout.addWidget(QLabel(f"{blue}"), row, 1)
+        layout.addWidget(QLabel(f"{red}"), row, 2)
 
     def updateLayout(self, debriefing: Debriefing) -> None:
         updateBox = QGroupBox("Mission status")
@@ -147,40 +151,28 @@ class QWaitingForMissionResultWindow(QDialog):
         updateBox.setLayout(update_layout)
         self.debriefing = debriefing
 
-        self.add_update_row(
-            "Aircraft destroyed", len(list(debriefing.air_losses.losses)), update_layout
+        blue = debriefing.loss_counts(Player.BLUE)
+        red = debriefing.loss_counts(Player.RED)
+
+        update_layout.addWidget(
+            QLabel(f"<b>{debriefing.player_country} (OwnFor)</b>"), 0, 1
         )
-        self.add_update_row(
-            "Front line units destroyed",
-            len(list(debriefing.front_line_losses)),
-            update_layout,
+        update_layout.addWidget(
+            QLabel(f"<b>{debriefing.enemy_country} (OpFor)</b>"), 0, 2
         )
-        self.add_update_row(
-            "Convoy units destroyed", len(list(debriefing.convoy_losses)), update_layout
-        )
-        self.add_update_row(
-            "Shipping cargo destroyed",
-            len(list(debriefing.cargo_ship_losses)),
-            update_layout,
-        )
-        self.add_update_row(
-            "Airlift cargo destroyed",
-            sum(len(loss.cargo) for loss in debriefing.airlift_losses),
-            update_layout,
-        )
-        self.add_update_row(
-            "Ground Objects destroyed",
-            len(list(debriefing.ground_object_losses)),
-            update_layout,
-        )
-        self.add_update_row(
-            "Scenery Objects destroyed",
-            len(list(debriefing.scenery_object_losses)),
-            update_layout,
-        )
-        self.add_update_row(
-            "Base capture events", len(debriefing.base_captures), update_layout
-        )
+
+        rows = [
+            ("Aircraft lost", blue.aircraft, red.aircraft),
+            ("Front line units lost", blue.front_line, red.front_line),
+            ("Convoy units lost", blue.convoy, red.convoy),
+            ("Shipping cargo lost", blue.cargo_ships, red.cargo_ships),
+            ("Airlift cargo lost", blue.airlift_cargo, red.airlift_cargo),
+            ("Ground Objects lost", blue.ground_objects, red.ground_objects),
+            ("Scenery Objects lost", blue.scenery, red.scenery),
+            ("Bases lost", blue.bases_lost, red.bases_lost),
+        ]
+        for label, blue_count, red_count in rows:
+            self.add_update_row(label, blue_count, red_count, update_layout)
 
         # Clear previous content of the window
         for i in reversed(range(self.gridLayout.count())):

--- a/tests/test_debriefing.py
+++ b/tests/test_debriefing.py
@@ -1,0 +1,107 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+from game.debriefing import (
+    AirLosses,
+    BaseCaptureEvent,
+    Debriefing,
+    GroundLosses,
+    SideLossCounts,
+)
+from game.theater import ControlPoint, Player
+
+
+def _items(n: int) -> list[Any]:
+    """n placeholder loss objects. loss_counts only needs list length."""
+    return [MagicMock() for _ in range(n)]
+
+
+def _airlift(cargo_size: int) -> Any:
+    """An airlift loss whose .cargo has the given length."""
+    return SimpleNamespace(cargo=list(range(cargo_size)))
+
+
+def _capture(captured_by: Player) -> BaseCaptureEvent:
+    return BaseCaptureEvent(cast(ControlPoint, MagicMock()), captured_by)
+
+
+def _sample_debriefing() -> Debriefing:
+    """A Debriefing with known per-side losses, built without the heavy
+    __init__ (which needs a Game and UnitMap). loss_counts and the loss
+    properties only read air_losses, ground_losses, and base_captures."""
+    air = AirLosses(player=_items(1), enemy=_items(2))
+    ground = GroundLosses(
+        player_front_line=_items(3),
+        enemy_front_line=_items(1),
+        player_convoy=_items(2),
+        enemy_convoy=_items(0),
+        player_cargo_ships=_items(1),
+        enemy_cargo_ships=_items(4),
+        player_airlifts=[_airlift(2)],
+        enemy_airlifts=[_airlift(1), _airlift(3)],
+        player_ground_objects=_items(5),
+        enemy_ground_objects=_items(2),
+        player_scenery=_items(0),
+        enemy_scenery=_items(1),
+    )
+    captures = [
+        _capture(Player.BLUE),
+        _capture(Player.BLUE),
+        _capture(Player.RED),
+    ]
+    debriefing = Debriefing.__new__(Debriefing)
+    debriefing.air_losses = air
+    debriefing.ground_losses = ground
+    debriefing.base_captures = captures
+    return debriefing
+
+
+def test_loss_counts_blue_side() -> None:
+    blue = _sample_debriefing().loss_counts(Player.BLUE)
+    assert blue == SideLossCounts(
+        aircraft=1,
+        front_line=3,
+        convoy=2,
+        cargo_ships=1,
+        airlift_cargo=2,
+        ground_objects=5,
+        scenery=0,
+        bases_lost=1,  # one base captured by RED == one base Blue lost
+    )
+
+
+def test_loss_counts_red_side() -> None:
+    red = _sample_debriefing().loss_counts(Player.RED)
+    assert red == SideLossCounts(
+        aircraft=2,
+        front_line=1,
+        convoy=0,
+        cargo_ships=4,
+        airlift_cargo=4,  # 1 + 3
+        ground_objects=2,
+        scenery=1,
+        bases_lost=2,  # two bases captured by BLUE == two bases Red lost
+    )
+
+
+def test_loss_counts_partition_matches_combined_totals() -> None:
+    """Blue + Red for each category must equal the combined total the UI
+    shows today (the existing Debriefing properties). Pins that loss_counts
+    reads the same lists and never alters totals."""
+    debriefing = _sample_debriefing()
+    blue = debriefing.loss_counts(Player.BLUE)
+    red = debriefing.loss_counts(Player.RED)
+
+    assert blue.aircraft + red.aircraft == len(list(debriefing.air_losses.losses))
+    assert blue.front_line + red.front_line == len(list(debriefing.front_line_losses))
+    assert blue.convoy + red.convoy == len(list(debriefing.convoy_losses))
+    assert blue.cargo_ships + red.cargo_ships == len(list(debriefing.cargo_ship_losses))
+    assert blue.airlift_cargo + red.airlift_cargo == sum(
+        len(loss.cargo) for loss in debriefing.airlift_losses
+    )
+    assert blue.ground_objects + red.ground_objects == len(
+        list(debriefing.ground_object_losses)
+    )
+    assert blue.scenery + red.scenery == len(list(debriefing.scenery_object_losses))
+    assert blue.bases_lost + red.bases_lost == len(debriefing.base_captures)


### PR DESCRIPTION
## Summary
- The mission status window previously showed a single combined total per
  loss category (e.g. "Front line units destroyed: 37"), giving no sense of
  who lost what. This splits every category into **OwnFor** (your faction)
  and **OpFor** (enemy) columns.
- Adds `SideLossCounts` and `Debriefing.loss_counts(player)` to compute
  per-side losses for aircraft, front line, convoy, shipping cargo, airlift
  cargo, ground objects, scenery, and bases lost.
- Rewires `QWaitingForMissionResultWindow` to render the blue/red columns;
  no change to how losses are detected, only how they're attributed and shown.
