### PR TITLE
DEAD/SEAD: one waypoint per target, with kneeboard STPT column

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@
 * **[Modding]** Add support for Su-35S mod (v2.0.27b)
 * **[Plugins]** Update EW Script to version 2.1
 * **[Options]** New option to spawn TACAN beacons at captured airfields
-* **[Mission Generation]** DEAD and SEAD flights against a ground target now get one waypoint per individual target — the same targets (with coordinates) already listed on the SEAD/DEAD kneeboard page — so they can be designated quickly with TOO, just like Strike flights. The waypoints are player-only (AI tasking is unchanged), and targets the kneeboard does not list with coordinates (e.g. SEAD against a naval group) are unaffected.
+* **[Mission Generation]** DEAD and SEAD flights against a ground target now get one waypoint per individual target — the same targets (with coordinates) already listed on the SEAD/DEAD kneeboard page — so they can be designated quickly with TOO, just like Strike flights. The waypoints are player-only (AI tasking is unchanged), and targets the kneeboard does not list with coordinates (e.g. SEAD against a naval group) are unaffected. The SEAD/DEAD kneeboard target list also gains an "STPT" column showing each target's assigned waypoint number, matching the strike task page.
 
 ## Fixes
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * **[Modding]** Add support for Su-35S mod (v2.0.27b)
 * **[Plugins]** Update EW Script to version 2.1
 * **[Options]** New option to spawn TACAN beacons at captured airfields
+* **[Mission Generation]** DEAD and SEAD flights against a ground target now get one waypoint per individual target — the same targets (with coordinates) already listed on the SEAD/DEAD kneeboard page — so they can be designated quickly with TOO, just like Strike flights. The waypoints are player-only (AI tasking is unchanged), and targets the kneeboard does not list with coordinates (e.g. SEAD against a naval group) are unaffected.
 
 ## Fixes
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.

--- a/game/ato/flightplans/dead.py
+++ b/game/ato/flightplans/dead.py
@@ -26,16 +26,16 @@ class Builder(FormationAttackBuilder[DeadFlightPlan, FormationAttackLayout]):
     def layout(self) -> FormationAttackLayout:
         location = self.package.target
 
-        is_ewr = isinstance(location, EwrGroundObject)
-        is_sam = isinstance(location, SamGroundObject)
-        if not is_ewr and not is_sam:
+        if not isinstance(location, (EwrGroundObject, SamGroundObject)):
             logging.exception(
                 f"Invalid Objective Location for DEAD flight {self.flight=} at "
                 f"{location=}"
             )
             raise InvalidObjectiveLocation(self.flight.flight_type, location)
 
-        return self._build(FlightWaypointType.INGRESS_DEAD)
+        return self._build(
+            FlightWaypointType.INGRESS_DEAD, self.strike_targets_for(location)
+        )
 
     def build(self, dump_debug_info: bool = False) -> DeadFlightPlan:
         return DeadFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/formationattack.py
+++ b/game/ato/flightplans/formationattack.py
@@ -175,18 +175,7 @@ class FormationAttackBuilder(IBuilder[FlightPlanT, LayoutT], ABC):
         assert self.package.waypoints is not None
         builder = WaypointBuilder(self.flight, targets)
 
-        target_waypoints: list[FlightWaypoint] = []
-        if targets is not None:
-            for target in targets:
-                target_waypoints.append(
-                    self.target_waypoint(self.flight, builder, target)
-                )
-        else:
-            target_waypoints.append(
-                self.target_area_waypoint(
-                    self.flight, self.flight.package.target, builder
-                )
-            )
+        target_waypoints = self._target_waypoints(builder, targets)
 
         hold = None
         if not self.flight.is_helo:
@@ -246,6 +235,22 @@ class FormationAttackBuilder(IBuilder[FlightPlanT, LayoutT], ABC):
             bullseye=builder.bullseye(),
             custom_waypoints=list(),
         )
