### PR TITLE
Fix player ground-start flights spawning in the air

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 
 ## Fixes
+* **[Flight Plans]** Player flights with a ground start (Cold/Warm/Runway) no longer spawn in the air when their computed startup time falls before mission start (e.g. due to a long player startup estimate); they now wait and start on the ground at mission start.
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission

--- a/game/ato/flightstate/flightstate.py
+++ b/game/ato/flightstate/flightstate.py
@@ -25,12 +25,25 @@ class FlightState(ABC):
         from game.ato.flightstate import WaitingForStart
 
         start_time = self.flight.flight_plan.startup_time()
-        if start_time <= now:
-            self._set_active_flight_state(start_time)
-        else:
+        if start_time > now:
             self.flight.set_state(
                 WaitingForStart(self.flight, self.settings, start_time)
             )
+        elif self.flight.client_count > 0 and self.flight.start_type in (
+            StartType.COLD,
+            StartType.WARM,
+            StartType.RUNWAY,
+        ):
+            # A player flight with a ground start whose computed startup time
+            # lands before mission start (e.g. a long player startup estimate
+            # pushes startup_time earlier than the mission's start time) must
+            # not be pre-activated. Pre-activation skips the StartUp/Taxi/Takeoff
+            # state at tick 0, so the player-startup fast-forward stop condition
+            # never catches the flight and the player ends up spawning in the
+            # air. Keep it grounded and start it at mission start instead.
+            self.flight.set_state(WaitingForStart(self.flight, self.settings, now))
+        else:
+            self._set_active_flight_state(start_time)
 
     def _set_active_flight_state(self, now: datetime) -> None:
         from game.ato.flightstate import StartUp


### PR DESCRIPTION
## Summary

A player flight configured with a ground start (Cold/Warm/Runway) could spawn **in the air** when its computed `startup_time()` fell *before* the mission start time (e.g. when a long player startup estimate pushes startup earlier than the stored TOT allows).

In `FlightState.reinitialize()`, when `startup_time() <= now` the flight was pre-activated via `_set_active_flight_state(...)`, which skips the `StartUp`/`Taxi`/`Takeoff` state at tick 0. The `PLAYER_STARTUP` fast-forward stop condition only halts flights that are *currently in* `StartUp`, so it never caught these pre-activated flights and the simulation ran them straight through to `Navigating` — leaving the player airborne at mission start despite a cold/warm/runway start being selected.

This change keeps such flights grounded: a client flight with a ground start whose `startup_time()` lands at or before mission start now waits via `WaitingForStart(now)` and starts on the ground at mission start. AI flights and in-flight starts keep their previous behaviour.
