### PR TITLE
Highlight and select flight from its map route line

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Avoid having escorts from wondering off too far while chasing a target.
 * **[UX]** Improved fast-forward settings with the ability to skip combat.
 * **[Data]** Add Refueling/Recovery tasks to A-6E Intruder mod

--- a/client/src/api/_liberationApi.ts
+++ b/client/src/api/_liberationApi.ts
@@ -162,6 +162,15 @@ const injectedRtkApi = api.injectEndpoints({
         method: "POST",
       }),
     }),
+    selectFlight: build.mutation<
+      SelectFlightApiResponse,
+      SelectFlightApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/qt/select-flight/${queryArg.flightId}`,
+        method: "POST",
+      }),
+    }),
     listSupplyRoutes: build.query<
       ListSupplyRoutesApiResponse,
       ListSupplyRoutesApiArg
@@ -307,6 +316,11 @@ export type OpenControlPointInfoDialogApiResponse =
   /** status 200 Successful Response */ any;
 export type OpenControlPointInfoDialogApiArg = {
   cpId: string;
+};
+export type SelectFlightApiResponse =
+  /** status 200 Successful Response */ any;
+export type SelectFlightApiArg = {
+  flightId: string;
 };
 export type ListSupplyRoutesApiResponse =
   /** status 200 Successful Response */ SupplyRoute[];
@@ -496,6 +510,7 @@ export const {
   useOpenTgoInfoDialogMutation,
   useOpenNewControlPointPackageDialogMutation,
   useOpenControlPointInfoDialogMutation,
+  useSelectFlightMutation,
   useListSupplyRoutesQuery,
   useListTgosQuery,
   useGetTgoByIdQuery,

--- a/client/src/components/flightplan/FlightPlan.tsx
+++ b/client/src/components/flightplan/FlightPlan.tsx
@@ -1,5 +1,8 @@
 import { Flight } from "../../api/liberationApi";
-import { useGetCommitBoundaryForFlightQuery } from "../../api/liberationApi";
+import {
+  useGetCommitBoundaryForFlightQuery,
+  useSelectFlightMutation,
+} from "../../api/liberationApi";
 import WaypointMarker from "../waypointmarker";
 import { Polyline as LPolyline } from "leaflet";
 import { ReactElement, useEffect, useRef } from "react";
@@ -28,6 +31,7 @@ const pathColor = (props: FlightPlanProps) => {
 function FlightPlanPath(props: FlightPlanProps) {
   const color = pathColor(props);
   const waypoints = props.flight.waypoints;
+  const [selectFlight] = useSelectFlightMutation();
 
   const polylineRef = useRef<LPolyline | null>(null);
 
@@ -61,11 +65,35 @@ function FlightPlanPath(props: FlightPlanProps) {
     .filter((waypoint) => waypoint.include_in_path)
     .map((waypoint) => waypoint.position);
 
+  // Only blue flight plans are interactive: hovering highlights the route in
+  // yellow and clicking selects the owning package (and flight) in the Qt
+  // sidebar via a round-trip through the server.
+  const interactive = props.flight.blue;
+
   return (
     <Polyline
       positions={points}
-      pathOptions={{ color: color, interactive: false }}
+      pathOptions={{ color: color, interactive: interactive }}
       ref={polylineRef}
+      eventHandlers={
+        interactive
+          ? {
+              mouseover: () => {
+                polylineRef.current?.setStyle({ color: SELECTED_PATH });
+                polylineRef.current?.bringToFront();
+              },
+              mouseout: () => {
+                if (!props.selected) {
+                  polylineRef.current?.setStyle({ color: color });
+                  polylineRef.current?.bringToBack();
+                }
+              },
+              click: () => {
+                selectFlight({ flightId: props.flight.id });
+              },
+            }
+          : undefined
+      }
     />
   );
 }

--- a/game/server/dependencies.py
+++ b/game/server/dependencies.py
@@ -6,6 +6,7 @@ from game.theater import ControlPoint, MissionTarget, TheaterGroundObject
 
 if TYPE_CHECKING:
     from game import Game
+    from game.ato import Flight
     from qt_ui.models import GameModel
 
 
@@ -37,10 +38,12 @@ class QtCallbacks:
         create_new_package: Callable[[MissionTarget], None],
         show_tgo_info: Callable[[TheaterGroundObject], None],
         show_control_point_info: Callable[[ControlPoint], None],
+        select_flight: Callable[[Flight], None],
     ) -> None:
         self.create_new_package = create_new_package
         self.show_tgo_info = show_tgo_info
         self.show_control_point_info = show_control_point_info
+        self.select_flight = select_flight
 
 
 class QtContext:

--- a/game/server/qt/routes.py
+++ b/game/server/qt/routes.py
@@ -76,7 +76,13 @@ def select_flight(
     game: Game = Depends(GameContext.require),
     qt: QtCallbacks = Depends(QtContext.get),
 ) -> None:
-    qt.select_flight(game.db.flights.get(flight_id))
+    flight = game.db.flights.get(flight_id)
+    if flight is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail=f"Game has no flight with ID {flight_id}",
+        )
+    qt.select_flight(flight)
 
 
 @router.post(

--- a/game/server/qt/routes.py
+++ b/game/server/qt/routes.py
@@ -67,6 +67,19 @@ def new_cp_package(
 
 
 @router.post(
+    "/select-flight/{flight_id}",
+    operation_id="select_flight",
+    status_code=status.HTTP_200_OK,
+)
+def select_flight(
+    flight_id: UUID,
+    game: Game = Depends(GameContext.require),
+    qt: QtCallbacks = Depends(QtContext.get),
+) -> None:
+    qt.select_flight(game.db.flights.get(flight_id))
+
+
+@router.post(
     "/info/control-point/{cp_id}",
     operation_id="open_control_point_info_dialog",
     status_code=status.HTTP_200_OK,

--- a/qt_ui/widgets/ato.py
+++ b/qt_ui/widgets/ato.py
@@ -515,6 +515,35 @@ class QAirTaskingOrderPanel(QSplitter):
         self.flight_panel = QFlightPanel(game_model)
         self.addWidget(self.flight_panel)
 
+    def select_flight_on_map(self, flight: Flight) -> None:
+        """Selects the package and flight owning the given flight.
+
+        Triggered when the player clicks a flight's route line on the web map.
+        """
+        # Make sure the panel is showing the ATO that owns this flight.
+        show_opfor = not flight.blue.is_blue
+        if self.red_ato_checkbox.isChecked() != show_opfor:
+            self.red_ato_checkbox.setChecked(show_opfor)
+
+        packages = list(self.ato_model.ato.packages)
+        if flight.package not in packages:
+            return
+        package_row = packages.index(flight.package)
+        self.package_panel.package_list.selectionModel().setCurrentIndex(
+            self.ato_model.index(package_row, 0),
+            QItemSelectionModel.SelectionFlag.ClearAndSelect,
+        )
+
+        # Selecting the package synchronously triggers on_package_change, which
+        # sets the flight panel's package model. Now select the flight row.
+        if flight not in flight.package.flights:
+            return
+        flight_row = flight.package.flights.index(flight)
+        self.flight_panel.flight_list.selectionModel().setCurrentIndex(
+            self.flight_panel.flight_list.model().index(flight_row, 0),
+            QItemSelectionModel.SelectionFlag.ClearAndSelect,
+        )
+
     def on_package_change(self) -> None:
         """Sets the newly selected flight for display in the bottom panel."""
         index = self.package_panel.package_list.currentIndex()

--- a/qt_ui/windows/QLiberationWindow.py
+++ b/qt_ui/windows/QLiberationWindow.py
@@ -19,6 +19,7 @@ from PySide6.QtWidgets import (
 
 import qt_ui.uiconstants as CONST
 from game import Game, VERSION, persistency, Migrator
+from game.ato import Flight
 from game.debriefing import Debriefing
 from game.game import TurnState
 from game.layout import LAYOUTS
@@ -56,6 +57,7 @@ class QLiberationWindow(QMainWindow):
     new_package_signal = Signal(MissionTarget)
     tgo_info_signal = Signal(TheaterGroundObject)
     control_point_info_signal = Signal(ControlPoint)
+    select_flight_signal = Signal(Flight)
 
     def __init__(self, game: Game | None, ui_flags: UiFlags) -> None:
         super().__init__()
@@ -72,11 +74,13 @@ class QLiberationWindow(QMainWindow):
         )
         self.tgo_info_signal.connect(self.open_tgo_info_dialog)
         self.control_point_info_signal.connect(self.open_control_point_info_dialog)
+        self.select_flight_signal.connect(self.on_select_flight)
         QtContext.set_callbacks(
             QtCallbacks(
                 lambda target: self.new_package_signal.emit(target),
                 lambda tgo: self.tgo_info_signal.emit(tgo),
                 lambda cp: self.control_point_info_signal.emit(cp),
+                lambda flight: self.select_flight_signal.emit(flight),
             )
         )
         Dialog.set_game(self.game_model)
@@ -619,6 +623,9 @@ class QLiberationWindow(QMainWindow):
     def open_control_point_info_dialog(self, cp: ControlPoint) -> None:
         self._cp_dialog = QBaseMenu2(None, cp, self.game_model)
         self._cp_dialog.show()
+
+    def on_select_flight(self, flight: Flight) -> None:
+        self.ato_panel.select_flight_on_map(flight)
 
     def _qsettings(self) -> QSettings:
         return QSettings("DCS Retribution", "Qt UI")


### PR DESCRIPTION
## Summary
- Hovering a friendly flight's route line on the map now highlights it in yellow (the same color as the threat-range circles in #750 ). This makes a lot easier to see the current package and flight route on busy maps.
- Clicking the route line selects that flight's package in the ATO sidebar, and also selects the flight itself in the flight list below.

Only friendly (blue) route lines are interactive.