+
+    def _target_waypoints(
+        self, builder: WaypointBuilder, targets: list[StrikeTarget] | None
+    ) -> list[FlightWaypoint]:
+        # `targets` can be an *empty* list (not just None) -- e.g. a Strike/DEAD/
+        # SEAD against an objective whose units are all already destroyed, since
+        # strike_targets_for() only lists live units. Fall back to a single
+        # target-area waypoint in that case so the layout always has at least one
+        # target (tot_waypoint and the timing math index targets[0]).
+        if targets:
+            return [
+                self.target_waypoint(self.flight, builder, target) for target in targets
+            ]
+        return [
+            self.target_area_waypoint(self.flight, self.flight.package.target, builder)
+        ]
 
     def _build_refuel(self, builder: WaypointBuilder) -> Optional[FlightWaypoint]:
         refuel: Optional[FlightWaypoint] = None

--- a/game/ato/flightplans/formationattack.py
+++ b/game/ato/flightplans/formationattack.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING, TypeVar
 from dcs import Point
 
 from game.flightplan import HoldZoneGeometry
-from game.theater import MissionTarget
+from game.theater import MissionTarget, TheaterGroundObject
+from game.theater.theatergroup import SceneryUnit
 from game.utils import nautical_miles, Speed, feet
 from .flightplan import FlightPlan
 from .formation import FormationFlightPlan, FormationLayout
@@ -264,6 +265,22 @@ class FormationAttackBuilder(IBuilder[FlightPlanT, LayoutT], ABC):
             assert self.package.primary_flight is not None
             fp = self.package.primary_flight.flight_plan
             return fp.is_airassault
