### PR TITLE
Improve auto-asigned TACAN codes' visibility

### DIFF
--- a/client/src/api/_liberationApi.ts
+++ b/client/src/api/_liberationApi.ts
@@ -349,6 +349,8 @@ export type ControlPoint = {
   mobile: boolean;
   destination?: LatLng;
   sidc: string;
+  tacan?: string | null;
+  atc_frequency?: string | null;
 };
 export type ValidationError = {
   loc: (string | number)[];

--- a/client/src/components/controlpoints/LocationTooltipText.tsx
+++ b/client/src/components/controlpoints/LocationTooltipText.tsx
@@ -1,9 +1,19 @@
 interface LocationTooltipTextProps {
   name: string;
+  tacan?: string | null;
+  atcFrequency?: string | null;
 }
 
 export const LocationTooltipText = (props: LocationTooltipTextProps) => {
-  return <h3 style={{ margin: 0 }}>{props.name}</h3>;
+  return (
+    <>
+      <h3 style={{ margin: 0 }}>{props.name}</h3>
+      {props.atcFrequency && (
+        <div style={{ marginTop: 2 }}>ATC: {props.atcFrequency}</div>
+      )}
+      {props.tacan && <div>TACAN: {props.tacan}</div>}
+    </>
+  );
 };
 
 export default LocationTooltipText;

--- a/client/src/components/controlpoints/MobileControlPoint.tsx
+++ b/client/src/components/controlpoints/MobileControlPoint.tsx
@@ -102,7 +102,11 @@ function PrimaryMarker(props: PrimaryMarkerProps) {
             true
           )
         : ReactDOMServer.renderToString(
-            <LocationTooltipText name={props.controlPoint.name} />
+            <LocationTooltipText
+              name={props.controlPoint.name}
+              tacan={props.controlPoint.tacan}
+              atcFrequency={props.controlPoint.atc_frequency}
+            />
           )
     );
   });

--- a/client/src/components/controlpoints/StaticControlPoint.tsx
+++ b/client/src/components/controlpoints/StaticControlPoint.tsx
@@ -20,7 +20,11 @@ export const StaticControlPoint = (props: StaticControlPointProps) => {
       eventHandlers={makeLocationMarkerEventHandlers(props.controlPoint)}
     >
       <Tooltip>
-        <LocationTooltipText name={props.controlPoint.name} />
+        <LocationTooltipText
+          name={props.controlPoint.name}
+          tacan={props.controlPoint.tacan}
+          atcFrequency={props.controlPoint.atc_frequency}
+        />
       </Tooltip>
     </Marker>
   );

--- a/game/missiongenerator/briefinggenerator.py
+++ b/game/missiongenerator/briefinggenerator.py
@@ -32,15 +32,6 @@ class CommInfo:
     freq: RadioFrequency
 
 
-@dataclass
-class OwnedAirbaseInfo:
-    """A friendly airbase with its (optional) TACAN, for the briefing."""
-
-    name: str
-    tacan: str
-    tacan_callsign: str
-
-
 class FrontLineInfo:
     def __init__(self, front_line: FrontLine):
         self.front_line: FrontLine = front_line
@@ -177,35 +168,10 @@ class BriefingGenerator(MissionInfoGenerator):
         """Generate the mission briefing"""
         self._generate_frontline_info()
         self.generate_allied_flights_by_departure()
-        self.owned_airbases = self._collect_owned_airbases()
         self.mission.set_description_text(self.template.render(vars(self)))
         self.mission.add_picture_blue(
             os.path.abspath("./resources/ui/splash_screen.png")
         )
-
-    def _collect_owned_airbases(self) -> List[OwnedAirbaseInfo]:
-        """List friendly airfields with their TACAN (when present)."""
-        from game.radio.TacanContainer import TacanContainer
-        from game.theater.controlpoint import Airfield
-
-        owned: List[OwnedAirbaseInfo] = []
-        for cp in self.game.theater.controlpoints:
-            if not isinstance(cp, Airfield):
-                continue
-            if not cp.is_friendly(cp.coalition.player):
-                continue
-            tacan = "-"
-            callsign = ""
-            if isinstance(cp, TacanContainer) and cp.tacan is not None:
-                tacan = str(cp.tacan)
-                callsign = cp.tcn_name or ""
-            owned.append(
-                OwnedAirbaseInfo(
-                    name=cp.name, tacan=tacan, tacan_callsign=callsign
-                )
-            )
-        owned.sort(key=lambda a: a.name)
-        return owned
 
     def _generate_frontline_info(self) -> None:
         """Build FrontLineInfo objects from FrontLine type and append to briefing."""

