### PR TITLE
feat(waypoints): better waypoint editing — reorder, editable ToTs, on-station timing (#671)

### DIFF
--- a/game/ato/flight.py
+++ b/game/ato/flight.py
@@ -104,6 +104,12 @@ class Flight(
         # options when players switch loadouts.
         self.props: dict[str, Any] = {}
 
+        # Manual-timing state for player flights. When manually_timed is True the flight's
+        # waypoint times are user-owned: they form a forward chain from manual_takeoff_time
+        # plus each waypoint's manual_tot_offset, fully decoupled from the package TOT.
+        self.manually_timed: bool = False
+        self.manual_takeoff_time: datetime | None = None
+
         # Used for simulating the travel to first contact.
         self.state: FlightState = Uninitialized(self, squadron.settings)
 
@@ -154,6 +160,8 @@ class Flight(
     def degrade_to_custom_flight_plan(self) -> None:
         from .flightplans.custom import Builder as CustomBuilder
 
+        self.manually_timed = False
+        self.manual_takeoff_time = None
         self._flight_plan_builder = CustomBuilder(self, self.flight_plan.waypoints[1:])
         self.recreate_flight_plan()
 
@@ -170,6 +178,10 @@ class Flight(
         state["state"] = Uninitialized(self, state["squadron"].settings)
         if "use_same_loadout_for_all_members" not in state:
             state["use_same_loadout_for_all_members"] = True
+        if "manually_timed" not in state:
+            state["manually_timed"] = False
+        if "manual_takeoff_time" not in state:
+            state["manual_takeoff_time"] = None
         self.__dict__.update(state)
         if isinstance(self.roster, FlightRoster):
             self.roster = FlightMembers.from_roster(self, self.roster)
@@ -353,6 +365,8 @@ class Flight(
                 results.kill_pilot(self, pilot)
 
     def recreate_flight_plan(self, dump_debug_info: bool = False) -> None:
+        self.manually_timed = False
+        self.manual_takeoff_time = None
         self._flight_plan_builder.regenerate(dump_debug_info)
 
     @staticmethod

--- a/game/ato/flightplans/airlift.py
+++ b/game/ato/flightplans/airlift.py
@@ -48,7 +48,7 @@ class AirliftLayout(StandardLayout):
     def add_waypoint(
         self, wpt: FlightWaypoint, next_wpt: Optional[FlightWaypoint]
     ) -> bool:
-        new_wpt = self.get_midpoint(wpt, next_wpt)
+        new_wpt = WaypointBuilder.nav_midpoint(wpt, next_wpt)
         if wpt.waypoint_type in [
             FlightWaypointType.PICKUP_ZONE,
             FlightWaypointType.CARGO_STOP,
@@ -64,6 +64,19 @@ class AirliftLayout(StandardLayout):
         elif super().delete_waypoint(waypoint):
             return True
         return False
+
+    def move_waypoint(self, waypoint: FlightWaypoint, direction: int) -> bool:
+        if waypoint in self.nav_to_drop_off:
+            index = self.nav_to_drop_off.index(waypoint)
+            target = index + direction
+            if 0 <= target < len(self.nav_to_drop_off):
+                self.nav_to_drop_off[index], self.nav_to_drop_off[target] = (
+                    self.nav_to_drop_off[target],
+                    self.nav_to_drop_off[index],
+                )
+                return True
+            return False
+        return super().move_waypoint(waypoint, direction)
 
     def iter_waypoints(self) -> Iterator[FlightWaypoint]:
         yield self.departure

--- a/game/ato/flightplans/custom.py
+++ b/game/ato/flightplans/custom.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING, Optional, Type
 
 from .flightplan import FlightPlan, Layout
 from .ibuilder import IBuilder
@@ -20,6 +20,31 @@ class CustomLayout(Layout):
     def iter_waypoints(self) -> Iterator[FlightWaypoint]:
         yield self.departure
         yield from self.custom_waypoints
+
+    def move_waypoint(self, waypoint: FlightWaypoint, direction: int) -> bool:
+        if waypoint in self.custom_waypoints:
+            index = self.custom_waypoints.index(waypoint)
+            target = index + direction
+            if 0 <= target < len(self.custom_waypoints):
+                self.custom_waypoints[index], self.custom_waypoints[target] = (
+                    self.custom_waypoints[target],
+                    self.custom_waypoints[index],
+                )
+                return True
+        return False
+
+    def add_waypoint(
+        self, wpt: "FlightWaypoint", next_wpt: "Optional[FlightWaypoint]"
+    ) -> bool:
+        new_wpt = WaypointBuilder.nav_midpoint(wpt, next_wpt)
+        if wpt in self.custom_waypoints:
+            index = self.custom_waypoints.index(wpt) + 1
+            self.custom_waypoints.insert(index, new_wpt)
+            return True
+        if wpt is self.departure:
+            self.custom_waypoints.insert(0, new_wpt)
+            return True
+        return False
 
 
 class CustomFlightPlan(FlightPlan[CustomLayout]):
@@ -38,9 +63,13 @@ class CustomFlightPlan(FlightPlan[CustomLayout]):
             FlightWaypointType.TARGET_GROUP_LOC,
             FlightWaypointType.TARGET_POINT,
             FlightWaypointType.TARGET_SHIP,
+            # CAS plans anchor their ToT on the FLOT (a CAS-type waypoint). Without it
+            # a CAS flight converted to a custom plan finds no anchor here and falls back
+            # to the departure, collapsing the takeoff time onto the package TOT.
+            FlightWaypointType.CAS,
         )
         for waypoint in self.waypoints:
-            if waypoint in target_types:
+            if waypoint.waypoint_type in target_types:
                 return waypoint
         return self.layout.departure
 

--- a/game/ato/flightplans/flightplan.py
+++ b/game/ato/flightplans/flightplan.py
@@ -32,6 +32,30 @@ if TYPE_CHECKING:
     from .patrolling import PatrollingFlightPlan
 
 
+def cascade_waypoint_times(
+    takeoff: datetime,
+    legs: list[timedelta],
+    offsets: list[timedelta],
+) -> list[datetime]:
+    """Compute the time at each waypoint for a manually-timed flight.
+
+    ``legs[i]`` is the travel time from waypoint ``i`` to ``i + 1`` (length
+    ``len(offsets) - 1``). ``offsets[i]`` is the per-waypoint manual shift. The result is
+    a forward chain from ``takeoff`` with a cumulative (prefix-sum) of offsets, so adding to
+    ``offsets[N]`` shifts waypoint ``N`` and every later waypoint by the same amount and
+    leaves earlier waypoints unchanged.
+    """
+    times: list[datetime] = []
+    cumulative_offset = timedelta()
+    running = takeoff
+    for i, offset in enumerate(offsets):
+        if i > 0:
+            running += legs[i - 1]
+        cumulative_offset += offset
+        times.append(running + cumulative_offset)
+    return times
+
+
 @dataclass
 class Layout(ABC):
     departure: FlightWaypoint
@@ -43,6 +67,14 @@ class Layout(ABC):
         return list(self.iter_waypoints())
 
     def delete_waypoint(self, waypoint: FlightWaypoint) -> bool:
+        return False
+
+    def move_waypoint(self, waypoint: FlightWaypoint, direction: int) -> bool:
+        """Move ``waypoint`` one slot. ``direction`` is -1 (up) or +1 (down).
+
+        Returns True if the move happened. The base layout cannot reorder anything, so it
+        returns False; subclasses override for their mutable waypoint lists.
+        """
         return False
 
     def iter_waypoints(self) -> Iterator[FlightWaypoint]:
@@ -234,7 +266,103 @@ class FlightPlan(ABC, Generic[LayoutT]):
             if waypoint == end:
                 return
 
+    def manual_waypoint_times(self) -> list[datetime]:
+        """Forward-chained times for a manually-timed flight (decoupled from package)."""
+        assert self.flight.manual_takeoff_time is not None
+        waypoints = self.waypoints
+        # Floor each leg to whole seconds, matching _travel_time_to_waypoint: DCS has no
+        # sub-second task resolution, so cascaded ETAs must not carry a fractional remainder.
+        legs = [
+            timedelta(
+                seconds=math.floor(
+                    self.total_time_between_waypoints(a, b).total_seconds()
+                )
+            )
+            for a, b in zip(waypoints, waypoints[1:])
+        ]
+        offsets = [wp.manual_tot_offset for wp in waypoints]
+        return cascade_waypoint_times(self.flight.manual_takeoff_time, legs, offsets)
+
+    def effective_tot_for_waypoint(self, waypoint: FlightWaypoint) -> datetime | None:
+        """ToT used for display and mission generation.
+
+        For manually-timed flights this is the cascaded time at every waypoint. For
+        auto-timed flights this is exactly the structural ``tot_for_waypoint`` (unchanged
+        behavior: non-structural waypoints return ``None``).
+        """
+        if self.flight.manually_timed and self.flight.manual_takeoff_time is not None:
+            return self.manual_waypoint_times()[self.waypoints.index(waypoint)]
+        return self.tot_for_waypoint(waypoint)
+
+    def chained_tot_for_waypoint(self, waypoint: FlightWaypoint) -> datetime | None:
+        """Forward-chained time at ``waypoint`` for display and mission generation.
+
+        For manually-timed flights this is the manual cascade. For auto-timed flights it
+        is the takeoff time plus the floored travel time of every preceding leg, so every
+        waypoint (not just the structural ToT) carries a monotonic time. Returns ``None``
+        only if ``waypoint`` is not part of this plan.
+        """
+        waypoints = self.waypoints
+        if waypoint not in waypoints:
+            return None
+        index = waypoints.index(waypoint)
+        if self.flight.manually_timed and self.flight.manual_takeoff_time is not None:
+            return self.manual_waypoint_times()[index]
+        running = self.takeoff_time()
+        for a, b in zip(waypoints[:index], waypoints[1 : index + 1]):
+            running += timedelta(
+                seconds=math.floor(
+                    self.total_time_between_waypoints(a, b).total_seconds()
+                )
+            )
+        return running
+
+    def would_invert_order(self, waypoint: FlightWaypoint, desired: datetime) -> bool:
+        """True if ``desired`` is not strictly later than the previous waypoint's time.
+
+        A desired time at or before the previous waypoint produces a non-monotonic
+        schedule that DCS re-sorts by time, so the UI rejects it.
+        """
+        waypoints = self.waypoints
+        if waypoint not in waypoints:
+            return False
+        index = waypoints.index(waypoint)
+        if index == 0:
+            return False
+        previous = self.chained_tot_for_waypoint(waypoints[index - 1])
+        return previous is not None and desired <= previous
+
+    def set_waypoint_tot(self, waypoint: FlightWaypoint, desired: datetime) -> None:
+        """Set a waypoint's ToT; shifts this waypoint and all later ones by the delta."""
+        if not self.flight.manually_timed:
+            self.flight.manual_takeoff_time = self.takeoff_time()
+            self.flight.manually_timed = True
+        times = self.manual_waypoint_times()
+        index = self.waypoints.index(waypoint)
+        waypoint.manual_tot_offset += desired - times[index]
+
+    def clear_manual_timing(self) -> None:
+        """Return the flight to automatic, package-driven timing."""
+        for waypoint in self.waypoints:
+            waypoint.manual_tot_offset = timedelta()
+        self.flight.manually_timed = False
+        self.flight.manual_takeoff_time = None
+
+    def move_waypoint(self, waypoint: FlightWaypoint, direction: int) -> bool:
+        """Reorder ``waypoint`` one slot (``direction`` is -1 up, +1 down).
+
+        Manual per-waypoint offsets are position-relative, so a reorder would silently
+        change every cascaded time. Rather than carry stale offsets into a new order, a
+        successful move drops manual timing and reverts the flight to auto-calculated ToTs.
+        """
+        moved = self.layout.move_waypoint(waypoint, direction)
+        if moved:
+            self.clear_manual_timing()
+        return moved
+
     def takeoff_time(self) -> datetime:
+        if self.flight.manually_timed and self.flight.manual_takeoff_time is not None:
+            return self.manual_waypoint_times()[0]
         return self.tot - self._travel_time_to_waypoint(self.tot_waypoint)
 
     def minimum_duration_from_start_to_tot(self) -> timedelta:

--- a/game/ato/flightplans/patrolling.py
+++ b/game/ato/flightplans/patrolling.py
@@ -80,6 +80,18 @@ class PatrollingFlightPlan(StandardFlightPlan[LayoutT], UiZoneDisplay, ABC):
             return self.patrol_end_time
         return None
 
+    def total_time_between_waypoints(
+        self, a: FlightWaypoint, b: FlightWaypoint
+    ) -> timedelta:
+        # The patrol_start -> patrol_end leg is on-station time, not travel: the flight
+        # orbits between the two points for patrol_duration (so patrol_end_time =
+        # patrol_start_time + patrol_duration). Schedules chained leg-by-leg -- the manual
+        # ToT cascade and the kneeboard ETAs -- sum this method per leg, so without this
+        # the loiter collapses to flight time and every later waypoint shifts early.
+        if a is self.layout.patrol_start and b is self.layout.patrol_end:
+            return self.patrol_duration
+        return super().total_time_between_waypoints(a, b)
+
     def takeoff_time(self) -> datetime:
         return self.patrol_start_time - self._travel_time_to_waypoint(self.tot_waypoint)
 

--- a/game/ato/flightplans/standard.py
+++ b/game/ato/flightplans/standard.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC
-from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, TypeVar, Optional
@@ -9,7 +8,6 @@ from typing import TYPE_CHECKING, TypeVar, Optional
 from game.ato.flightplans.flightplan import FlightPlan, Layout
 from .waypointbuilder import WaypointBuilder
 from ..flightwaypointtype import FlightWaypointType
-from ...utils import feet
 
 if TYPE_CHECKING:
     from ..flightwaypoint import FlightWaypoint
@@ -26,7 +24,7 @@ class StandardLayout(Layout, ABC):
     def add_waypoint(
         self, wpt: FlightWaypoint, next_wpt: Optional[FlightWaypoint]
     ) -> bool:
-        new_wpt = self.get_midpoint(wpt, next_wpt)
+        new_wpt = WaypointBuilder.nav_midpoint(wpt, next_wpt)
         if wpt.waypoint_type in [FlightWaypointType.TAKEOFF, FlightWaypointType.LOITER]:
             self.nav_to.insert(0, new_wpt)
             return True
@@ -49,18 +47,6 @@ class StandardLayout(Layout, ABC):
                 return True
         return False
 
-    @staticmethod
-    def get_midpoint(
-        wpt: FlightWaypoint, next_wpt: Optional[FlightWaypoint]
-    ) -> FlightWaypoint:
-        new_pos = deepcopy(wpt.position)
-        next_alt = feet(20000)
-        if next_wpt:
-            new_pos = wpt.position.lerp(next_wpt.position, 0.5)
-            next_alt = next_wpt.alt
-        new_wpt = WaypointBuilder.nav(new_pos, max(wpt.alt, next_alt))
-        return new_wpt
-
     def delete_waypoint(self, waypoint: FlightWaypoint) -> bool:
         if waypoint is self.divert:
             self.divert = None
@@ -74,6 +60,22 @@ class StandardLayout(Layout, ABC):
         elif waypoint in self.custom_waypoints:
             self.custom_waypoints.remove(waypoint)
             return True
+        return False
+
+    def move_waypoint(self, waypoint: FlightWaypoint, direction: int) -> bool:
+        for sequence in (self.nav_to, self.nav_from, self.custom_waypoints):
+            if waypoint in sequence:
+                index = sequence.index(waypoint)
+                target = index + direction
+                if 0 <= target < len(sequence):
+                    sequence[index], sequence[target] = (
+                        sequence[target],
+                        sequence[index],
+                    )
+                    return True
+                # At the edge of its list: moving further would cross a structural
+                # boundary, which this layout cannot do. The UI offers degrade-to-custom.
+                return False
         return False
 
 

--- a/game/ato/flightplans/waypointbuilder.py
+++ b/game/ato/flightplans/waypointbuilder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import random
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import (
     Iterable,
@@ -750,6 +751,22 @@ class WaypointBuilder:
             description="NAV",
             pretty_name="Nav",
         )
+
+    @staticmethod
+    def nav_midpoint(
+        wpt: FlightWaypoint, next_wpt: Optional[FlightWaypoint]
+    ) -> FlightWaypoint:
+        """A NAV waypoint halfway between ``wpt`` and ``next_wpt``.
+
+        When there is no following waypoint the new point reuses ``wpt``'s position and a
+        default cruise altitude.
+        """
+        new_pos = deepcopy(wpt.position)
+        next_alt = feet(20000)
+        if next_wpt:
+            new_pos = wpt.position.lerp(next_wpt.position, 0.5)
+            next_alt = next_wpt.alt
+        return WaypointBuilder.nav(new_pos, max(wpt.alt, next_alt))
 
     def nav_path(
         self, a: Point, b: Point, altitude: Distance, altitude_is_agl: bool = False

--- a/game/ato/flighttype.py
+++ b/game/ato/flighttype.py
@@ -104,6 +104,19 @@ class FlightType(Enum):
         return self in {FlightType.ESCORT, FlightType.SEAD_ESCORT}
 
     @property
+    def provides_escort_coverage(self) -> bool:
+        """Flight types that fly escort-like coverage tied to the package's timing.
+
+        Broader than ``is_escort_type``: includes TARCAP, which guards a strike package
+        the same way a dedicated escort does and so is affected by manual-timing drift.
+        """
+        return self in {
+            FlightType.ESCORT,
+            FlightType.SEAD_ESCORT,
+            FlightType.TARCAP,
+        }
+
+    @property
     def entity_type(self) -> AirEntity:
         return {
             FlightType.AEWC: AirEntity.AIRBORNE_EARLY_WARNING,

--- a/game/ato/flightwaypoint.py
+++ b/game/ato/flightwaypoint.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Literal, TYPE_CHECKING, Any, Dict, Optional
 
 from dcs import Point
@@ -50,6 +50,12 @@ class FlightWaypoint:
     tot: datetime | None = None
     departure_time: datetime | None = None
 
+    # Manual per-waypoint ToT shift for player flights. Effective times are a forward
+    # chain from the flight's frozen takeoff plus a cumulative sum of these offsets, so a
+    # non-zero value here shifts this waypoint and every later waypoint. Zero for
+    # auto-timed flights. See FlightPlan.set_waypoint_tot.
+    manual_tot_offset: timedelta = field(default_factory=timedelta)
+
     @property
     def x(self) -> float:
         return self.position.x
@@ -83,9 +89,9 @@ class FlightWaypoint:
         return hash(id(self))
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
-        # Saves made before custom_name existed won't carry the key; default it so
-        # attribute access on a reloaded waypoint is safe.
+        # Preserve compatibility with saves made before either field existed.
         state.setdefault("custom_name", None)
+        state.setdefault("manual_tot_offset", timedelta())
         self.__dict__.update(state)
 
     def __deepcopy__(self, memo: Optional[Dict[int, Any]] = None) -> FlightWaypoint:

--- a/game/ato/traveltime.py
+++ b/game/ato/traveltime.py
@@ -43,7 +43,12 @@ class TotEstimator:
         if not self.package.flights:
             return now
 
-        return max(self.earliest_tot_for_flight(f, now) for f in self.package.flights)
+        # Manually-timed flights own their schedule and are decoupled from the package
+        # TOT, so they must not pull the package's ASAP time.
+        candidates = [f for f in self.package.flights if not f.manually_timed]
+        if not candidates:
+            candidates = list(self.package.flights)
+        return max(self.earliest_tot_for_flight(f, now) for f in candidates)
 
     @staticmethod
     def earliest_tot_for_flight(flight: Flight, now: datetime) -> datetime:

--- a/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
+++ b/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
@@ -102,11 +102,33 @@ class PydcsWaypointBuilder:
                 waypoint.alt = 0
                 waypoint.alt_type = "RADIO"
 
-        tot = self.flight.flight_plan.tot_for_waypoint(self.waypoint)
-        if tot is not None:
-            self.set_waypoint_tot(waypoint, tot)
+        self._assign_waypoint_tot(waypoint)
         self.add_tasks(waypoint)
         return waypoint
+
+    def _assign_waypoint_tot(self, waypoint: MovingPoint) -> None:
+        # Lock the DCS ETA for anchored times (structural target or manually-timed) so
+        # the AI keeps timing flexibility between auto waypoints.
+        locked_tot = self.flight.flight_plan.effective_tot_for_waypoint(self.waypoint)
+        if locked_tot is not None:
+            self.set_waypoint_tot(waypoint, locked_tot)
+            return
+        # ...otherwise fall back to the chained ToT so every waypoint carries a time.
+        display_tot = self.flight.flight_plan.chained_tot_for_waypoint(self.waypoint)
+        if display_tot is None:
+            return
+
+        if self.flight.client_count:
+            # Player flights: lock the chained ToT into the DCS ETA too. These ETAs are
+            # loaded into the jet's nav computer, so leaving them unlocked makes the
+            # cockpit time-on-waypoint read wrong (it omits startup/taxi and on-station
+            # time). There is no AI route-follower to over-constrain here -- the human
+            # flies the route and any AI wingmen formate on the lead.
+            self.set_waypoint_tot(waypoint, display_tot)
+        else:
+            # AI flights: publish on the model for kneeboards, but leave the DCS ETA
+            # unlocked so the AI keeps timing flexibility between auto waypoints.
+            self.waypoint.tot = display_tot
 
     def switch_to_baro_if_in_sea(self, waypoint: MovingPoint) -> None:
         if waypoint.alt_type == "RADIO" and (

--- a/game/server/waypoints/models.py
+++ b/game/server/waypoints/models.py
@@ -13,7 +13,7 @@ def timing_info(flight: Flight, waypoint_idx: int) -> str:
 
     waypoint = flight.flight_plan.waypoints[waypoint_idx - 1]
     prefix = "TOT"
-    time = flight.flight_plan.tot_for_waypoint(waypoint)
+    time = flight.flight_plan.effective_tot_for_waypoint(waypoint)
     if time is None:
         prefix = "Depart"
         time = flight.flight_plan.depart_time_for_waypoint(waypoint)

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointList.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointList.py
@@ -1,14 +1,26 @@
 from typing import Optional
 
-from PySide6.QtCore import QItemSelectionModel, QPoint, QModelIndex
+from PySide6.QtCore import (
+    QEvent,
+    QItemSelectionModel,
+    QModelIndex,
+    QPoint,
+    Qt,
+    QTime,
+    QTimer,
+    Signal,
+)
 from PySide6.QtGui import QStandardItem, QStandardItemModel
 from PySide6.QtWidgets import (
-    QHeaderView,
-    QTableView,
-    QStyledItemDelegate,
-    QWidget,
-    QStyleOptionViewItem,
+    QAbstractItemView,
     QDoubleSpinBox,
+    QHeaderView,
+    QMessageBox,
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
+    QTableView,
+    QTimeEdit,
+    QWidget,
 )
 
 from game.ato.flight import Flight
@@ -33,7 +45,61 @@ class AltitudeEditorDelegate(QStyledItemDelegate):
         return editor
 
 
+class TotEditorDelegate(QStyledItemDelegate):
+    def __init__(self, waypoint_list: "QFlightWaypointList", flight: Flight) -> None:
+        super().__init__(waypoint_list)
+        self.waypoint_list = waypoint_list
+        self.flight = flight
+
+    def createEditor(self, parent, option, index) -> QWidget:
+        editor = QTimeEdit(parent)
+        editor.setDisplayFormat("HH:mm:ss")
+        return editor
+
+    def setEditorData(self, editor: QTimeEdit, index) -> None:
+        text = (
+            (index.data(Qt.ItemDataRole.DisplayRole) or "")
+            .replace("Depart ", "")
+            .strip()
+        )
+        qt = QTime.fromString(text, "HH:mm:ss")
+        if qt.isValid():
+            editor.setTime(qt)
+
+    def setModelData(self, editor: QTimeEdit, model, index) -> None:
+        waypoint = index.data(Qt.ItemDataRole.UserRole)
+        # Base the date on the package TOT; the user only edits the clock time.
+        base = self.flight.package.time_over_target
+        t = editor.time()
+        desired = base.replace(
+            hour=t.hour(), minute=t.minute(), second=t.second(), microsecond=0
+        )
+        if self.flight.flight_plan.would_invert_order(waypoint, desired):
+            waypoints = self.flight.flight_plan.waypoints
+            previous = self.flight.flight_plan.chained_tot_for_waypoint(
+                waypoints[waypoints.index(waypoint) - 1]
+            )
+            previous_text = f"{previous:%H:%M:%S}" if previous is not None else "it"
+            QMessageBox.warning(
+                self.waypoint_list,
+                "Invalid time over target",
+                f"Time over target must be later than the previous waypoint "
+                f"({previous_text}). To place this waypoint earlier, reorder the "
+                f"waypoints with Move Up / Move Down instead.",
+            )
+            return
+        self.flight.flight_plan.set_waypoint_tot(waypoint, desired)
+        # set_waypoint_tot mutates the flight plan, not the model, so nothing else would
+        # repaint the cascaded times or reveal the manual-timing controls. Signal the
+        # owner to rebuild the list and refresh its widgets, but defer to the next event
+        # loop tick: rebuilding the model (model.clear()) while this edit is still
+        # committing is unsafe.
+        QTimer.singleShot(0, self.waypoint_list.tot_changed.emit)
+
+
 class QFlightWaypointList(QTableView):
+    tot_changed = Signal()
+
     def __init__(self, package: Package, flight: Flight):
         super().__init__()
         self._last_waypoint: Optional[FlightWaypoint] = None
@@ -55,6 +121,29 @@ class QFlightWaypointList(QTableView):
 
         self.altitude_editor_delegate = AltitudeEditorDelegate(self)
         self.setItemDelegateForColumn(1, self.altitude_editor_delegate)
+
+        self.tot_editor_delegate = TotEditorDelegate(self, self.flight)
+        self.setItemDelegateForColumn(3, self.tot_editor_delegate)
+
+    def edit(  # type: ignore[override]
+        self,
+        index: QModelIndex,
+        trigger: QAbstractItemView.EditTrigger,
+        event: QEvent,
+    ) -> bool:
+        if (
+            index.column() == 3
+            and self.flight.client_count == 0
+            and trigger != QAbstractItemView.EditTrigger.NoEditTriggers
+        ):
+            QMessageBox.information(
+                self,
+                "AI flight timing",
+                "AI flight times over target are scheduled automatically and can't be "
+                "edited. Add a player slot to this flight to time it manually.",
+            )
+            return False
+        return super().edit(index, trigger, event)
 
     def update_list(self) -> None:
         # ignore signals when updating list so on_changed does not fire
@@ -109,7 +198,11 @@ class QFlightWaypointList(QTableView):
 
         tot = self.tot_text(flight, waypoint)
         tot_item = QStandardItem(tot)
-        tot_item.setEditable(False)
+        editable = flight.client_count > 0 and (
+            waypoint.waypoint_type != FlightWaypointType.TAKEOFF
+        )
+        tot_item.setEditable(editable)
+        tot_item.setData(waypoint, Qt.ItemDataRole.UserRole)
         self.model.setItem(row, 3, tot_item)
 
     def on_changed(self) -> None:
@@ -126,6 +219,9 @@ class QFlightWaypointList(QTableView):
         flight: Flight,
         waypoint: FlightWaypoint,
     ) -> str:
+        if flight.manually_timed and flight.manual_takeoff_time is not None:
+            time = flight.flight_plan.effective_tot_for_waypoint(waypoint)
+            return f"{time:%H:%M:%S}" if time is not None else ""
         if waypoint.waypoint_type == FlightWaypointType.TAKEOFF:
             self.update_last_tot(flight.flight_plan.takeoff_time())
             self._last_waypoint = waypoint

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointTab.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Iterable, List, Optional
 
-from PySide6.QtCore import Signal, Qt, QModelIndex
+from PySide6.QtCore import Signal, Qt, QModelIndex, QItemSelectionModel
 from PySide6.QtWidgets import (
     QFrame,
     QGridLayout,
@@ -71,12 +71,20 @@ class QFlightWaypointTab(QFrame):
         self.coalition = game.coalition_for(player=Player.BLUE)
         self.package = package
         self.flight = flight
+        # Show the escort-drift warning at most once per manual-timing session.
+        self._escort_warning_shown = False
 
         self.flight_waypoint_list: Optional[QFlightWaypointList] = None
         self.rtb_waypoint: Optional[QPushButton] = None
         self.delete_selected: Optional[QPushButton] = None
         self.add_nav_waypoint: Optional[QPushButton] = None
         self.open_fast_waypoint_button: Optional[QPushButton] = None
+        self.move_up_button: Optional[QPushButton] = None
+        self.move_down_button: Optional[QPushButton] = None
+        self.manual_tot_label: Optional[QLabel] = None
+        self.reset_tot_button: Optional[QPushButton] = None
+        self.plan_type_label: Optional[QLabel] = None
+        self.convert_button: Optional[QPushButton] = None
         self.recreate_buttons: List[QPushButton] = []
         self.init_ui()
 
@@ -84,6 +92,7 @@ class QFlightWaypointTab(QFrame):
         layout = QGridLayout()
 
         self.flight_waypoint_list = QFlightWaypointList(self.package, self.flight)
+        self.flight_waypoint_list.tot_changed.connect(self.on_tot_changed)
         layout.addWidget(self.flight_waypoint_list, 0, 0)
 
         rlayout = QVBoxLayout()
@@ -111,6 +120,8 @@ class QFlightWaypointTab(QFrame):
 
         rlayout.addWidget(QLabel("<strong>Generator :</strong>"))
         rlayout.addWidget(QLabel("<small>AI compatible</small>"))
+        self.plan_type_label = QLabel()
+        rlayout.addWidget(self.plan_type_label)
 
         self.recreate_buttons.clear()
         for task in self.package.target.mission_types(for_player=Player.BLUE):
@@ -135,12 +146,33 @@ class QFlightWaypointTab(QFrame):
         self.add_nav_waypoint.clicked.connect(self.on_add_nav)
         rlayout.addWidget(self.add_nav_waypoint)
 
+        self.move_up_button = QPushButton("Move Up")
+        self.move_up_button.clicked.connect(lambda: self.on_move_waypoint(-1))
+        rlayout.addWidget(self.move_up_button)
+
+        self.move_down_button = QPushButton("Move Down")
+        self.move_down_button.clicked.connect(lambda: self.on_move_waypoint(1))
+        rlayout.addWidget(self.move_down_button)
+
+        self.manual_tot_label = QLabel(
+            "<small><b>Manually timed</b> — decoupled from package TOT</small>"
+        )
+        rlayout.addWidget(self.manual_tot_label)
+
+        self.reset_tot_button = QPushButton("Reset ToT to auto")
+        self.reset_tot_button.clicked.connect(self.on_reset_tot)
+        rlayout.addWidget(self.reset_tot_button)
+
         rlayout.addWidget(QLabel("<strong>Advanced : </strong>"))
         rlayout.addWidget(QLabel("<small>Do not use for AI flights</small>"))
 
         self.rtb_waypoint = QPushButton("Add RTB Waypoint")
         self.rtb_waypoint.clicked.connect(self.on_rtb_waypoint)
         rlayout.addWidget(self.rtb_waypoint)
+
+        self.convert_button = QPushButton("Convert to custom plan")
+        self.convert_button.clicked.connect(self.on_convert_to_custom)
+        rlayout.addWidget(self.convert_button)
 
         self.delete_selected = QPushButton("Delete Selected")
         self.delete_selected.clicked.connect(self.on_delete_waypoint)
@@ -151,6 +183,8 @@ class QFlightWaypointTab(QFrame):
         rlayout.addWidget(self.open_fast_waypoint_button)
         rlayout.addStretch()
         self.setLayout(layout)
+        self.refresh_manual_tot_widgets()
+        self.refresh_plan_type()
 
     def on_add_nav(self):
         selected = self.flight_waypoint_list.selectedIndexes()
@@ -217,9 +251,11 @@ class QFlightWaypointTab(QFrame):
     def confirm_degrade(self, parent: Optional[QWidget] = None) -> bool:
         result = QMessageBox.warning(
             parent if parent else self,
-            "Degrade flight-plan?",
-            "Deleting the selected waypoint(s) will require degradation to a custom flight-plan. "
-            "A custom flight-plan will no longer respect the TOTs of the package.<br><br>"
+            "Convert flight plan?",
+            "Deleting the selected waypoint(s) requires converting this flight to a "
+            "custom flight plan. A custom flight plan is no longer automatically timed "
+            "to the package TOT; its waypoint times become independent and manually "
+            "adjustable.<br><br>"
             "<b>Are you sure you wish to continue?</b>",
             QMessageBox.StandardButton.Yes,
             QMessageBox.StandardButton.No,
@@ -234,10 +270,31 @@ class QFlightWaypointTab(QFrame):
         self.subwindow.show()
 
     def on_waypoints_added(self, waypoints: Iterable[FlightWaypoint]) -> None:
+        waypoints = list(waypoints)
         if not waypoints:
             return
-        self.flight.flight_plan.layout.custom_waypoints.extend(waypoints)
-        self.add_rows(len(list(waypoints)))
+        customs = self.flight.flight_plan.layout.custom_waypoints
+        insert_at = self._custom_insert_index()
+        if insert_at is None:
+            customs.extend(waypoints)
+        else:
+            customs[insert_at:insert_at] = waypoints
+        self.add_rows(len(waypoints))
+
+    def _custom_insert_index(self) -> Optional[int]:
+        selected = self.flight_waypoint_list.selectedIndexes()
+        if not selected:
+            return None
+        row = selected[0].row()
+        waypoints = self.flight.flight_plan.waypoints
+        customs = self.flight.flight_plan.layout.custom_waypoints
+        selected_wp = waypoints[row]
+        if selected_wp in customs:
+            # Insert immediately after the selected custom waypoint.
+            return customs.index(selected_wp) + 1
+        # Selected waypoint is structural: append to the front of custom_waypoints so the
+        # new waypoint still renders after the structural section it follows.
+        return 0 if customs else None
 
     def add_rows(self, count: int) -> None:
         rc = self.flight_waypoint_list.model.rowCount()
@@ -254,6 +311,35 @@ class QFlightWaypointTab(QFrame):
     def degrade_to_custom_flight_plan(self) -> None:
         if not isinstance(self.flight.flight_plan, CustomFlightPlan):
             self.flight.degrade_to_custom_flight_plan()
+
+    def on_convert_to_custom(self) -> None:
+        if self.flight.flight_plan.is_custom:
+            return
+        result = QMessageBox.question(
+            self,
+            "Convert flight plan?",
+            "Convert this flight to a custom flight plan? A custom flight plan is no "
+            "longer automatically timed to the package TOT; its waypoint times become "
+            "independent and manually adjustable.",
+            QMessageBox.StandardButton.Yes,
+            QMessageBox.StandardButton.No,
+        )
+        if result != QMessageBox.StandardButton.Yes:
+            return
+        self.degrade_to_custom_flight_plan()
+        self.on_change()
+
+    def refresh_plan_type(self) -> None:
+        if self.plan_type_label is None or self.convert_button is None:
+            return
+        is_custom = self.flight.flight_plan.is_custom
+        if is_custom:
+            self.plan_type_label.setText("<small><b>Plan:</b> Custom</small>")
+        else:
+            self.plan_type_label.setText(
+                f"<small><b>Plan:</b> Standard ({self.flight.flight_type})</small>"
+            )
+        self.convert_button.setEnabled(not is_custom)
 
     def confirm_recreate(self, task: FlightType) -> None:
         result = QMessageBox.question(
@@ -314,7 +400,74 @@ class QFlightWaypointTab(QFrame):
         if changed:
             self.on_change()
 
+    def on_move_waypoint(self, direction: int) -> None:
+        selected = self.flight_waypoint_list.selectedIndexes()
+        if not selected:
+            return
+        row = selected[0].row()
+        if row == 0:
+            # The departure/takeoff waypoint is fixed.
+            return
+        waypoint = self.flight.flight_plan.waypoints[row]
+        if not self.flight.flight_plan.move_waypoint(waypoint, direction):
+            QMessageBox.information(
+                self,
+                "Cannot move waypoint",
+                "This waypoint can't move past a fixed point in a standard flight "
+                "plan. To reorder freely, convert this flight to a custom plan using "
+                "Convert to custom plan in the Advanced section.",
+            )
+            return
+        new_row = row + direction
+        self.on_change()
+        self.flight_waypoint_list.selectionModel().setCurrentIndex(
+            self.flight_waypoint_list.model.index(new_row, 0),
+            QItemSelectionModel.SelectionFlag.ClearAndSelect,
+        )
+
+    def on_reset_tot(self) -> None:
+        self.flight.flight_plan.clear_manual_timing()
+        self.on_change()
+
+    def on_tot_changed(self) -> None:
+        self.on_change()
+        self.maybe_warn_escort_drift()
+
+    def maybe_warn_escort_drift(self) -> None:
+        """Remind the player that manual timing won't move the package's escorts.
+
+        Escort start/end times are derived from the package's automatic ToTs, so a flight
+        with manual waypoint times can arrive out of sync with its escort. Warn once per
+        manual-timing session when the package actually contains an escort.
+        """
+        if self._escort_warning_shown or not self.flight.manually_timed:
+            return
+        if not any(
+            f.flight_type.provides_escort_coverage for f in self.package.flights
+        ):
+            return
+        self._escort_warning_shown = True
+        QMessageBox.warning(
+            self,
+            "Escort timing may drift",
+            "This flight now has manually-timed waypoints that are decoupled from the "
+            "package TOT. Escort coordination still uses the package's automatic timing, "
+            "so the escort may arrive at the wrong time. Adjust the escort flight's "
+            "timing to match, or reset this flight's ToT to auto.",
+        )
+
+    def refresh_manual_tot_widgets(self) -> None:
+        manual = self.flight.manually_timed
+        self.manual_tot_label.setVisible(manual)
+        self.reset_tot_button.setVisible(manual)
+        if not manual:
+            # Timing reverted to auto (reset button or a reorder); re-arm the warning so
+            # the next manual-timing session prompts again.
+            self._escort_warning_shown = False
+
     def on_change(self):
         self.flight_waypoint_list.update_list()
         self.flight_waypoint_list.on_changed()
         self.update()
+        self.refresh_manual_tot_widgets()
+        self.refresh_plan_type()

--- a/tests/ato/flightplans/test_custom_add_waypoint.py
+++ b/tests/ato/flightplans/test_custom_add_waypoint.py
@@ -1,0 +1,42 @@
+from dcs import Point
+from dcs.terrain import Caucasus
+
+from game.ato.flightplans.custom import CustomLayout
+from game.ato.flightwaypoint import FlightWaypoint
+from game.ato.flightwaypointtype import FlightWaypointType
+
+
+def _wp(name: str, kind: FlightWaypointType = FlightWaypointType.NAV) -> FlightWaypoint:
+    return FlightWaypoint(name, kind, Point(0, 0, Caucasus()))
+
+
+def test_add_waypoint_after_custom_inserts_after_selection() -> None:
+    a, b = _wp("a"), _wp("b")
+    layout = CustomLayout(_wp("dep", FlightWaypointType.TAKEOFF), [a, b])
+    assert layout.add_waypoint(a, b) is True
+    assert len(layout.custom_waypoints) == 3
+    assert layout.custom_waypoints[0] is a
+    assert layout.custom_waypoints[1].waypoint_type is FlightWaypointType.NAV
+    assert layout.custom_waypoints[2] is b
+
+
+def test_add_waypoint_after_departure_inserts_front() -> None:
+    a = _wp("a")
+    dep = _wp("dep", FlightWaypointType.TAKEOFF)
+    layout = CustomLayout(dep, [a])
+    assert layout.add_waypoint(dep, a) is True
+    assert layout.custom_waypoints[0].waypoint_type is FlightWaypointType.NAV
+    assert layout.custom_waypoints[1] is a
+
+
+def test_add_waypoint_after_last_custom_appends() -> None:
+    a = _wp("a")
+    layout = CustomLayout(_wp("dep", FlightWaypointType.TAKEOFF), [a])
+    assert layout.add_waypoint(a, None) is True
+    assert len(layout.custom_waypoints) == 2
+    assert layout.custom_waypoints[1].waypoint_type is FlightWaypointType.NAV
+
+
+def test_add_waypoint_unknown_selection_returns_false() -> None:
+    layout = CustomLayout(_wp("dep", FlightWaypointType.TAKEOFF), [_wp("a")])
+    assert layout.add_waypoint(_wp("ghost"), None) is False

--- a/tests/ato/flightplans/test_move_waypoint.py
+++ b/tests/ato/flightplans/test_move_waypoint.py
@@ -1,0 +1,72 @@
+from collections.abc import Iterator
+
+from dcs import Point
+from dcs.terrain import Caucasus
+
+from game.ato.flightwaypoint import FlightWaypoint
+from game.ato.flightwaypointtype import FlightWaypointType
+from game.ato.flightplans.standard import StandardLayout
+
+
+def _wp(name: str, kind: FlightWaypointType = FlightWaypointType.NAV) -> FlightWaypoint:
+    return FlightWaypoint(name, kind, Point(0, 0, Caucasus()))
+
+
+def _standard_layout(
+    nav_to: list[FlightWaypoint],
+    nav_from: list[FlightWaypoint],
+    custom: list[FlightWaypoint],
+) -> StandardLayout:
+    # StandardLayout is abstract (no iter_waypoints); build a minimal concrete subclass.
+    class _L(StandardLayout):
+        def iter_waypoints(self) -> Iterator[FlightWaypoint]:
+            yield self.departure
+            yield from self.nav_to
+            yield from self.nav_from
+            yield from self.custom_waypoints
+
+    return _L(
+        departure=_wp("dep", FlightWaypointType.TAKEOFF),
+        custom_waypoints=custom,
+        arrival=_wp("arr", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=_wp("bull", FlightWaypointType.BULLSEYE),
+        nav_to=nav_to,
+        nav_from=nav_from,
+    )
+
+
+def test_move_down_within_nav_to_swaps() -> None:
+    a, b = _wp("a"), _wp("b")
+    layout = _standard_layout([a, b], [], [])
+    assert layout.move_waypoint(a, 1) is True
+    assert layout.nav_to == [b, a]
+
+
+def test_move_up_within_custom_swaps() -> None:
+    a, b = _wp("a"), _wp("b")
+    layout = _standard_layout([], [], [a, b])
+    assert layout.move_waypoint(b, -1) is True
+    assert layout.custom_waypoints == [b, a]
+
+
+def test_move_off_end_of_list_returns_false() -> None:
+    a = _wp("a")
+    layout = _standard_layout([a], [], [])
+    assert layout.move_waypoint(a, 1) is False  # would cross into nav_from / structural
+    assert layout.nav_to == [a]
+
+
+def test_move_unknown_waypoint_returns_false() -> None:
+    layout = _standard_layout([_wp("a")], [], [])
+    assert layout.move_waypoint(_wp("ghost"), 1) is False
+
+
+def test_custom_layout_reorders_custom_waypoints() -> None:
+    from game.ato.flightplans.custom import CustomLayout
+
+    a, b, c = _wp("a"), _wp("b"), _wp("c")
+    layout = CustomLayout(_wp("dep", FlightWaypointType.TAKEOFF), [a, b, c])
+    assert layout.move_waypoint(c, -1) is True
+    assert layout.custom_waypoints == [a, c, b]
+    assert layout.move_waypoint(a, -1) is False  # already first

--- a/tests/ato/flightplans/test_patrol_timing.py
+++ b/tests/ato/flightplans/test_patrol_timing.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+from dcs import Point
+from dcs.terrain import Caucasus
+
+from game.ato.flightplans.patrolling import PatrollingFlightPlan, PatrollingLayout
+from game.ato.flightwaypoint import FlightWaypoint
+from game.ato.flightwaypointtype import FlightWaypointType
+from game.utils import Distance, Speed, kph, nautical_miles
+
+T0 = datetime(2020, 1, 1, 12, 0, 0)
+
+
+def _wp(name: str, kind: FlightWaypointType = FlightWaypointType.NAV) -> FlightWaypoint:
+    return FlightWaypoint(name, kind, Point(0, 0, Caucasus()))
+
+
+class _FixedPatrolPlan(PatrollingFlightPlan[PatrollingLayout]):
+    """Patrol plan with constant 2-minute travel legs for deterministic tests."""
+
+    @property
+    def patrol_duration(self) -> timedelta:
+        return timedelta(minutes=30)
+
+    @property
+    def patrol_speed(self) -> Speed:
+        return kph(400)
+
+    @property
+    def engagement_distance(self) -> Distance:
+        return nautical_miles(10)
+
+    def travel_time_between_waypoints(
+        self, a: FlightWaypoint, b: FlightWaypoint
+    ) -> timedelta:
+        return timedelta(minutes=2)
+
+
+def _make_patrol_plan() -> _FixedPatrolPlan:
+    layout = PatrollingLayout(
+        departure=_wp("dep", FlightWaypointType.TAKEOFF),
+        custom_waypoints=[],
+        arrival=_wp("arr", FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=_wp("bull", FlightWaypointType.BULLSEYE),
+        nav_to=[],
+        nav_from=[],
+        patrol_start=_wp("ps", FlightWaypointType.PATROL_TRACK),
+        patrol_end=_wp("pe", FlightWaypointType.PATROL),
+    )
+    flight = SimpleNamespace(package=SimpleNamespace(time_over_target=T0))
+    return _FixedPatrolPlan(flight, layout)  # type: ignore[arg-type]
+
+
+def test_patrol_leg_carries_on_station_time() -> None:
+    plan = _make_patrol_plan()
+    ps = plan.layout.patrol_start
+    pe = plan.layout.patrol_end
+    # The on-station leg is patrol_duration (30 min), not the 2-minute travel stub. This
+    # is what makes patrol_end_time = patrol_start_time + patrol_duration hold when the
+    # schedule is chained leg-by-leg (manual ToT cascade, kneeboard ETAs).
+    assert plan.total_time_between_waypoints(ps, pe) == timedelta(minutes=30)
+
+
+def test_non_patrol_legs_are_travel_only() -> None:
+    plan = _make_patrol_plan()
+    ps = plan.layout.patrol_start
+    pe = plan.layout.patrol_end
+    # Only the patrol_start -> patrol_end orbit carries the loiter; every other leg
+    # (including the reverse direction) stays at travel time.
+    assert plan.total_time_between_waypoints(plan.layout.departure, ps) == timedelta(
+        minutes=2
+    )
+    assert plan.total_time_between_waypoints(pe, plan.layout.arrival) == timedelta(
+        minutes=2
+    )
+    assert plan.total_time_between_waypoints(pe, ps) == timedelta(minutes=2)

--- a/tests/ato/flightplans/test_waypoint_cascade.py
+++ b/tests/ato/flightplans/test_waypoint_cascade.py
@@ -1,0 +1,275 @@
+import pickle
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+from dcs import Point
+from dcs.terrain import Caucasus
+
+from game.ato.flightplans.custom import CustomFlightPlan, CustomLayout
+from game.ato.flightplans.flightplan import cascade_waypoint_times
+from game.ato.flightwaypoint import FlightWaypoint
+from game.ato.flightwaypointtype import FlightWaypointType
+from game.ato.traveltime import TotEstimator
+
+T0 = datetime(2020, 1, 1, 12, 0, 0)
+
+
+def _legs(*minutes: int) -> list[timedelta]:
+    return [timedelta(minutes=m) for m in minutes]
+
+
+def test_no_offsets_is_takeoff_plus_prefix_legs() -> None:
+    times = cascade_waypoint_times(
+        T0, _legs(10, 5), [timedelta(), timedelta(), timedelta()]
+    )
+    assert times == [T0, T0 + timedelta(minutes=10), T0 + timedelta(minutes=15)]
+
+
+def test_offset_shifts_that_waypoint_and_all_after() -> None:
+    offsets = [timedelta(), timedelta(minutes=3), timedelta()]
+    times = cascade_waypoint_times(T0, _legs(10, 5), offsets)
+    assert times[0] == T0
+    assert times[1] == T0 + timedelta(minutes=13)
+    assert times[2] == T0 + timedelta(minutes=18)
+
+
+def test_negative_offset_pulls_earlier() -> None:
+    offsets = [timedelta(), timedelta(), timedelta(minutes=-2)]
+    times = cascade_waypoint_times(T0, _legs(10, 5), offsets)
+    assert times[2] == T0 + timedelta(minutes=13)
+
+
+def test_stacked_offsets_accumulate() -> None:
+    offsets = [timedelta(), timedelta(minutes=3), timedelta(minutes=2)]
+    times = cascade_waypoint_times(T0, _legs(10, 5), offsets)
+    assert times[1] == T0 + timedelta(minutes=13)
+    assert times[2] == T0 + timedelta(minutes=20)
+
+
+def test_manual_tot_offset_defaults_to_zero() -> None:
+    wp = FlightWaypoint("", FlightWaypointType.NAV, Point(0, 0, Caucasus()))
+    assert wp.manual_tot_offset == timedelta()
+
+
+def test_manual_tot_offset_survives_pickle() -> None:
+    wp = FlightWaypoint("", FlightWaypointType.NAV, Point(0, 0, Caucasus()))
+    wp.manual_tot_offset = timedelta(minutes=4)
+    restored = pickle.loads(pickle.dumps(wp))
+    assert restored.manual_tot_offset == timedelta(minutes=4)
+
+
+def test_old_save_without_field_loads_zero() -> None:
+    wp = FlightWaypoint("", FlightWaypointType.NAV, Point(0, 0, Caucasus()))
+    state = wp.__dict__.copy()
+    del state["manual_tot_offset"]
+    restored = FlightWaypoint.__new__(FlightWaypoint)
+    restored.__setstate__(state)
+    assert restored.manual_tot_offset == timedelta()
+
+
+class _FixedTimePlan(CustomFlightPlan):
+    """CustomFlightPlan with constant 10-minute legs for deterministic tests."""
+
+    def total_time_between_waypoints(
+        self, a: FlightWaypoint, b: FlightWaypoint
+    ) -> timedelta:
+        return timedelta(minutes=10)
+
+
+def _make_plan(n: int) -> _FixedTimePlan:
+    terrain = Caucasus()
+    departure = FlightWaypoint("dep", FlightWaypointType.TAKEOFF, Point(0, 0, terrain))
+    customs = [
+        FlightWaypoint(f"w{i}", FlightWaypointType.NAV, Point(0, i, terrain))
+        for i in range(1, n)
+    ]
+    layout = CustomLayout(departure, customs)
+    flight = SimpleNamespace(
+        manually_timed=True,
+        manual_takeoff_time=T0,
+        package=SimpleNamespace(time_over_target=T0),
+    )
+    plan = _FixedTimePlan(flight, layout)  # type: ignore[arg-type]
+    return plan
+
+
+def test_manual_waypoint_times_chain() -> None:
+    plan = _make_plan(3)
+    times = plan.manual_waypoint_times()
+    assert times == [T0, T0 + timedelta(minutes=10), T0 + timedelta(minutes=20)]
+
+
+def test_set_waypoint_tot_cascades_forward() -> None:
+    plan = _make_plan(3)
+    wps = plan.waypoints
+    plan.set_waypoint_tot(wps[1], T0 + timedelta(minutes=15))  # +5 on wp1
+    times = plan.manual_waypoint_times()
+    assert times[0] == T0
+    assert times[1] == T0 + timedelta(minutes=15)
+    assert times[2] == T0 + timedelta(minutes=25)
+
+
+def test_effective_tot_indexes_correct_waypoint() -> None:
+    plan = _make_plan(3)
+    wps = plan.waypoints
+    plan.set_waypoint_tot(wps[2], T0 + timedelta(minutes=30))
+    assert plan.effective_tot_for_waypoint(wps[2]) == T0 + timedelta(minutes=30)
+    assert plan.effective_tot_for_waypoint(wps[1]) == T0 + timedelta(minutes=10)
+
+
+def test_clear_manual_timing_resets() -> None:
+    plan = _make_plan(3)
+    wps = plan.waypoints
+    plan.set_waypoint_tot(wps[1], T0 + timedelta(minutes=15))
+    plan.clear_manual_timing()
+    assert plan.flight.manually_timed is False
+    assert plan.flight.manual_takeoff_time is None
+    assert all(wp.manual_tot_offset == timedelta() for wp in plan.waypoints)
+
+
+class _FractionalLegPlan(CustomFlightPlan):
+    """CustomFlightPlan whose legs carry sub-second remainders."""
+
+    def total_time_between_waypoints(
+        self, a: FlightWaypoint, b: FlightWaypoint
+    ) -> timedelta:
+        return timedelta(seconds=125, microseconds=900000)
+
+
+def test_manual_waypoint_times_floored_to_whole_seconds() -> None:
+    terrain = Caucasus()
+    departure = FlightWaypoint("dep", FlightWaypointType.TAKEOFF, Point(0, 0, terrain))
+    customs = [
+        FlightWaypoint(f"w{i}", FlightWaypointType.NAV, Point(0, i, terrain))
+        for i in range(1, 3)
+    ]
+    flight = SimpleNamespace(
+        manually_timed=True,
+        manual_takeoff_time=T0,
+        package=SimpleNamespace(time_over_target=T0),
+    )
+    plan = _FractionalLegPlan(flight, CustomLayout(departure, customs))  # type: ignore[arg-type]
+    times = plan.manual_waypoint_times()
+    assert all(t.microsecond == 0 for t in times)
+    # Each leg floors 125.9s -> 125s before chaining.
+    assert times == [T0, T0 + timedelta(seconds=125), T0 + timedelta(seconds=250)]
+
+
+def test_move_waypoint_resets_manual_timing() -> None:
+    plan = _make_plan(3)
+    wps = plan.waypoints
+    plan.set_waypoint_tot(wps[1], T0 + timedelta(minutes=15))
+    was_manual = plan.flight.manually_timed
+    moved = plan.move_waypoint(wps[2], -1)
+    assert was_manual
+    assert moved is True
+    assert not plan.flight.manually_timed
+    assert plan.flight.manual_takeoff_time is None
+    assert all(wp.manual_tot_offset == timedelta() for wp in plan.waypoints)
+
+
+def test_move_waypoint_failure_keeps_manual_timing() -> None:
+    plan = _make_plan(3)
+    wps = plan.waypoints
+    plan.set_waypoint_tot(wps[1], T0 + timedelta(minutes=15))
+    # The departure waypoint is not reorderable; a failed move must not reset timing.
+    assert plan.move_waypoint(wps[0], -1) is False
+    assert plan.flight.manually_timed
+
+
+def test_custom_tot_waypoint_finds_target() -> None:
+    terrain = Caucasus()
+    departure = FlightWaypoint("dep", FlightWaypointType.TAKEOFF, Point(0, 0, terrain))
+    nav = FlightWaypoint("nav", FlightWaypointType.NAV, Point(0, 1, terrain))
+    target = FlightWaypoint(
+        "tgt", FlightWaypointType.TARGET_POINT, Point(0, 2, terrain)
+    )
+    flight = SimpleNamespace(
+        manually_timed=False,
+        manual_takeoff_time=None,
+        package=SimpleNamespace(time_over_target=T0),
+    )
+    plan = _FixedTimePlan(flight, CustomLayout(departure, [nav, target]))  # type: ignore[arg-type]
+    assert plan.tot_waypoint is target
+
+
+def test_custom_tot_waypoint_finds_cas_flot() -> None:
+    # A CAS flight degraded to a custom plan anchors its ToT on the FLOT (CAS-type)
+    # waypoint. Without CAS in the recognized types the anchor fell back to the
+    # departure, collapsing the takeoff time onto the package TOT.
+    terrain = Caucasus()
+    departure = FlightWaypoint("dep", FlightWaypointType.TAKEOFF, Point(0, 0, terrain))
+    nav = FlightWaypoint("nav", FlightWaypointType.NAV, Point(0, 1, terrain))
+    flot = FlightWaypoint("FLOT START", FlightWaypointType.CAS, Point(0, 2, terrain))
+    flight = SimpleNamespace(
+        manually_timed=False,
+        manual_takeoff_time=None,
+        package=SimpleNamespace(time_over_target=T0),
+    )
+    plan = _FixedTimePlan(flight, CustomLayout(departure, [nav, flot]))  # type: ignore[arg-type]
+    assert plan.tot_waypoint is flot
+
+
+def test_earliest_tot_skips_manually_timed_flights() -> None:
+    auto = SimpleNamespace(manually_timed=False)
+    manual = SimpleNamespace(manually_timed=True)
+    package = SimpleNamespace(flights=[auto, manual])
+    estimator = TotEstimator(package)  # type: ignore[arg-type]
+
+    seen = []
+
+    def fake_for_flight(flight: object, now: datetime) -> datetime:
+        seen.append(flight)
+        return now
+
+    estimator.earliest_tot_for_flight = fake_for_flight  # type: ignore[method-assign]
+    estimator.earliest_tot(T0)
+    assert manual not in seen
+    assert auto in seen
+
+
+def _make_auto_plan(n: int) -> _FixedTimePlan:
+    terrain = Caucasus()
+    departure = FlightWaypoint("dep", FlightWaypointType.TAKEOFF, Point(0, 0, terrain))
+    customs = [
+        FlightWaypoint(f"w{i}", FlightWaypointType.NAV, Point(0, i, terrain))
+        for i in range(1, n)
+    ]
+    flight = SimpleNamespace(
+        manually_timed=False,
+        manual_takeoff_time=None,
+        package=SimpleNamespace(time_over_target=T0),
+    )
+    return _FixedTimePlan(flight, CustomLayout(departure, customs))  # type: ignore[arg-type]
+
+
+def test_chained_tot_auto_chains_from_takeoff() -> None:
+    plan = _make_auto_plan(3)
+    wps = plan.waypoints
+    assert plan.chained_tot_for_waypoint(wps[0]) == plan.takeoff_time()
+    assert plan.chained_tot_for_waypoint(wps[2]) == plan.takeoff_time() + timedelta(
+        minutes=20
+    )
+
+
+def test_chained_tot_manual_matches_cascade() -> None:
+    plan = _make_plan(3)
+    wps = plan.waypoints
+    plan.set_waypoint_tot(wps[1], T0 + timedelta(minutes=15))
+    assert plan.chained_tot_for_waypoint(wps[2]) == plan.manual_waypoint_times()[2]
+
+
+def test_would_invert_order_rejects_at_or_before_previous() -> None:
+    plan = _make_auto_plan(3)
+    wps = plan.waypoints
+    prev = plan.chained_tot_for_waypoint(wps[1])
+    assert prev is not None
+    assert plan.would_invert_order(wps[2], prev - timedelta(minutes=1)) is True
+    assert plan.would_invert_order(wps[2], prev) is True
+    assert plan.would_invert_order(wps[2], prev + timedelta(minutes=1)) is False
+
+
+def test_would_invert_order_first_waypoint_never_inverts() -> None:
+    plan = _make_auto_plan(3)
+    wps = plan.waypoints
+    assert plan.would_invert_order(wps[0], T0 - timedelta(hours=1)) is False

--- a/tests/ato/test_flighttype.py
+++ b/tests/ato/test_flighttype.py
@@ -1,0 +1,13 @@
+from game.ato.flighttype import FlightType
+
+
+def test_provides_escort_coverage_includes_escort_like_types() -> None:
+    assert FlightType.ESCORT.provides_escort_coverage
+    assert FlightType.SEAD_ESCORT.provides_escort_coverage
+    assert FlightType.TARCAP.provides_escort_coverage
+
+
+def test_provides_escort_coverage_excludes_others() -> None:
+    assert not FlightType.STRIKE.provides_escort_coverage
+    assert not FlightType.BARCAP.provides_escort_coverage
+    assert not FlightType.CAS.provides_escort_coverage

--- a/tests/missiongenerator/aircraft/test_pydcswaypointbuilder.py
+++ b/tests/missiongenerator/aircraft/test_pydcswaypointbuilder.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 from dcs import Point
@@ -90,3 +91,69 @@ def test_divert_and_bullseye_waypoints_are_player_only() -> None:
     divert = builder.divert(divert_point)  # type: ignore[arg-type]
     assert divert is not None
     assert divert.only_for_player is True
+
+
+T0 = datetime(2020, 1, 1, 12, 0, 0)
+
+
+class _FakeMovingPoint:
+    """Minimal stand-in for a pydcs MovingPoint -- only the ETA fields are exercised."""
+
+    def __init__(self) -> None:
+        self.ETA: int = 0
+        self.ETA_locked: bool = False
+        self.speed_locked: bool = False
+
+
+def _make_builder(
+    client_count: int,
+    locked_tot: datetime | None,
+    display_tot: datetime | None,
+) -> PydcsWaypointBuilder:
+    waypoint = FlightWaypoint("wp", FlightWaypointType.NAV, Point(0, 0, Caucasus()))
+    flight = SimpleNamespace(
+        client_count=client_count,
+        unit_type=SimpleNamespace(dcs_unit_type=object()),  # not an AJS37 Viggen
+        flight_plan=SimpleNamespace(
+            effective_tot_for_waypoint=lambda wp: locked_tot,
+            chained_tot_for_waypoint=lambda wp: display_tot,
+        ),
+    )
+    builder = PydcsWaypointBuilder.__new__(PydcsWaypointBuilder)
+    builder.waypoint = waypoint
+    builder.flight = flight  # type: ignore[assignment]
+    builder.now = T0
+    return builder
+
+
+def test_player_auto_waypoint_locks_eta() -> None:
+    display = T0 + timedelta(minutes=10)
+    builder = _make_builder(client_count=1, locked_tot=None, display_tot=display)
+    point = _FakeMovingPoint()
+    builder._assign_waypoint_tot(point)  # type: ignore[arg-type]
+    # Player flights feed waypoint ETAs into the jet's nav computer, so the chained ToT
+    # must be locked into the DCS ETA -- otherwise the cockpit time-on-waypoint is wrong.
+    assert point.ETA_locked is True
+    assert point.ETA == int(timedelta(minutes=10).total_seconds())
+    assert builder.waypoint.tot == display
+
+
+def test_ai_auto_waypoint_leaves_eta_unlocked() -> None:
+    display = T0 + timedelta(minutes=10)
+    builder = _make_builder(client_count=0, locked_tot=None, display_tot=display)
+    point = _FakeMovingPoint()
+    builder._assign_waypoint_tot(point)  # type: ignore[arg-type]
+    # AI flights keep the DCS ETA flexible (no over-constraint); only the kneeboard model
+    # field is populated.
+    assert point.ETA_locked is False
+    assert builder.waypoint.tot == display
+
+
+def test_anchored_waypoint_locks_for_ai_and_player() -> None:
+    anchor = T0 + timedelta(minutes=5)
+    builder = _make_builder(client_count=0, locked_tot=anchor, display_tot=None)
+    point = _FakeMovingPoint()
+    builder._assign_waypoint_tot(point)  # type: ignore[arg-type]
+    # Structural / manual ToTs are always locked, regardless of player presence.
+    assert point.ETA_locked is True
+    assert point.ETA == int(timedelta(minutes=5).total_seconds())


### PR DESCRIPTION
## Summary

Implements #671. Players get direct control over waypoint **order** and **per-waypoint Times-over-Target**, and the timing model is corrected so the planned schedule (kneeboard and in-cockpit nav) matches what the aircraft actually flies.

## What's included

### Editing
- **Reorder intermediate waypoints** and **insert NAV points** from the waypoint list — including on **custom flight plans**, which previously crashed.
- **Editable per-waypoint ToTs** with a manual-timing cascade: setting one waypoint's ToT shifts it and every later waypoint (floored to whole seconds), decoupled from the package TOT.
- **Ordering guard**: rejects a ToT at or earlier than the previous waypoint, so the schedule can't be inverted.
- **Plan-type visibility**: the tab header shows whether the flight is on a standard or custom plan, with a **convert-to-custom**button.
- **Clearer dialog copy** for convert/delete, plus an **info dialog** explaining why AI flights can't have their ToT edited.
- **Escort-drift warning** for TARCAP packages.

### Timing model
- **Chained per-waypoint ToTs** so kneeboards show a time for *every* waypoint, not just structural targets.
- **Patrol on-station time preserved**: the `patrol_start → patrol_end` leg carries `patrol_duration`, so chained schedules no longer collapse the loiter and shift later waypoints early.
- **Custom CAS plans anchor on the FLOT** waypoint, so a CAS flight converted to a custom plan doesn't collapse its takeoff onto the package TOT.
- **Player-flight ETA locking**: waypoint ETAs are written into the DCS mission for player flights, so the jet's nav computer reports correct time-on-waypoint (including startup/taxi and on-station). AI flights keep ETA flexibility — their loiter is driven bythe orbit task, not the waypoint ETA.

## How the timing model works

- Manual timing lives on `Flight.manually_timed` + `Flight.manual_takeoff_time` + per-waypoint `FlightWaypoint.manual_tot_offset`. `effective_tot_for_waypoint` returns the manual cascade when set, otherwise the structural ToT.
- `chained_tot_for_waypoint` forward-chains per-leg travel (and on-station) time for display fill.
- At generation: anchored/manual ToTs lock the DCS ETA; for **player** flights the chained ToT is also locked (the avionics read it); **AI** auto waypoints stay unlocked so the AI isn't over-constrained. Patrol loiter is enforced by the existing `OrbitAction`+ stop-orbit trigger, independent of the waypoint ETA.
- Save-compatible: `Flight.__setstate__` migrates older saves (the new fields default safely). Player Viggens keep their existingcarve-out (no ToT lock on non-target waypoints).

## Testing

### Automated
New unit tests cover the manual cascade & second-flooring, the ordering predicate, custom-plan ToT anchoring (incl. the CAS FLOT), patrol on-station timing, player-vs-AI ETA locking, custom Insert-NAV, and the escort-coverage flag. All CI gates green: `black --check`, `mypy game`, `mypy tests`, `pytest tests`.

### In-DCS acceptance
Validated against a live campaign save across player and AI flights (CAS / TARCAP / BARCAP / BAI / DEAD / Strike, fixed-wing and helo):

| Area | Result |
|---|---|
| Insert NAV on a custom plan | No longer crashes |
| Reorder / move waypoints | Works; reordering resets manual timing as intended |
| Backward-ToT guard | Blocks an earlier-than-previous ToT |
| AI-flight ToT edit | Shows the info dialog instead of editing |
| Convert-to-custom + plan-type label | Button converts; header reflects the plan type |
| TARCAP escort-drift warning | Fires on drift |
| Kneeboard per-waypoint ETAs | Filled for BARCAP / TARCAP / CAS |
| Helicopter ToT editing | Editable |
| CAS reset-to-auto takeoff | Takeoff now well before the package TOT (was collapsing onto it) |
| Patrol on-station when editing a ToT | start→end time preserved (was collapsing to flight time) |
| Player cockpit / ME waypoint times | Match the kneeboard/plan, incl. startup/taxi + on-station, after ETA locking |
| AI-only flight loiter | Holds station for the full patrol duration (orbit task + stop trigger) |

Closes #671.