+
+    @staticmethod
+    def strike_targets_for(location: TheaterGroundObject) -> list[StrikeTarget]:
+        """One StrikeTarget per individual unit of a ground objective.
+
+        This is the same per-unit list the kneeboard target page renders (with
+        coordinates). Mission types whose kneeboard lists targets with
+        coordinates (Strike, DEAD, SEAD) pass this to ``_build`` so each listed
+        target also gets its own TARGET_POINT waypoint in the aircraft, making it
+        trivial to designate with TOO.
+        """
+        targets: list[StrikeTarget] = []
+        for idx, unit in enumerate(location.strike_targets):
+            name = unit.name if isinstance(unit, SceneryUnit) else unit.type.id
+            targets.append(StrikeTarget(f"{name} #{idx}", unit))
+        return targets
 
     @staticmethod
     def target_waypoint(

--- a/game/ato/flightplans/sead.py
+++ b/game/ato/flightplans/sead.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Type
 
+from game.theater import TheaterGroundObject
 from .formationattack import (
     FormationAttackBuilder,
     FormationAttackFlightPlan,
@@ -22,7 +23,17 @@ class SeadFlightPlan(FormationAttackFlightPlan):
 
 class Builder(FormationAttackBuilder[SeadFlightPlan, FormationAttackLayout]):
     def layout(self) -> FormationAttackLayout:
-        return self._build(FlightWaypointType.INGRESS_SEAD)
+        location = self.package.target
+        # Only ground objectives expose individual units with coordinates (the
+        # same list the SEAD kneeboard page renders). Against those, give each
+        # listed target its own waypoint; against e.g. naval groups the kneeboard
+        # lists no per-unit coordinates, so fall back to the single target area.
+        targets = (
+            self.strike_targets_for(location)
+            if isinstance(location, TheaterGroundObject)
+            else None
+        )
+        return self._build(FlightWaypointType.INGRESS_SEAD, targets)
 
     def build(self, dump_debug_info: bool = False) -> SeadFlightPlan:
         return SeadFlightPlan(self.flight, self.layout())

--- a/game/ato/flightplans/strike.py
+++ b/game/ato/flightplans/strike.py
@@ -9,9 +9,7 @@ from .formationattack import (
     FormationAttackLayout,
 )
 from .invalidobjectivelocation import InvalidObjectiveLocation
-from .waypointbuilder import StrikeTarget
 from ..flightwaypointtype import FlightWaypointType
-from ...theater.theatergroup import SceneryUnit
 
 
 class StrikeFlightPlan(FormationAttackFlightPlan):
@@ -27,14 +25,9 @@ class Builder(FormationAttackBuilder[StrikeFlightPlan, FormationAttackLayout]):
         if not isinstance(location, TheaterGroundObject):
             raise InvalidObjectiveLocation(self.flight.flight_type, location)
 
-        targets: list[StrikeTarget] = []
-        for idx, unit in enumerate(location.strike_targets):
-            name = unit.type.id
-            if isinstance(unit, SceneryUnit):
-                name = unit.name
-            targets.append(StrikeTarget(f"{name} #{idx}", unit))
-
-        return self._build(FlightWaypointType.INGRESS_STRIKE, targets)
+        return self._build(
+            FlightWaypointType.INGRESS_STRIKE, self.strike_targets_for(location)
+        )
 
     def build(self, dump_debug_info: bool = False) -> StrikeFlightPlan:
         return StrikeFlightPlan(self.flight, self.layout())

--- a/game/missiongenerator/aircraft/waypoints/strikeingress.py
+++ b/game/missiongenerator/aircraft/waypoints/strikeingress.py
@@ -62,6 +62,11 @@ class StrikeIngressBuilder(PydcsWaypointBuilder):
     def add_strike_tasks(
         self, waypoint: MovingPoint, weapon_type: WeaponType = WeaponType.Auto
     ) -> None:
+        if not self.waypoint.targets:
+            # Nothing to strike (e.g. an objective whose units are all already
+            # destroyed). Skip -- as add_bombing_tasks does -- so we neither add
+            # an empty attack task nor divide by zero on the units/targets ratio.
+            return
         bomber = self.group.units[0].unit_type in [B_1B, B_52H]
         ratio = len(self.group.units) / len(self.waypoint.targets)
         for target in self.waypoint.targets:

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -713,6 +713,22 @@ class SeadTaskPage(KneeboardPage):
         if isinstance(self.flight.package.target, TheaterGroundObject):
             yield from self.flight.package.target.strike_targets
 
+    def _waypoint_number_by_position(self) -> Dict[Tuple[float, float], int]:
+        """STPT number of each per-target waypoint, keyed by its position.
+
+        DEAD/SEAD flights get one TARGET_POINT waypoint per target, built at the
+        target's position, so each listed target can show its assigned waypoint
+        number — the same "STPT" the strike task page shows. The number is the
+        index into the flight's waypoint list, matching the flight-plan page.
+        Targets without a matching waypoint (e.g. an old flight plan generated
+        before per-target waypoints existed) simply show a blank STPT.
+        """
+        numbers: Dict[Tuple[float, float], int] = {}
+        for idx, waypoint in enumerate(self.flight.waypoints):
+            if waypoint.waypoint_type == FlightWaypointType.TARGET_POINT:
+                numbers.setdefault((waypoint.position.x, waypoint.position.y), idx)
+        return numbers
+
     @staticmethod
     def alic_for(unit: TheaterUnit) -> str:
         try:
@@ -729,18 +745,23 @@ class SeadTaskPage(KneeboardPage):
         task = "DEAD" if self.flight.flight_type == FlightType.DEAD else "SEAD"
         writer.title(f"{self.flight.callsign} {task} Target Info{custom_name_title}")
 
+        waypoint_numbers = self._waypoint_number_by_position()
         writer.table(
-            [self.target_info_row(t) for t in self.target_units],
-            headers=["Description", "ALIC", "Location"],
+            [self.target_info_row(t, waypoint_numbers) for t in self.target_units],
+            headers=["STPT", "Description", "ALIC", "Location"],
         )
 
         writer.write(path)
 
-    def target_info_row(self, unit: TheaterUnit) -> List[str]:
+    def target_info_row(
+        self, unit: TheaterUnit, waypoint_numbers: Dict[Tuple[float, float], int]
+    ) -> List[str]:
         ll = unit.position.latlng()
         unit_type = unit.type
         name = unit.name if unit_type is None else unit_type.name
+        number = waypoint_numbers.get((unit.position.x, unit.position.y))
         return [
+            "" if number is None else str(number),
             name,
             self.alic_for(unit),
             ll.format_dms(include_decimal_seconds=True),

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -746,9 +746,16 @@ class SeadTaskPage(KneeboardPage):
         writer.title(f"{self.flight.callsign} {task} Target Info{custom_name_title}")
 
         waypoint_numbers = self._waypoint_number_by_position()
+        # Smaller table font + 1-char "#" header keep the full DMS Location
+        # on-page; at size 20 the longest SAM names (e.g. S-300 Big Bird SR)
+        # clipped the coordinates off the right edge.
+        table_font = ImageFont.truetype(
+            "courbd.ttf", 18, layout_engine=ImageFont.Layout.BASIC
+        )
         writer.table(
             [self.target_info_row(t, waypoint_numbers) for t in self.target_units],
-            headers=["STPT", "Description", "ALIC", "Location"],
+            headers=["#", "Description", "ALIC", "Location"],
+            font=table_font,
         )
 
         writer.write(path)

--- a/tests/ato/test_formationattack_targets.py
+++ b/tests/ato/test_formationattack_targets.py
@@ -6,7 +6,12 @@ per-target TARGET_POINT waypoints, keeping the two in lockstep for Strike,
 DEAD and SEAD.
 """
 
+from types import SimpleNamespace
+
+from game.ato.flighttype import FlightType
 from game.ato.flightplans.formationattack import FormationAttackBuilder
+from game.ato.flightplans.strike import Builder as StrikeBuilder
+from game.ato.flightplans.waypointbuilder import StrikeTarget
 
 
 class _FakeType:
@@ -45,3 +50,30 @@ def test_one_target_per_alive_unit_with_indexed_names() -> None:
 
 def test_no_targets_when_objective_has_no_units() -> None:
     assert FormationAttackBuilder.strike_targets_for(_FakeLocation([])) == []  # type: ignore[arg-type]
+
+
+def test_target_waypoints_fall_back_to_area_when_no_live_targets() -> None:
+    """An objective with all units destroyed yields an empty target list.
+
+    The layout must still get one (area) target waypoint, otherwise
+    ``tot_waypoint`` -- which indexes ``targets[0]`` -- raises IndexError while
+    planning a Strike/DEAD/SEAD against a fully destroyed objective (regression).
+    """
+    builder = StrikeBuilder.__new__(StrikeBuilder)  # skip IBuilder.__init__
+    builder.flight = SimpleNamespace(  # type: ignore[assignment]
+        flight_type=FlightType.STRIKE,
+        package=SimpleNamespace(target=object()),
+    )
+    wp_builder = SimpleNamespace(
+        strike_point=lambda target: ("point", target),
+        strike_area=lambda location: "area",
+    )
+
+    # Empty list (all targets dead) and None both fall back to one area waypoint.
+    assert builder._target_waypoints(wp_builder, []) == ["area"]  # type: ignore[arg-type]
+    assert builder._target_waypoints(wp_builder, None) == ["area"]  # type: ignore[arg-type]
+
+    # With live targets, one waypoint per target is produced.
+    targets = [StrikeTarget("a #0", object()), StrikeTarget("b #1", object())]  # type: ignore[arg-type]
+    result = builder._target_waypoints(wp_builder, targets)  # type: ignore[arg-type]
+    assert result == [("point", targets[0]), ("point", targets[1])]

--- a/tests/ato/test_formationattack_targets.py
+++ b/tests/ato/test_formationattack_targets.py
@@ -1,0 +1,47 @@
+"""Tests for FormationAttackBuilder.strike_targets_for.
+
+This helper turns a ground objective's individual units into the per-target
+list used both by the kneeboard target page (with coordinates) and by the
+per-target TARGET_POINT waypoints, keeping the two in lockstep for Strike,
+DEAD and SEAD.
+"""
+
+from game.ato.flightplans.formationattack import FormationAttackBuilder
+
+
+class _FakeType:
+    def __init__(self, id_: str) -> None:
+        self.id = id_
+
+
+class _FakeUnit:
+    """Stands in for a TheaterUnit (not a SceneryUnit, so .type.id is used)."""
+
+    def __init__(self, id_: str) -> None:
+        self.type = _FakeType(id_)
+
+
+class _FakeLocation:
+    def __init__(self, units: list[_FakeUnit]) -> None:
+        self.strike_targets = units
+
+
+def test_one_target_per_alive_unit_with_indexed_names() -> None:
+    location = _FakeLocation(
+        [_FakeUnit("SA-10 ln"), _FakeUnit("SA-10 tr"), _FakeUnit("SA-10 cp")]
+    )
+
+    targets = FormationAttackBuilder.strike_targets_for(location)  # type: ignore[arg-type]
+
+    assert [t.name for t in targets] == [
+        "SA-10 ln #0",
+        "SA-10 tr #1",
+        "SA-10 cp #2",
+    ]
+    # Each StrikeTarget references the originating unit, so the waypoint and the
+    # kneeboard row describe the same target.
+    assert [t.target for t in targets] == location.strike_targets
+
+
+def test_no_targets_when_objective_has_no_units() -> None:
+    assert FormationAttackBuilder.strike_targets_for(_FakeLocation([])) == []  # type: ignore[arg-type]

--- a/tests/missiongenerator/aircraft/test_strikeingress.py
+++ b/tests/missiongenerator/aircraft/test_strikeingress.py
@@ -1,0 +1,27 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+from game.missiongenerator.aircraft.waypoints.strikeingress import (
+    StrikeIngressBuilder,
+)
+
+
+def test_add_strike_tasks_handles_no_targets() -> None:
+    """Regression: a Strike against an objective whose units are all destroyed
+    leaves the strike waypoint with no targets. add_strike_tasks must not divide
+    by zero (len(units) / len(targets)) and must add no bombing task.
+    """
+    # Bypass __init__ (needs a full mission/flight); only add_strike_tasks() and
+    # the attributes it reads are exercised.
+    builder: Any = object.__new__(StrikeIngressBuilder)
+    builder.waypoint = MagicMock()
+    builder.waypoint.targets = []
+    builder.group = MagicMock()
+    builder.group.units = [MagicMock()]  # would make the ratio 1 / 0 if reached
+
+    waypoint = MagicMock()
+    waypoint.tasks = []
+
+    builder.add_strike_tasks(waypoint)  # must not raise ZeroDivisionError
+
+    assert waypoint.tasks == []


### PR DESCRIPTION
## Summary
Strike flights already build one `TARGET_POINT` waypoint per target unit, so every target the kneeboard lists with coordinates is also a selectable waypoint in the aircraft — trivial to designate with TOO. DEAD and SEAD flights listed the same per-unit targets (with coordinates) on their kneeboard page, but only generated a single target-area waypoint, so the player had to enter each target by hand.

This makes DEAD and SEAD flights against a ground objective generate one `TARGET_POINT` waypoint per target, exactly like Strike, and adds the matching **STPT** column to the SEAD/DEAD kneeboard target list.

## Behaviour / compatibility
- **AI tasking is unchanged**: the generated waypoints are `only_for_player`, so the AI still attacks via the `AttackGroup` tasks on the ingress point.
- Additive and backwards-compatible: existing flight plans without per-target waypoints simply show a blank STPT; non-ground SEAD targets are unaffected.