--- a/game/missiongenerator/briefinggenerator.py
+++ b/game/missiongenerator/briefinggenerator.py
@@ -32,6 +32,15 @@ class CommInfo:
     freq: RadioFrequency
 
 
+@dataclass
+class OwnedAirbaseInfo:
+    """A friendly airbase with its (optional) TACAN, for the briefing."""
+
+    name: str
+    tacan: str
+    tacan_callsign: str
+
+
 class FrontLineInfo:
     def __init__(self, front_line: FrontLine):
         self.front_line: FrontLine = front_line
@@ -168,10 +177,35 @@ class BriefingGenerator(MissionInfoGenerator):
         """Generate the mission briefing"""
         self._generate_frontline_info()
         self.generate_allied_flights_by_departure()
+        self.owned_airbases = self._collect_owned_airbases()
         self.mission.set_description_text(self.template.render(vars(self)))
         self.mission.add_picture_blue(
             os.path.abspath("./resources/ui/splash_screen.png")
         )
+
+    def _collect_owned_airbases(self) -> List[OwnedAirbaseInfo]:
+        """List friendly airfields with their TACAN (when present)."""
+        from game.radio.TacanContainer import TacanContainer
+        from game.theater.controlpoint import Airfield
+
+        owned: List[OwnedAirbaseInfo] = []
+        for cp in self.game.theater.controlpoints:
+            if not isinstance(cp, Airfield):
+                continue
+            if not cp.is_friendly(cp.coalition.player):
+                continue
+            tacan = "-"
+            callsign = ""
+            if isinstance(cp, TacanContainer) and cp.tacan is not None:
+                tacan = str(cp.tacan)
+                callsign = cp.tcn_name or ""
+            owned.append(
+                OwnedAirbaseInfo(
+                    name=cp.name, tacan=tacan, tacan_callsign=callsign
+                )
+            )
+        owned.sort(key=lambda a: a.name)
+        return owned
 
     def _generate_frontline_info(self) -> None:
         """Build FrontLineInfo objects from FrontLine type and append to briefing."""

--- a/game/missiongenerator/briefinggenerator.py
+++ b/game/missiongenerator/briefinggenerator.py
@@ -32,6 +32,16 @@ class CommInfo:
     freq: RadioFrequency
 
 
+@dataclass
+class OwnedAirbaseInfo:
+    """A friendly airbase with its (optional) TACAN and ATC, for the briefing."""
+
+    name: str
+    tacan: str
+    tacan_callsign: str
+    atc: str
+
+
 class FrontLineInfo:
     def __init__(self, front_line: FrontLine):
         self.front_line: FrontLine = front_line
@@ -168,10 +178,48 @@ class BriefingGenerator(MissionInfoGenerator):
         """Generate the mission briefing"""
         self._generate_frontline_info()
         self.generate_allied_flights_by_departure()
+        self.owned_airbases = self._collect_owned_airbases()
         self.mission.set_description_text(self.template.render(vars(self)))
         self.mission.add_picture_blue(
             os.path.abspath("./resources/ui/splash_screen.png")
         )
+
+    def _collect_owned_airbases(self) -> List[OwnedAirbaseInfo]:
+        """List friendly airfields with their TACAN and ATC (when present).
+
+        The existing 'Carriers and FARPs' section only covers runways the
+        mission generator registers (carriers and per-flight alternates), so
+        regular blue airfields don't appear there.
+        """
+        from game.atcdata import AtcData
+        from game.radio.TacanContainer import TacanContainer
+        from game.theater.controlpoint import Airfield
+
+        owned: List[OwnedAirbaseInfo] = []
+        for cp in self.game.theater.controlpoints:
+            if not isinstance(cp, Airfield):
+                continue
+            if not cp.is_friendly(cp.coalition.player):
+                continue
+            tacan = "-"
+            callsign = ""
+            if isinstance(cp, TacanContainer) and cp.tacan is not None:
+                tacan = str(cp.tacan)
+                callsign = cp.tcn_name or ""
+            atc = "-"
+            atc_radio = AtcData.from_pydcs(cp.airport)
+            if atc_radio is not None and atc_radio.uhf is not None:
+                atc = str(atc_radio.uhf)
+            owned.append(
+                OwnedAirbaseInfo(
+                    name=cp.name,
+                    tacan=tacan,
+                    tacan_callsign=callsign,
+                    atc=atc,
+                )
+            )
+        owned.sort(key=lambda a: a.name)
+        return owned
 
     def _generate_frontline_info(self) -> None:
         """Build FrontLineInfo objects from FrontLine type and append to briefing."""

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -1412,19 +1412,32 @@ class PortableTacanGenerator:
         if runway_data.tacan is not None:
             return
 
-        # Allocate a TACAN channel from the X band.
-        try:
-            tacan = self.tacan_registry.alloc_for_band(
-                TacanBand.X, TacanUsage.TransmitReceive
-            )
-        except OutOfTacanChannelsError:
-            logging.warning(
-                "No TACAN channels available for portable beacon at %s",
-                self.airfield.name,
-            )
-            return
+        # Re-use a previously assigned TACAN channel and callsign for this
+        # airfield if it has one (set by the player from the base dialog, or
+        # auto-allocated on an earlier turn). Otherwise allocate fresh and
+        # persist the choice on the airfield so it stays stable across turns
+        # and is visible in tooltips/briefings even before the next mission
+        # generation.
+        if self.airfield.tacan is not None:
+            tacan = self.airfield.tacan
+        else:
+            try:
+                tacan = self.tacan_registry.alloc_for_band(
+                    TacanBand.X, TacanUsage.TransmitReceive
+                )
+            except OutOfTacanChannelsError:
+                logging.warning(
+                    "No TACAN channels available for portable beacon at %s",
+                    self.airfield.name,
+                )
+                return
+            self.airfield.tacan = tacan
 
-        callsign = self._derive_callsign(self.airfield.name)
+        if self.airfield.tcn_name is not None:
+            callsign = self.airfield.tcn_name
+        else:
+            callsign = self._derive_callsign(self.airfield.name)
+            self.airfield.tcn_name = callsign
 
         # Place the portable TACAN beacon near the airport reference point.
         position = airport.position.point_from_heading(
@@ -1432,7 +1445,7 @@ class PortableTacanGenerator:
         )
         group = self.mission.vehicle_group(
             country=self.country,
-            name=f"{self.airfield.name} TACAN",
+            name=f"{self.airfield.name} TACAN {tacan} ({callsign})",
             _type=VehicleFortification.TACAN_beacon,
             position=position,
             group_size=1,

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -637,10 +637,15 @@ class GenericCarrierGenerator(GroundObjectGenerator):
                     tacan = self.tacan_registry.alloc_for_band(
                         TacanBand.X, TacanUsage.TransmitReceive
                     )
+                    # Persist back so subsequent turns reuse the same channel
+                    # and the UI (base dialog, tooltip) reflects the value
+                    # instead of "AUTO".
+                    self.control_point.tacan = tacan
                 else:
                     tacan = self.control_point.tacan
                 if self.control_point.tcn_name is None:
                     tacan_callsign = self.tacan_callsign()
+                    self.control_point.tcn_name = tacan_callsign
                 else:
                     tacan_callsign = self.control_point.tcn_name
                 link4 = None
@@ -1410,6 +1415,18 @@ class PortableTacanGenerator:
         assigner = RunwayAssigner(self.game.conditions)
         runway_data = assigner.get_preferred_runway(self.game.theater, airport)
         if runway_data.tacan is not None:
+            # Built-in TACAN from the terrain. Reflect it on the airfield so the
+            # base dialog, map tooltip and other UI surfaces show it just like
+            # they do for portable beacons; no portable beacon needs to be
+            # placed.
+            self.airfield.tacan = runway_data.tacan
+            self.airfield.tcn_name = runway_data.tacan_callsign
+            return
+
+        # No built-in beacon. If the portable-TACAN feature is disabled, leave
+        # this airfield without a TACAN at all -- don't allocate or place
+        # anything.
+        if not self.game.settings.generate_portable_tacans:
             return
 
         # Re-use a previously assigned TACAN channel and callsign for this
@@ -1628,13 +1645,11 @@ class TgoGenerator:
                     )
                 generator.generate()
 
-            # Place portable TACAN beacons at blue airfields without built-in
-            # TACAN, if the setting is enabled.
-            if (
-                self.game.settings.generate_portable_tacans
-                and isinstance(cp, Airfield)
-                and cp.captured.is_blue
-            ):
+            # Reflect built-in airfield TACAN (and, if the setting is on,
+            # place portable beacons at airfields without a built-in TACAN) so
+            # the UI surfaces (base dialog, map tooltip, briefing) can show
+            # the channel everywhere.
+            if isinstance(cp, Airfield) and cp.captured.is_blue:
                 portable_tacan_gen = PortableTacanGenerator(
                     self.m,
                     self.game,

--- a/game/radio/TacanContainer.py
+++ b/game/radio/TacanContainer.py
@@ -6,3 +6,9 @@ from game.radio.tacan import TacanChannel
 class TacanContainer:
     tacan: Optional[TacanChannel] = None
     tcn_name: Optional[str] = None
+    # True while the channel was picked automatically by the mission
+    # generator (or no channel has been set yet); False once the user has
+    # explicitly chosen one from the base dialog. Used by the UI to show
+    # 'AUTO (94X)' vs '94X (KUT)' so the player can tell at a glance whether
+    # they own the choice or whether it may change between turns.
+    tacan_is_auto: bool = True

--- a/game/server/controlpoints/models.py
+++ b/game/server/controlpoints/models.py
@@ -20,6 +20,10 @@ class ControlPointJs(BaseModel):
     mobile: bool
     destination: LeafletPoint | None
     sidc: str
+    # Comms/nav summary for the hover tooltip. None when not applicable
+    # (e.g. enemy control point, or no TACAN allocated yet).
+    tacan: str | None
+    atc_frequency: str | None
 
     class Config:
         title = "ControlPoint"
@@ -33,6 +37,7 @@ class ControlPointJs(BaseModel):
             blue = True
         else:
             blue = False
+        tacan, atc_frequency = _comms_summary(control_point)
         return ControlPointJs(
             id=control_point.id,
             name=control_point.name,
@@ -41,6 +46,8 @@ class ControlPointJs(BaseModel):
             mobile=control_point.moveable and control_point.captured.is_blue,
             destination=destination,
             sidc=str(control_point.sidc()),
+            tacan=tacan,
+            atc_frequency=atc_frequency,
         )
 
     @staticmethod
@@ -48,3 +55,32 @@ class ControlPointJs(BaseModel):
         return [
             ControlPointJs.for_control_point(cp) for cp in game.theater.controlpoints
         ]
+
+
+def _comms_summary(cp: ControlPoint) -> tuple[str | None, str | None]:
+    """Return (tacan, atc_frequency) strings for the tooltip, or None if N/A.
+
+    Only resolved for friendly (blue) airfields, since the tooltip shows our
+    own bases' comms — enemy details are not exposed in planning.
+    """
+    from game.atcdata import AtcData
+    from game.radio.TacanContainer import TacanContainer
+    from game.theater.controlpoint import Airfield
+
+    if not cp.captured.is_blue:
+        return None, None
+
+    tacan: str | None = None
+    if isinstance(cp, TacanContainer) and cp.tacan is not None:
+        if cp.tcn_name:
+            tacan = f"{cp.tacan} ({cp.tcn_name})"
+        else:
+            tacan = str(cp.tacan)
+
+    atc: str | None = None
+    if isinstance(cp, Airfield):
+        atc_radio = AtcData.from_pydcs(cp.airport)
+        if atc_radio is not None and atc_radio.uhf is not None:
+            atc = str(atc_radio.uhf)
+
+    return tacan, atc

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1221,7 +1221,7 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
     def status(self) -> ControlPointStatus: ...
 
 
-class Airfield(ControlPoint, CTLD):
+class Airfield(ControlPoint, CTLD, TacanContainer):
     def __init__(
         self,
         airport: Airport,

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -608,9 +608,7 @@ class GameModel:
                 allocated_freqs.add(cp.frequency)
             # Airfields are TacanContainers too (built-in/portable TACAN); pick
             # them up so the manual-assign dialog can warn on duplicates.
-            if isinstance(cp, TacanContainer) and not isinstance(
-                cp, NavalControlPoint
-            ):
+            if isinstance(cp, TacanContainer) and not isinstance(cp, NavalControlPoint):
                 allocated_tacan.add(cp.tacan)
         allocated_freqs.remove(None)
         allocated_tacan.remove(None)

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -19,6 +19,7 @@ from game.ato.flighttype import FlightType
 from game.ato.package import Package
 from game.game import Game
 from game.radio.RadioFrequencyContainer import RadioFrequencyContainer
+from game.radio.TacanContainer import TacanContainer
 from game.radio.radios import RadioFrequency
 from game.radio.tacan import TacanChannel
 from game.server import EventStream
@@ -605,6 +606,12 @@ class GameModel:
                 allocated_icls.add(cp.icls_channel)
             elif isinstance(cp, RadioFrequencyContainer):
                 allocated_freqs.add(cp.frequency)
+            # Airfields are TacanContainers too (built-in/portable TACAN); pick
+            # them up so the manual-assign dialog can warn on duplicates.
+            if isinstance(cp, TacanContainer) and not isinstance(
+                cp, NavalControlPoint
+            ):
+                allocated_tacan.add(cp.tacan)
         allocated_freqs.remove(None)
         allocated_tacan.remove(None)
         allocated_icls.remove(None)

--- a/qt_ui/widgets/QTacanWidget.py
+++ b/qt_ui/widgets/QTacanWidget.py
@@ -1,6 +1,7 @@
 from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
+    QMessageBox,
     QPushButton,
     QWidget,
 )
@@ -56,8 +57,30 @@ class QTacanWidget(QWidget):
         channel = self.tacan_dialog.tacan_input.value()
         band = self.tacan_dialog.band_input.currentText()
         band = TacanBand.X if band == "X" else TacanBand.Y
+        candidate = TacanChannel(number=channel, band=band)
+
+        # Warn before letting the user double-book a TACAN that is already in
+        # use elsewhere (another base/carrier, or a flight). Skip the warning
+        # when the user "re-saves" the same channel this container already
+        # owns — that's not a new collision.
+        if candidate != self.ct.tacan and candidate in self.gm.allocated_tacan:
+            reply = QMessageBox.question(
+                self,
+                "TACAN already in use",
+                (
+                    f"TACAN channel {candidate} is already assigned elsewhere "
+                    "in this mission (another base, carrier or flight). "
+                    "Assigning it here will double-book the channel.\n\n"
+                    "Use it anyway?"
+                ),
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            if reply != QMessageBox.StandardButton.Yes:
+                return
+
         self._try_remove()
-        self.ct.tacan = TacanChannel(number=channel, band=band)
+        self.ct.tacan = candidate
         self.gm.allocated_tacan.append(self.ct.tacan)
         if cs := self.tacan_dialog.callsign_input.text():
             self.ct.tcn_name = cs.upper()

--- a/qt_ui/widgets/QTacanWidget.py
+++ b/qt_ui/widgets/QTacanWidget.py
@@ -39,10 +39,13 @@ class QTacanWidget(QWidget):
         self.reset_tacan_btn.clicked.connect(self.reset_tacan)
 
     def _get_label_text(self) -> str:
-        c = "AUTO" if self.ct.tacan is None else self.ct.tacan
+        if self.ct.tacan is None:
+            return "<b>TACAN: AUTO</b>"
         cs = self.ct.tcn_name
         cs = "" if cs is None else f" ({cs})"
-        return f"<b>TACAN: {c}{cs}</b>"
+        is_auto = getattr(self.ct, "tacan_is_auto", False)
+        prefix = "AUTO " if is_auto else ""
+        return f"<b>TACAN: {prefix}{self.ct.tacan}{cs}</b>"
 
     def open_tacan_dialog(self) -> None:
         self.tacan_dialog = QTacanDialog(self, self.ct)
@@ -58,6 +61,9 @@ class QTacanWidget(QWidget):
         self.gm.allocated_tacan.append(self.ct.tacan)
         if cs := self.tacan_dialog.callsign_input.text():
             self.ct.tcn_name = cs.upper()
+        # User-chosen channel: lock it in so the auto-allocator reuses it and
+        # the UI no longer labels it 'AUTO'.
+        self.ct.tacan_is_auto = False
         self.channel.setText(self._get_label_text())
         self.check_channel()
 
@@ -65,6 +71,9 @@ class QTacanWidget(QWidget):
         self._try_remove()
         self.ct.tacan = None
         self.ct.tcn_name = None
+        # Back to auto: the next mission generation will allocate a fresh
+        # channel and the dialog will read 'AUTO' or 'AUTO (94X)' afterwards.
+        self.ct.tacan_is_auto = True
         self.channel.setText(self._get_label_text())
         self._reset_color_and_tooltip()
 

--- a/resources/briefing/templates/briefingtemplate_EN.j2
+++ b/resources/briefing/templates/briefingtemplate_EN.j2
@@ -104,6 +104,15 @@ TACAN : {{ runway.tacan }} {{ runway.tacan_callsign }}
 {% endfor %}
 
 {% endif %}
+{%- if owned_airbases|length > 0 %}
+Owned Airbases:
+====================
+{% for ab in owned_airbases %}
+{{ ab.name }} -- TACAN: {{ ab.tacan }}{% if ab.tacan_callsign %} ({{ ab.tacan_callsign }}){% endif %} -- ATC: {{ ab.atc }}
+
+{% endfor %}
+
+{% endif %}
 {%- if awacs|length > 0 %}
 AWACS:
 ====================

--- a/resources/briefing/templates/briefingtemplate_EN.j2
+++ b/resources/briefing/templates/briefingtemplate_EN.j2
@@ -104,15 +104,6 @@ TACAN : {{ runway.tacan }} {{ runway.tacan_callsign }}
 {% endfor %}
 
 {% endif %}
-{%- if owned_airbases|length > 0 %}
-Owned Airbases:
-====================
-{% for ab in owned_airbases %}
-{{ ab.name }} -- TACAN: {{ ab.tacan }}{% if ab.tacan_callsign %} ({{ ab.tacan_callsign }}){% endif %}
-
-{% endfor %}
-
-{% endif %}
 {%- if awacs|length > 0 %}
 AWACS:
 ====================

--- a/resources/briefing/templates/briefingtemplate_EN.j2
+++ b/resources/briefing/templates/briefingtemplate_EN.j2
@@ -104,6 +104,15 @@ TACAN : {{ runway.tacan }} {{ runway.tacan_callsign }}
 {% endfor %}
 
 {% endif %}
+{%- if owned_airbases|length > 0 %}
+Owned Airbases:
+====================
+{% for ab in owned_airbases %}
+{{ ab.name }} -- TACAN: {{ ab.tacan }}{% if ab.tacan_callsign %} ({{ ab.tacan_callsign }}){% endif %}
+
+{% endfor %}
+
+{% endif %}
 {%- if awacs|length > 0 %}
 AWACS:
 ====================

--- a/tests/test_portable_tacan.py
+++ b/tests/test_portable_tacan.py
@@ -125,6 +125,8 @@ class TestPortableTacanSkipsWhenAlreadyPresent:
         gen.airfield = MagicMock()
         gen.airfield.airport.runways = [MagicMock()]  # has runways
         gen.airfield.name = "Batumi"
+        gen.airfield.tacan = None
+        gen.airfield.tcn_name = None
         gen.game = MagicMock()
         gen.tacan_registry = TacanRegistry()
         gen.runways = {}
@@ -161,6 +163,8 @@ class TestPortableTacanSkipsWhenAlreadyPresent:
         gen.airfield.airport.position.point_from_heading.return_value = MagicMock()
         gen.airfield.name = "TestAirfield"
         gen.airfield.full_name = "TestAirfield"
+        gen.airfield.tacan = None
+        gen.airfield.tcn_name = None
         gen.game = MagicMock()
         gen.tacan_registry = registry
         gen.runways = {}
@@ -195,6 +199,8 @@ class TestPortableTacanSkipsWhenAlreadyPresent:
         gen.airfield = MagicMock()
         gen.airfield.airport.runways = [MagicMock()]
         gen.airfield.name = "ExhaustedAirfield"
+        gen.airfield.tacan = None
+        gen.airfield.tcn_name = None
         gen.game = MagicMock()
         gen.tacan_registry = registry
         gen.runways = {}


### PR DESCRIPTION
#699 from @red-one1 added portable TACANs to captured based, which is great and works beautifully. I found, however, that is not very obvious to find the TACAN code for a base; it was only added to the briefing and only if the airport was configured as a divert one. There was no way of knowing the code from the F10 map or the UI (if it was auto assigned).

This PR tries to improve the base's TACAN code visibility in these ways:

- Map tooltip: hovering a friendly base shows its TACAN and ATC frequency.
- Base / carrier dialog: the current TACAN channel and callsign are shown, with AUTO / AUTO (94X) labels so it's clear when it was auto-allocated vs user-set.
- Briefing: new Owned Airbases section listing every friendly airfield with its TACAN and ATC frequency.
- F10 map: the portable TACAN ground unit is named with its channel and callsign so you can read it straight from DCS.
- Carrier TACANs stay stable across turns instead of being re-rolled every mission generation.

Also, semi unrelated, I added that if you pick a channel that's already used by another base, carrier or flight, a confirmation dialog warns you before double-booking.