### PR TITLE
Relocate ground units that spawn on water to nearest land (#59)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission
 * **[Engine]** Fixed a bug where squadrons could transfer to enemy owned control points
+* **[Mission Generation]** Relocate ground units that spawn on inland water (ponds, rivers, lakes) to the nearest land at mission start, fixing armor and SAM sites spawning underwater (#59).
 
 # Retribution v1.5.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission
 * **[Engine]** Fixed a bug where squadrons could transfer to enemy owned control points
 * **[Mission Generation]** Relocate ground units that spawn on inland water (ponds, rivers, lakes) to the nearest land at mission start, fixing armor and SAM sites spawning underwater (#59).
+* **[Mission Generation]** Relocate ships that spawn on land (e.g. carrier escorts when the carrier hugs the shore) to the nearest deep water at mission start (#59).
 
 # Retribution v1.5.0
 

--- a/resources/plugins/base/land_relocate.lua
+++ b/resources/plugins/base/land_relocate.lua
@@ -51,6 +51,14 @@ local SEARCH_HEADINGS = 8        -- sample points per ring (every 45 degrees)
 local CLEAR_RADIUS = 1 * NM      -- destination must be open water this far out...
 local CLEAR_STEP   = 0.2 * NM    -- ...sampled every 0.2 nm along each spoke
 
+-- Relaxed fallback: when the strict open-water search finds nothing (e.g. a
+-- carrier's escorts in a narrow canal), a beached ship is moved to the nearest
+-- deep water. The gated relaxed pass keeps that destination at least
+-- MIN_ANCHOR_DIST from the nearest afloat ship so escorts don't stack on the
+-- carrier when a farther channel point exists; a final ungated pass ignores it so
+-- a ship whose only water is the sliver beside the carrier still gets afloat.
+local MIN_ANCHOR_DIST = 0.5 * NM
+
 local DRY_SURFACES = {
     [land.SurfaceType.LAND] = true,
     [land.SurfaceType.ROAD] = true,
@@ -106,24 +114,42 @@ local function is_open_water(x, y)
     return true
 end
 
--- Expanding-ring spiral search for the nearest open-water point. When a bias
--- target is given, the equidistant candidates on a ring are resolved in favour
--- of the one closest to the target (the carrier / open sea), not just the first.
--- Returns { x = ..., y = ... } or nil if no open water within SEARCH_MAX.
-local function nearest_deep_water(x, y, bias)
+-- Expanding-ring spiral search for the nearest water point matching `opts`.
+--   opts.require_open    -- gate candidates on is_open_water (strict clearance)
+--   opts.min_anchor_dist -- reject candidates nearer than this (metres) to `bias`;
+--                           0, nil, or a nil bias disables the gate.
+-- With a bias target, a ring's qualifying candidates resolve in favour of the one
+-- nearest it (the carrier / open sea); exact ties fall to heading-iteration order.
+-- Returns { x = ..., y = ... } or nil if nothing within SEARCH_MAX.
+local function find_water(x, y, bias, opts)
+    -- Gate distance is compared squared, to match distance_sq and skip a sqrt.
+    -- A nil min_anchor_dist is treated as 0 (gate off) so a preset may omit it.
+    local min_anchor_dist = opts.min_anchor_dist or 0
+    local min_d2 = 0
+    if bias and min_anchor_dist > 0 then
+        min_d2 = min_anchor_dist * min_anchor_dist
+    end
     for r = SEARCH_STEP, SEARCH_MAX, SEARCH_STEP do
         local best, best_d
         for i = 0, SEARCH_HEADINGS - 1 do
             local a = i * (2 * math.pi / SEARCH_HEADINGS)
             local cx = x + r * math.cos(a)
             local cy = y + r * math.sin(a)
-            if DEEP_WATER_SURFACES[surface_at(cx, cy)] and is_open_water(cx, cy) then
+            if DEEP_WATER_SURFACES[surface_at(cx, cy)]
+                and (not opts.require_open or is_open_water(cx, cy))
+            then
+                -- With no anchor to bias toward, take the first qualifying
+                -- candidate. Otherwise a positive min_anchor_dist keeps the
+                -- destination clear of the anchor (so escorts don't pile onto the
+                -- carrier), and among the rest the one nearest the anchor wins.
                 if not bias then
                     return { x = cx, y = cy }
                 end
                 local d = distance_sq(cx, cy, bias.x, bias.y)
-                if not best_d or d < best_d then
-                    best, best_d = { x = cx, y = cy }, d
+                if d >= min_d2 then
+                    if not best_d or d < best_d then
+                        best, best_d = { x = cx, y = cy }, d
+                    end
                 end
             end
         end
@@ -132,6 +158,48 @@ local function nearest_deep_water(x, y, bias)
         end
     end
     return nil
+end
+
+-- Pass presets for find_destination, loosest-last.
+local STRICT          = { require_open = true,  min_anchor_dist = 0 }
+local RELAXED_GATED   = { require_open = false, min_anchor_dist = MIN_ANCHOR_DIST }
+local RELAXED_UNGATED = { require_open = false, min_anchor_dist = 0 }
+
+-- Find a water destination for a dry point. Tries the strict open-water search
+-- first (unchanged behaviour for open coasts), then a relaxed search that accepts
+-- any deep water but keeps MIN_ANCHOR_DIST off the nearest afloat ship, then a
+-- final relaxed search with no spacing gate so an abeam escort still gets afloat
+-- instead of stranded on land.
+-- Returns (point, fallback): fallback is nil for the strict pass, or the
+-- "gated" / "ungated" name of the relaxed pass that found the point. Returns
+-- (nil, nil) when no pass found water within SEARCH_MAX.
+local function find_destination(x, y, bias)
+    local p = find_water(x, y, bias, STRICT)
+    if p then
+        return p, nil
+    end
+    p = find_water(x, y, bias, RELAXED_GATED)
+    if p then
+        return p, "gated"
+    end
+    p = find_water(x, y, bias, RELAXED_UNGATED)
+    if p then
+        return p, "ungated"
+    end
+    return nil, nil
+end
+
+-- Move a dry point (a unit or a route waypoint -- anything with x/y) onto water
+-- in place, biased toward the nearest afloat anchor. Returns (moved, fallback):
+-- moved is false when no pass found water; fallback is nil for the strict pass or
+-- the "gated" / "ungated" name of the relaxed pass that produced the destination.
+local function relocate_point(p, anchors)
+    local bias = nearest_anchor(p.x, p.y, anchors)
+    local dest, fallback = find_destination(p.x, p.y, bias)
+    if dest then
+        p.x, p.y = dest.x, dest.y
+    end
+    return dest ~= nil, fallback
 end
 
 -- Entry point -----------------------------------------------------------------
@@ -165,11 +233,20 @@ local function run()
 
         for _, unit in ipairs(data.units) do
             if DRY_SURFACES[surface_at(unit.x, unit.y)] then
-                local bias = nearest_anchor(unit.x, unit.y, anchors)
-                local p = nearest_deep_water(unit.x, unit.y, bias)
-                if p then
-                    unit.x, unit.y = p.x, p.y
+                local moved, fallback = relocate_point(unit, anchors)
+                if moved then
                     changed = true
+                    if fallback then
+                        env.info(
+                            "land_relocate: "
+                                .. name
+                                .. " placed in nearest deep water via "
+                                .. fallback
+                                .. " fallback (no open-water site within "
+                                .. SEARCH_MAX
+                                .. "m)"
+                        )
+                    end
                 else
                     env.warning(
                         "land_relocate: no deep water within "
@@ -185,11 +262,18 @@ local function run()
         if data.route and data.route.points and data.route.points[1] then
             local pt = data.route.points[1]
             if DRY_SURFACES[surface_at(pt.x, pt.y)] then
-                local bias = nearest_anchor(pt.x, pt.y, anchors)
-                local p = nearest_deep_water(pt.x, pt.y, bias)
-                if p then
-                    pt.x, pt.y = p.x, p.y
+                local moved, fallback = relocate_point(pt, anchors)
+                if moved then
                     changed = true
+                    if fallback then
+                        env.info(
+                            "land_relocate: "
+                                .. name
+                                .. " spawn waypoint placed via "
+                                .. fallback
+                                .. " fallback"
+                        )
+                    end
                 end
             end
         end

--- a/resources/plugins/base/land_relocate.lua
+++ b/resources/plugins/base/land_relocate.lua
@@ -21,20 +21,35 @@
 -- beached ship is the waterline, which is often too shallow to float a hull, so
 -- skipping the shallow band lands ships in water deep enough to clear the coast.
 --
--- Direction bias: the nearest wet point can be an inland lake on the wrong side
--- of the ship. There is no runtime link from an escort to its carrier, but ships
+-- Open-water clearance: the nearest deep-water point to a beached ship is often a
+-- sliver -- a river or a tidal inlet -- that leaves the hull straddling land. A
+-- candidate is only accepted if deep water extends a full nautical mile out along
+-- eight spokes, sampled every 0.2 nm, so the destination is genuinely open sea.
+-- The check is heading-agnostic on purpose: a ship's spawn heading can point
+-- inland, and keying the clearance off it could reject every valid destination.
+--
+-- Direction bias: the nearest open-water point can still be on the wrong side of
+-- the ship. There is no runtime link from an escort to its carrier, but ships
 -- placed correctly sit in deep water, so we treat every already-afloat ship unit
--- as an anchor and, among the equidistant deep-water candidates on a search ring,
--- pick the one nearest the closest anchor. That pulls beached escorts toward the
--- carrier / open sea (and keeps a partially-beached group together) instead of
--- toward a random pond. With no afloat ship anywhere we fall back to plain
--- nearest-water.
+-- as an anchor and, among the equidistant candidates on a search ring, pick the
+-- one nearest the closest anchor. That pulls beached escorts toward the carrier /
+-- open sea (and keeps a partially-beached group together) instead of toward a
+-- lake behind them. With no afloat ship anywhere we fall back to plain nearest.
 
 -- Tunable constants -----------------------------------------------------------
-local RELOCATE_DELAY  = 1     -- seconds after start, so mist's group DB is ready
-local SEARCH_STEP     = 60    -- metres between expanding search rings
-local SEARCH_MAX      = 2000  -- metres; give up beyond this radius
-local SEARCH_HEADINGS = 8     -- sample points per ring (every 45 degrees)
+local NM = 1852  -- metres per nautical mile
+
+local RELOCATE_DELAY  = 1        -- seconds after start, so mist's group DB is ready
+local SEARCH_STEP     = 60       -- metres between expanding search rings
+local SEARCH_MAX      = 7 * NM   -- give up beyond ~7 nm. A carrier's outer escort
+                                 -- ring sits up to ~5.8 nm out (Carrier_Strike_
+                                 -- Group_8), so a landward escort can be that far
+                                 -- inland when the carrier hugs the shore; 7 nm
+                                 -- covers it plus the ~1 nm clearance margin
+local SEARCH_HEADINGS = 8        -- sample points per ring (every 45 degrees)
+
+local CLEAR_RADIUS = 1 * NM      -- destination must be open water this far out...
+local CLEAR_STEP   = 0.2 * NM    -- ...sampled every 0.2 nm along each spoke
 
 local DRY_SURFACES = {
     [land.SurfaceType.LAND] = true,
@@ -73,10 +88,28 @@ local function nearest_anchor(x, y, anchors)
     return best
 end
 
--- Expanding-ring spiral search for the nearest deep-water point. When a bias
+-- True only if deep water extends CLEAR_RADIUS out from (x, y) along every spoke,
+-- sampled every CLEAR_STEP. A spoke crossing a river bank or pond shore hits land
+-- and fails, so narrow slivers of water are rejected and a hull is never left
+-- straddling one.
+local function is_open_water(x, y)
+    for i = 0, SEARCH_HEADINGS - 1 do
+        local a = i * (2 * math.pi / SEARCH_HEADINGS)
+        local dx, dy = math.cos(a), math.sin(a)
+        -- +1 keeps the CLEAR_RADIUS endpoint in despite float drift.
+        for d = CLEAR_STEP, CLEAR_RADIUS + 1, CLEAR_STEP do
+            if not DEEP_WATER_SURFACES[surface_at(x + d * dx, y + d * dy)] then
+                return false
+            end
+        end
+    end
+    return true
+end
+
+-- Expanding-ring spiral search for the nearest open-water point. When a bias
 -- target is given, the equidistant candidates on a ring are resolved in favour
 -- of the one closest to the target (the carrier / open sea), not just the first.
--- Returns { x = ..., y = ... } or nil if no deep water within SEARCH_MAX.
+-- Returns { x = ..., y = ... } or nil if no open water within SEARCH_MAX.
 local function nearest_deep_water(x, y, bias)
     for r = SEARCH_STEP, SEARCH_MAX, SEARCH_STEP do
         local best, best_d
@@ -84,7 +117,7 @@ local function nearest_deep_water(x, y, bias)
             local a = i * (2 * math.pi / SEARCH_HEADINGS)
             local cx = x + r * math.cos(a)
             local cy = y + r * math.sin(a)
-            if DEEP_WATER_SURFACES[surface_at(cx, cy)] then
+            if DEEP_WATER_SURFACES[surface_at(cx, cy)] and is_open_water(cx, cy) then
                 if not bias then
                     return { x = cx, y = cy }
                 end

--- a/resources/plugins/base/land_relocate.lua
+++ b/resources/plugins/base/land_relocate.lua
@@ -1,0 +1,171 @@
+-- land_relocate.lua
+--
+-- Relocates ship units that spawn on land (LAND / ROAD / RUNWAY) to the nearest
+-- deep water at mission start, across all theaters. This is the naval mirror of
+-- water_relocate.lua: when a carrier sits close to shore its formation escorts
+-- can land on the coastline and end up stranded. Preserves each group's route,
+-- tasks, skill and -- critically -- its group and unit names, so DCS
+-- Retribution's kill/loss tracking and state.json parsing stay correct.
+--
+-- Part of the mandatory "base" plugin. Requires mist, which the plugin loads
+-- first (this script is registered after moose.lua in plugin.json).
+--
+-- Mechanism: a live unit cannot be cheaply teleported, so we read the original
+-- group definition with mist.getGroupData(), edit the x/y of beached units (and
+-- the spawn waypoint if it is dry), and re-add the group under the same name
+-- with mist.dynAdd(). coalition.addGroup with an existing name silently swaps
+-- the units (fires S_EVENT_BIRTH only), so none of the four loss/kill events
+-- Retribution tracks are emitted.
+--
+-- Destination is deep WATER only (not SHALLOW_WATER): the nearest wet point to a
+-- beached ship is the waterline, which is often too shallow to float a hull, so
+-- skipping the shallow band lands ships in water deep enough to clear the coast.
+--
+-- Direction bias: the nearest wet point can be an inland lake on the wrong side
+-- of the ship. There is no runtime link from an escort to its carrier, but ships
+-- placed correctly sit in deep water, so we treat every already-afloat ship unit
+-- as an anchor and, among the equidistant deep-water candidates on a search ring,
+-- pick the one nearest the closest anchor. That pulls beached escorts toward the
+-- carrier / open sea (and keeps a partially-beached group together) instead of
+-- toward a random pond. With no afloat ship anywhere we fall back to plain
+-- nearest-water.
+
+-- Tunable constants -----------------------------------------------------------
+local RELOCATE_DELAY  = 1     -- seconds after start, so mist's group DB is ready
+local SEARCH_STEP     = 60    -- metres between expanding search rings
+local SEARCH_MAX      = 2000  -- metres; give up beyond this radius
+local SEARCH_HEADINGS = 8     -- sample points per ring (every 45 degrees)
+
+local DRY_SURFACES = {
+    [land.SurfaceType.LAND] = true,
+    [land.SurfaceType.ROAD] = true,
+    [land.SurfaceType.RUNWAY] = true,
+}
+
+local DEEP_WATER_SURFACES = {
+    [land.SurfaceType.WATER] = true,
+}
+
+-- Helpers ---------------------------------------------------------------------
+
+-- DCS ground plane: getSurfaceType takes a 2D point { x = north, y = east }.
+-- Group/unit data and route points store these as .x and .y, so pass them
+-- straight through.
+local function surface_at(x, y)
+    return land.getSurfaceType({ x = x, y = y })
+end
+
+local function distance_sq(ax, ay, bx, by)
+    local dx, dy = ax - bx, ay - by
+    return dx * dx + dy * dy
+end
+
+-- Nearest afloat ship unit to (x, y), used as the bias target. Returns
+-- { x = ..., y = ... } or nil when no ship is currently in deep water.
+local function nearest_anchor(x, y, anchors)
+    local best, best_d
+    for _, a in ipairs(anchors) do
+        local d = distance_sq(x, y, a.x, a.y)
+        if not best_d or d < best_d then
+            best, best_d = a, d
+        end
+    end
+    return best
+end
+
+-- Expanding-ring spiral search for the nearest deep-water point. When a bias
+-- target is given, the equidistant candidates on a ring are resolved in favour
+-- of the one closest to the target (the carrier / open sea), not just the first.
+-- Returns { x = ..., y = ... } or nil if no deep water within SEARCH_MAX.
+local function nearest_deep_water(x, y, bias)
+    for r = SEARCH_STEP, SEARCH_MAX, SEARCH_STEP do
+        local best, best_d
+        for i = 0, SEARCH_HEADINGS - 1 do
+            local a = i * (2 * math.pi / SEARCH_HEADINGS)
+            local cx = x + r * math.cos(a)
+            local cy = y + r * math.sin(a)
+            if DEEP_WATER_SURFACES[surface_at(cx, cy)] then
+                if not bias then
+                    return { x = cx, y = cy }
+                end
+                local d = distance_sq(cx, cy, bias.x, bias.y)
+                if not best_d or d < best_d then
+                    best, best_d = { x = cx, y = cy }, d
+                end
+            end
+        end
+        if best then
+            return best
+        end
+    end
+    return nil
+end
+
+-- Entry point -----------------------------------------------------------------
+
+-- timer.scheduleFunction calls this with (argument, time); both are ignored.
+-- Returning nil (no number) means it runs exactly once.
+local function run()
+    -- Pass 1: gather every ship group's data and record the positions of units
+    -- already in deep water as bias anchors (the carrier and well-placed ships).
+    local ships = {}
+    local anchors = {}
+    for _, side in ipairs({ coalition.side.RED, coalition.side.BLUE }) do
+        for _, group in ipairs(coalition.getGroups(side, Group.Category.SHIP)) do
+            local name = group:getName()
+            local data = mist.getGroupData(name)
+            if data and data.units and #data.units > 0 then
+                ships[#ships + 1] = { name = name, data = data }
+                for _, unit in ipairs(data.units) do
+                    if DEEP_WATER_SURFACES[surface_at(unit.x, unit.y)] then
+                        anchors[#anchors + 1] = { x = unit.x, y = unit.y }
+                    end
+                end
+            end
+        end
+    end
+
+    -- Pass 2: relocate beached units toward the nearest anchor.
+    for _, ship in ipairs(ships) do
+        local name, data = ship.name, ship.data
+        local changed = false
+
+        for _, unit in ipairs(data.units) do
+            if DRY_SURFACES[surface_at(unit.x, unit.y)] then
+                local bias = nearest_anchor(unit.x, unit.y, anchors)
+                local p = nearest_deep_water(unit.x, unit.y, bias)
+                if p then
+                    unit.x, unit.y = p.x, p.y
+                    changed = true
+                else
+                    env.warning(
+                        "land_relocate: no deep water within "
+                            .. SEARCH_MAX
+                            .. "m for "
+                            .. name
+                    )
+                end
+            end
+        end
+
+        -- Keep the spawn waypoint (route point 1) on water too.
+        if data.route and data.route.points and data.route.points[1] then
+            local pt = data.route.points[1]
+            if DRY_SURFACES[surface_at(pt.x, pt.y)] then
+                local bias = nearest_anchor(pt.x, pt.y, anchors)
+                local p = nearest_deep_water(pt.x, pt.y, bias)
+                if p then
+                    pt.x, pt.y = p.x, p.y
+                    changed = true
+                end
+            end
+        end
+
+        if changed then
+            env.info("land_relocate: relocating " .. name)
+            mist.dynAdd(data)
+        end
+    end
+end
+
+timer.scheduleFunction(run, {}, timer.getTime() + RELOCATE_DELAY)

--- a/resources/plugins/base/plugin.json
+++ b/resources/plugins/base/plugin.json
@@ -19,6 +19,10 @@
         {
             "file": "moose.lua",
             "mnemonic": "moose"
+        },
+        {
+            "file": "water_relocate.lua",
+            "mnemonic": "water_relocate"
         }
     ],
     "configurationWorkOrders": []

--- a/resources/plugins/base/plugin.json
+++ b/resources/plugins/base/plugin.json
@@ -23,6 +23,10 @@
         {
             "file": "water_relocate.lua",
             "mnemonic": "water_relocate"
+        },
+        {
+            "file": "land_relocate.lua",
+            "mnemonic": "land_relocate"
         }
     ],
     "configurationWorkOrders": []

--- a/resources/plugins/base/water_relocate.lua
+++ b/resources/plugins/base/water_relocate.lua
@@ -1,0 +1,110 @@
+-- water_relocate.lua
+--
+-- Relocates ground units that spawn on water (WATER / SHALLOW_WATER) to the
+-- nearest land at mission start, across all theaters. Preserves each group's
+-- route, tasks, skill and -- critically -- its group and unit names, so DCS
+-- Retribution's kill/loss tracking and state.json parsing stay correct.
+--
+-- Part of the mandatory "base" plugin. Requires mist, which the plugin loads
+-- first (this script is registered after moose.lua in plugin.json).
+--
+-- Mechanism: a live unit cannot be cheaply teleported, so we read the original
+-- group definition with mist.getGroupData(), edit the x/y of wet units (and the
+-- spawn waypoint if it is wet), and re-add the group under the same name with
+-- mist.dynAdd(). coalition.addGroup with an existing name silently swaps the
+-- units (fires S_EVENT_BIRTH only), so none of the four loss/kill events
+-- Retribution tracks are emitted.
+
+-- Tunable constants -----------------------------------------------------------
+local RELOCATE_DELAY  = 1     -- seconds after start, so mist's group DB is ready
+local SEARCH_STEP     = 60    -- metres between expanding search rings
+local SEARCH_MAX      = 2000  -- metres; give up beyond this radius
+local SEARCH_HEADINGS = 8     -- sample points per ring (every 45 degrees)
+
+local WET_SURFACES = {
+    [land.SurfaceType.WATER] = true,
+    [land.SurfaceType.SHALLOW_WATER] = true,
+}
+
+local LAND_SURFACES = {
+    [land.SurfaceType.LAND] = true,
+    [land.SurfaceType.ROAD] = true,
+    [land.SurfaceType.RUNWAY] = true,
+}
+
+-- Helpers ---------------------------------------------------------------------
+
+-- DCS ground plane: getSurfaceType takes a 2D point { x = north, y = east }.
+-- Group/unit data and route points store these as .x and .y, so pass them
+-- straight through.
+local function surface_at(x, y)
+    return land.getSurfaceType({ x = x, y = y })
+end
+
+-- Expanding-ring spiral search for the nearest land point.
+-- Returns { x = ..., y = ... } or nil if no land within SEARCH_MAX.
+local function nearest_land(x, y)
+    for r = SEARCH_STEP, SEARCH_MAX, SEARCH_STEP do
+        for i = 0, SEARCH_HEADINGS - 1 do
+            local a = i * (2 * math.pi / SEARCH_HEADINGS)
+            local cx = x + r * math.cos(a)
+            local cy = y + r * math.sin(a)
+            if LAND_SURFACES[surface_at(cx, cy)] then
+                return { x = cx, y = cy }
+            end
+        end
+    end
+    return nil
+end
+
+-- Entry point -----------------------------------------------------------------
+
+-- timer.scheduleFunction calls this with (argument, time); both are ignored.
+-- Returning nil (no number) means it runs exactly once.
+local function run()
+    for _, side in ipairs({ coalition.side.RED, coalition.side.BLUE }) do
+        for _, group in ipairs(coalition.getGroups(side, Group.Category.GROUND)) do
+            local name = group:getName()
+            local data = mist.getGroupData(name)
+            if data and data.units and #data.units > 0 then
+                local changed = false
+
+                for _, unit in ipairs(data.units) do
+                    if WET_SURFACES[surface_at(unit.x, unit.y)] then
+                        local p = nearest_land(unit.x, unit.y)
+                        if p then
+                            unit.x, unit.y = p.x, p.y
+                            changed = true
+                        else
+                            env.warning(
+                                "water_relocate: no land within "
+                                    .. SEARCH_MAX
+                                    .. "m for "
+                                    .. name
+                            )
+                        end
+                    end
+                end
+
+                -- Keep the spawn waypoint (route point 1) on land too.
+                if data.route and data.route.points and data.route.points[1] then
+                    local pt = data.route.points[1]
+                    if WET_SURFACES[surface_at(pt.x, pt.y)] then
+                        local p = nearest_land(pt.x, pt.y)
+                        if p then
+                            pt.x, pt.y = p.x, p.y
+                            changed = true
+                        end
+                    end
+                end
+
+                if changed then
+                    env.info("water_relocate: relocating " .. name)
+                    mist.dynAdd(data)
+                end
+            end
+        end
+    end
+end
+
+timer.scheduleFunction(run, {}, timer.getTime() + RELOCATE_DELAY)

--- a/scripts/gen_land_relocate_test_mission.py
+++ b/scripts/gen_land_relocate_test_mission.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+"""Build a standalone DCS test mission for land_relocate.lua.
+
+Generates a self-contained Caucasus .miz that reproduces the "carrier hugs the
+shore, escorts spawn on land" case the naval relocation handles, wired up exactly
+like Retribution wires the base plugin: mist loads first, then land_relocate.lua,
+then a small diagnostic script that logs every ship's surface type and position.
+
+Run from the repo root:
+
+    .venv/bin/python scripts/gen_land_relocate_test_mission.py
+
+The .miz is written under docs/superpowers/land_relocate_validation/ (git-excluded).
+Copy it to your DCS Missions folder, fly it, and grep dcs.log for "RELOCATE_TEST"
+and "land_relocate".
+
+The mission is self-diagnostic so you do not have to trust the coordinates below:
+the diagnostic logs the actual surface under each ship at +0.5s and +6s. The
+escorts spawn ~1 nm inland of the coast, so they are guaranteed to start on land
+and exercise the relocation. If the diagnostic shows the carrier started on land
+too, nudge CARRIER_POS until it reports WATER so it can act as the bias anchor.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dcs import Mission
+from dcs.action import DoScript, DoScriptFile
+from dcs.mapping import Point
+from dcs.ships import CVN_73, USS_Arleigh_Burke_IIa
+from dcs.translation import String
+from dcs.triggers import TriggerStart
+
+# --- Geometry (Caucasus, metres; x = north, y = east) ------------------------
+# Beached escorts ~1 nm inland of the Black Sea coast SW of Kobuleti. This is the
+# Kobuleti airfield ramp (-317962, 635633) shifted 4 nm along bearing 255 deg
+# (the direction of the water), which acceptance testing showed leaves them ~1 nm
+# from the shoreline and within the relocation search radius.
+ESCORT_ORIGIN = Point(-319879, 628477, None)  # type: ignore[arg-type]
+ESCORT_SPACING = 250  # metres between the four beached escorts
+# Carrier afloat, a further ~3 nm out along the same bearing (well past the
+# shoreline). Adjust if the diagnostic reports the carrier started on land.
+CARRIER_POS = Point(-321317, 623111, None)  # type: ignore[arg-type]
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_DIR = REPO_ROOT / "resources" / "plugins" / "base"
+OUT_DIR = REPO_ROOT / "docs" / "superpowers" / "land_relocate_validation"
+OUT_MIZ = OUT_DIR / "land_relocate_test.miz"
+
+# Diagnostic: log each ship group's surface type + position, before and after the
+# relocate pass (which runs at +1s). Greppable with "RELOCATE_TEST".
+DIAGNOSTIC_LUA = """
+local SURFACE_NAMES = {
+    [land.SurfaceType.LAND] = "LAND",
+    [land.SurfaceType.SHALLOW_WATER] = "SHALLOW_WATER",
+    [land.SurfaceType.WATER] = "WATER",
+    [land.SurfaceType.ROAD] = "ROAD",
+    [land.SurfaceType.RUNWAY] = "RUNWAY",
+}
+
+local function report(label)
+    for _, side in ipairs({ coalition.side.RED, coalition.side.BLUE }) do
+        for _, group in ipairs(coalition.getGroups(side, Group.Category.SHIP)) do
+            for _, unit in ipairs(group:getUnits()) do
+                local p = unit:getPoint()
+                local surface = land.getSurfaceType({ x = p.x, y = p.z })
+                env.info(string.format(
+                    "RELOCATE_TEST [%s] %s: %s at x=%.0f z=%.0f",
+                    label, unit:getName(), SURFACE_NAMES[surface] or "?", p.x, p.z))
+            end
+        end
+    end
+end
+
+-- Before the relocate pass (it is scheduled at +1s) and well after it.
+timer.scheduleFunction(function() report("BEFORE") end, {}, timer.getTime() + 0.5)
+timer.scheduleFunction(function() report("AFTER") end, {}, timer.getTime() + 6)
+"""
+
+
+def _load_script_file(mission: Mission, filename: str, comment: str) -> None:
+    path = (PLUGIN_DIR / filename).resolve()
+    if not path.exists():
+        raise FileNotFoundError(path)
+    fileref = mission.map_resource.add_resource_file(str(path))
+    trigger = TriggerStart(comment=comment)
+    trigger.add_action(DoScriptFile(fileref))
+    mission.triggerrules.triggers.append(trigger)
+
+
+def main() -> None:
+    mission = Mission()  # defaults to Caucasus
+    usa = mission.country("USA")
+    terrain = mission.terrain
+
+    # Carrier afloat offshore — the deep-water bias anchor.
+    mission.ship_group(
+        usa,
+        "Carrier",
+        CVN_73,
+        Point(CARRIER_POS.x, CARRIER_POS.y, terrain),
+        heading=90,
+    )
+
+    # Four escorts ~1 nm inland — guaranteed to start on land.
+    escorts = mission.ship_group(
+        usa,
+        "Escorts",
+        USS_Arleigh_Burke_IIa,
+        Point(ESCORT_ORIGIN.x, ESCORT_ORIGIN.y, terrain),
+        heading=90,
+        group_size=1,
+    )
+    for i in range(1, 4):
+        unit = mission.ship(f"Escort-{i + 1}", USS_Arleigh_Burke_IIa)
+        unit.position = Point(
+            ESCORT_ORIGIN.x + i * ESCORT_SPACING, ESCORT_ORIGIN.y, terrain
+        )
+        unit.heading = 90
+        escorts.add_unit(unit)
+
+    # Wire up the plugin scripts in the same order the base plugin does.
+    _load_script_file(mission, "mist_4_5_126.lua", "Load mist")
+    _load_script_file(mission, "land_relocate.lua", "Load land_relocate")
+
+    diagnostic = TriggerStart(comment="Load relocate diagnostic")
+    diagnostic.add_action(DoScript(String(DIAGNOSTIC_LUA)))
+    mission.triggerrules.triggers.append(diagnostic)
+
+    mission.set_description_text(
+        "land_relocate.lua validation: four Arleigh Burke escorts spawn ~1 nm "
+        "inland SW of Kobuleti next to a CVN-73 offshore. At mission start they "
+        "should relocate into deep water, biased toward the carrier. Check dcs.log "
+        "for 'RELOCATE_TEST' and 'land_relocate' lines."
+    )
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    mission.save(str(OUT_MIZ))
+    print(f"wrote {OUT_MIZ}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/missiongenerator/land_relocate_test.lua
+++ b/tests/missiongenerator/land_relocate_test.lua
@@ -1,0 +1,266 @@
+-- land_relocate_test.lua
+--
+-- Standalone unit test for resources/plugins/base/land_relocate.lua under a
+-- mocked DCS/mist environment. Not run by CI (CI has no Lua); run locally with:
+--
+--   lua    tests/missiongenerator/land_relocate_test.lua
+--   luajit tests/missiongenerator/land_relocate_test.lua
+--
+-- Mirrors the in-DCS acceptance scenarios for the naval relocation mirror of
+-- water_relocate.lua: beached ships move to deep water, ships already afloat are
+-- untouched, the shallow waterline is skipped in favour of deep water, ships
+-- with no reachable deep water are left in place + warned, and group/unit names
+-- survive the dynAdd round-trip.
+
+local SCRIPT = "resources/plugins/base/land_relocate.lua"
+
+-- Surface type constants (values are arbitrary; only identity matters).
+local SURF = { LAND = 1, ROAD = 2, RUNWAY = 3, WATER = 4, SHALLOW_WATER = 5 }
+
+-- Test state, reset by each scenario via setup().
+local surface_fn   -- function(x, y) -> SURF.*
+local groups       -- list of ship groups for coalition.side.BLUE
+local dynadd_calls -- list of data tables passed to mist.dynAdd
+local warnings     -- list of env.warning strings
+local scheduled    -- the function handed to timer.scheduleFunction
+
+-- Install the mocked DCS/mist globals the script closes over.
+local function setup()
+    surface_fn = function()
+        return SURF.LAND
+    end
+    groups = {}
+    dynadd_calls = {}
+    warnings = {}
+    scheduled = nil
+
+    land = {
+        SurfaceType = SURF,
+        getSurfaceType = function(point)
+            return surface_fn(point.x, point.y)
+        end,
+    }
+
+    coalition = {
+        side = { RED = "red", BLUE = "blue" },
+        getGroups = function(side, _category)
+            if side == "blue" then
+                return groups
+            end
+            return {}
+        end,
+    }
+
+    Group = { Category = { SHIP = "ship" } }
+
+    mist = {
+        getGroupData = function(name)
+            for _, g in ipairs(groups) do
+                if g.name == name then
+                    return g.data
+                end
+            end
+            return nil
+        end,
+        dynAdd = function(data)
+            dynadd_calls[#dynadd_calls + 1] = data
+        end,
+    }
+
+    env = {
+        info = function() end,
+        warning = function(msg)
+            warnings[#warnings + 1] = msg
+        end,
+    }
+
+    timer = {
+        getTime = function()
+            return 0
+        end,
+        scheduleFunction = function(fn)
+            scheduled = fn
+        end,
+    }
+end
+
+-- Register a ship group. The entry doubles as the DCS group object (getName)
+-- and the carrier of its mist group data.
+local function add_group(name, data)
+    groups[#groups + 1] = {
+        name = name,
+        data = data,
+        getName = function(self)
+            return self.name
+        end,
+    }
+end
+
+-- Register a single-unit ship group named `name` at (x, y).
+local function add_ship(name, x, y)
+    add_group(name, {
+        name = name,
+        units = { { unitName = name .. "-1", x = x, y = y } },
+    })
+end
+
+-- Load and run the script once against the current mocks.
+local function run_script()
+    assert(loadfile(SCRIPT))()
+    assert(scheduled, "script never scheduled its run function")
+    scheduled(nil, 0)
+end
+
+local function ship(name)
+    for _, g in ipairs(groups) do
+        if g.name == name then
+            return g.data.units[1]
+        end
+    end
+    error("no ship named " .. name)
+end
+
+-- Assertions ------------------------------------------------------------------
+
+local passed = 0
+local function check(cond, label)
+    if not cond then
+        error("FAIL: " .. label, 2)
+    end
+    passed = passed + 1
+end
+
+-- Scenarios -------------------------------------------------------------------
+
+-- A beached ship relocates to the nearest deep water and is re-added.
+local function test_beached_ship_relocates()
+    setup()
+    -- Land for x < 500, deep water beyond.
+    surface_fn = function(x)
+        if x >= 500 then
+            return SURF.WATER
+        end
+        return SURF.LAND
+    end
+    add_ship("escort", 0, 0)
+
+    run_script()
+
+    check(ship("escort").x >= 500, "beached ship moved into water")
+    check(surface_fn(ship("escort").x) == SURF.WATER, "destination is deep water")
+    check(#dynadd_calls == 1, "dynAdd called once for the moved group")
+    check(dynadd_calls[1].name == "escort", "group name preserved on dynAdd")
+    check(#warnings == 0, "no warning when deep water is reachable")
+end
+
+-- A ship already floating in deep water is left untouched.
+local function test_floating_ship_untouched()
+    setup()
+    surface_fn = function()
+        return SURF.WATER
+    end
+    add_ship("carrier", 1000, 0)
+
+    run_script()
+
+    check(ship("carrier").x == 1000, "floating ship not moved")
+    check(#dynadd_calls == 0, "no dynAdd for an unchanged group")
+end
+
+-- The shallow waterline is skipped; the ship lands in deep water past it.
+local function test_shallow_waterline_skipped()
+    setup()
+    -- Land < 500, a 60 m shallow band, deep water beyond 560.
+    surface_fn = function(x)
+        if x >= 560 then
+            return SURF.WATER
+        elseif x >= 500 then
+            return SURF.SHALLOW_WATER
+        end
+        return SURF.LAND
+    end
+    add_ship("escort", 0, 0)
+
+    run_script()
+
+    check(surface_fn(ship("escort").x) == SURF.WATER, "skipped shallow, landed in deep water")
+    check(ship("escort").x >= 560, "moved past the shallow band")
+end
+
+-- No deep water within range: leave in place and warn, no dynAdd.
+local function test_no_water_warns_and_skips()
+    setup()
+    surface_fn = function()
+        return SURF.LAND
+    end
+    add_ship("stranded", 0, 0)
+
+    run_script()
+
+    check(ship("stranded").x == 0, "ship left in place when no deep water found")
+    check(#dynadd_calls == 0, "no dynAdd when nothing changed")
+    check(#warnings == 1, "warned about unreachable deep water")
+end
+
+-- A dry spawn waypoint is moved onto deep water too.
+local function test_spawn_waypoint_relocated()
+    setup()
+    surface_fn = function(x)
+        if x >= 500 then
+            return SURF.WATER
+        end
+        return SURF.LAND
+    end
+    add_group("escort", {
+        name = "escort",
+        -- Unit already afloat, but the spawn waypoint is on land.
+        units = { { unitName = "escort-1", x = 1000, y = 0 } },
+        route = { points = { { x = 0, y = 0 } } },
+    })
+
+    run_script()
+
+    check(groups[1].data.route.points[1].x >= 500, "dry spawn waypoint moved to water")
+    check(#dynadd_calls == 1, "dynAdd called for waypoint-only change")
+end
+
+-- With deep water on both sides, a beached escort is pulled toward the side an
+-- afloat ship (the carrier) sits on, not the first ring candidate.
+local function test_relocation_biased_toward_carrier()
+    setup()
+    -- Land in the middle; deep water both east (x >= 500) and west (x <= -500).
+    surface_fn = function(x)
+        if x >= 500 or x <= -500 then
+            return SURF.WATER
+        end
+        return SURF.LAND
+    end
+    -- Carrier afloat to the west; escort beached at the origin.
+    add_ship("carrier", -1000, 0)
+    add_ship("escort", 0, 0)
+
+    run_script()
+
+    check(ship("escort").x < 0, "beached escort pulled west toward the carrier")
+    check(surface_fn(ship("escort").x) == SURF.WATER, "destination is deep water")
+    check(ship("carrier").x == -1000, "afloat carrier left untouched")
+    check(#dynadd_calls == 1, "only the beached escort is re-added")
+    check(dynadd_calls[1].name == "escort", "the re-added group is the escort")
+end
+
+-- Driver ----------------------------------------------------------------------
+
+local tests = {
+    test_beached_ship_relocates,
+    test_floating_ship_untouched,
+    test_shallow_waterline_skipped,
+    test_no_water_warns_and_skips,
+    test_spawn_waypoint_relocated,
+    test_relocation_biased_toward_carrier,
+}
+
+for _, t in ipairs(tests) do
+    t()
+end
+
+print(string.format("ok - %d assertions across %d scenarios", passed, #tests))

--- a/tests/missiongenerator/land_relocate_test.lua
+++ b/tests/missiongenerator/land_relocate_test.lua
@@ -248,6 +248,29 @@ local function test_relocation_biased_toward_carrier()
     check(dynadd_calls[1].name == "escort", "the re-added group is the escort")
 end
 
+-- A narrow river nearer than the open sea is rejected; the ship skips past it to
+-- water with a full nautical mile of clearance instead of straddling the sliver.
+local function test_narrow_river_rejected()
+    setup()
+    -- A 60 m wide river band at 500 <= y <= 560, and the open sea at y >= 3000;
+    -- everything else is land.
+    surface_fn = function(_x, y)
+        if y >= 3000 then
+            return SURF.WATER
+        elseif y >= 500 and y <= 560 then
+            return SURF.WATER
+        end
+        return SURF.LAND
+    end
+    add_ship("escort", 0, 0)
+
+    run_script()
+
+    check(ship("escort").y > 560, "ship did not settle in the narrow river")
+    check(ship("escort").y >= 3000, "ship relocated to the open sea")
+    check(#dynadd_calls == 1, "the beached escort was re-added once")
+end
+
 -- Driver ----------------------------------------------------------------------
 
 local tests = {
@@ -257,6 +280,7 @@ local tests = {
     test_no_water_warns_and_skips,
     test_spawn_waypoint_relocated,
     test_relocation_biased_toward_carrier,
+    test_narrow_river_rejected,
 }
 
 for _, t in ipairs(tests) do

--- a/tests/missiongenerator/land_relocate_test.lua
+++ b/tests/missiongenerator/land_relocate_test.lua
@@ -271,6 +271,114 @@ local function test_narrow_river_rejected()
     check(#dynadd_calls == 1, "the beached escort was re-added once")
 end
 
+-- NARROW CHANNEL, ESCORT UP THE BANK (relaxed gated pass).
+-- A 200 m vertical water strip (|x| <= 100) flanked by land; carrier afloat in
+-- the strip; escort beached on the bank, well north of the carrier. Strict fails
+-- (the strip is too narrow for is_open_water); the gated relaxed pass moves the
+-- escort into the strip at a point >= 0.5 nm from the carrier.
+local function test_narrow_channel_escort_up_bank()
+    setup()
+    surface_fn = function(x)
+        if x >= -100 and x <= 100 then
+            return SURF.WATER
+        end
+        return SURF.LAND
+    end
+    add_ship("carrier", 0, 0)
+    add_ship("escort", 500, 2000)
+
+    run_script()
+
+    local e = ship("escort")
+    check(math.abs(e.x) <= 100, "escort moved into the channel strip")
+    local dx, dy = e.x - 0, e.y - 0
+    check(math.sqrt(dx * dx + dy * dy) >= 0.5 * 1852, "destination >= 0.5 nm from carrier")
+    check(ship("carrier").x == 0 and ship("carrier").y == 0, "carrier untouched")
+    check(#warnings == 0, "no warning when fallback relocates the escort")
+end
+
+-- ESCORT ABEAM CARRIER (relaxed ungated pass; soft gate).
+-- Same strip, but the escort is beached directly abeam the carrier, so every
+-- reachable strip point is < 0.5 nm from the carrier. The gated pass therefore
+-- finds nothing; the ungated pass still gets the escort afloat (afloat beats
+-- beached) at the nearest strip point, even though it is within 0.5 nm.
+local function test_escort_abeam_carrier_soft_gate()
+    setup()
+    surface_fn = function(x)
+        if x >= -100 and x <= 100 then
+            return SURF.WATER
+        end
+        return SURF.LAND
+    end
+    add_ship("carrier", 0, 0)
+    add_ship("escort", 500, 0)
+
+    run_script()
+
+    local e = ship("escort")
+    check(math.abs(e.x) <= 100, "escort relocated into the strip via ungated pass")
+    local dx, dy = e.x - 0, e.y - 0
+    check(math.sqrt(dx * dx + dy * dy) < 0.5 * 1852, "destination is the close water (gate bypassed)")
+    check(#dynadd_calls == 1, "escort re-added")
+    check(#warnings == 0, "escort got afloat, so no warning")
+end
+
+-- CLOSED POND NEARER THAN THE CHANNEL (documented limitation).
+-- A small near pond (200 <= x <= 400) and a far channel (x >= 5000) with the
+-- carrier afloat in it; both too narrow for is_open_water. The relaxed pass takes
+-- the NEAREST water -- the near pond -- even though carrier bias points at the far
+-- channel. Pins that relaxed has no sea-connectivity check.
+local function test_closed_pond_nearer_wins()
+    setup()
+    surface_fn = function(x)
+        if x >= 200 and x <= 400 then
+            return SURF.WATER   -- near pond
+        elseif x >= 5000 and x <= 5100 then
+            return SURF.WATER   -- far channel
+        end
+        return SURF.LAND
+    end
+    add_ship("carrier", 5050, 0)
+    add_ship("escort", 0, 0)
+
+    run_script()
+
+    local e = ship("escort")
+    check(e.x >= 200 and e.x <= 400, "escort settled in the nearer pond, not the far channel")
+    check(ship("carrier").x == 5050, "carrier untouched")
+    check(#dynadd_calls == 1, "only the escort is re-added")
+end
+
+-- THE SPACING GATE ACTUALLY PUSHES AN ESCORT CLEAR OF THE CARRIER (gated != ungated).
+-- The escort's NEAREST water is a small pond hugging the carrier (every point of it
+-- < 0.5 nm away); a separate open-water strip sits farther east, >= 0.5 nm away.
+-- Strict fails (both bodies are too narrow for is_open_water). The gated pass rejects
+-- the near pond and lands the escort in the far strip; the ungated pass alone would
+-- take the near pond. Asserting the far strip pins the gate: delete the gated pass,
+-- or shrink MIN_ANCHOR_DIST below the pond's reach, and the escort lands in the pond.
+local function test_gated_pass_pushes_clear_of_carrier()
+    setup()
+    surface_fn = function(x, y)
+        if x >= -100 and x <= 100 and y >= -100 and y <= 100 then
+            return SURF.WATER   -- pond hugging the carrier (all of it < 0.5 nm away)
+        elseif x >= 2000 and x <= 2100 then
+            return SURF.WATER   -- far strip, >= 0.5 nm from the carrier
+        end
+        return SURF.LAND
+    end
+    add_ship("carrier", 0, 0)
+    add_ship("escort", 500, 0)
+
+    run_script()
+
+    local e = ship("escort")
+    check(e.x >= 2000, "gate pushed escort to the far strip, past the near pond")
+    local dx, dy = e.x - 0, e.y - 0
+    check(math.sqrt(dx * dx + dy * dy) >= 0.5 * 1852, "destination >= 0.5 nm from carrier")
+    check(ship("carrier").x == 0 and ship("carrier").y == 0, "carrier untouched")
+    check(#dynadd_calls == 1, "only the escort is re-added")
+end
+
 -- Driver ----------------------------------------------------------------------
 
 local tests = {
@@ -281,6 +389,10 @@ local tests = {
     test_spawn_waypoint_relocated,
     test_relocation_biased_toward_carrier,
     test_narrow_river_rejected,
+    test_narrow_channel_escort_up_bank,
+    test_escort_abeam_carrier_soft_gate,
+    test_closed_pond_nearer_wins,
+    test_gated_pass_pushes_clear_of_carrier,
 }
 
 for _, t in ipairs(tests) do

--- a/tests/missiongenerator/test_land_relocate_plugin.py
+++ b/tests/missiongenerator/test_land_relocate_plugin.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import cast
+
+from dcs import Mission
+from dcs.action import DoScriptFile
+from dcs.triggers import TriggerStart
+
+from game import Game
+from game.missiongenerator.luagenerator import LuaGenerator
+from game.missiongenerator.missiondata import MissionData
+from game.plugins import LuaPluginManager
+
+
+def _base_work_order_files() -> list[str]:
+    base = next(
+        p for p in LuaPluginManager.plugins() if p.definition.identifier == "base"
+    )
+    return [work_order.filename for work_order in base.definition.work_orders]
+
+
+def test_land_relocate_registered_in_base_plugin() -> None:
+    assert "land_relocate.lua" in _base_work_order_files()
+
+
+def test_land_relocate_loaded_after_mist() -> None:
+    files = _base_work_order_files()
+    assert files.index("land_relocate.lua") > files.index("mist_4_5_126.lua")
+
+
+def test_land_relocate_injected_as_doscriptfile() -> None:
+    mission = Mission()
+    # inject_plugins only touches self.mission and self.plugin_scripts, so the
+    # game and mission_data arguments are unused here.
+    generator = LuaGenerator(cast(Game, None), mission, cast(MissionData, None))
+
+    generator.inject_plugins()
+
+    assert "land_relocate" in generator.plugin_scripts
+    load_triggers = [
+        trigger
+        for trigger in mission.triggerrules.triggers
+        if isinstance(trigger, TriggerStart) and trigger.comment == "Load land_relocate"
+    ]
+    assert len(load_triggers) == 1
+    assert any(isinstance(action, DoScriptFile) for action in load_triggers[0].actions)

--- a/tests/missiongenerator/test_water_relocate_plugin.py
+++ b/tests/missiongenerator/test_water_relocate_plugin.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import cast
+
+from dcs import Mission
+from dcs.action import DoScriptFile
+from dcs.triggers import TriggerStart
+
+from game import Game
+from game.missiongenerator.luagenerator import LuaGenerator
+from game.missiongenerator.missiondata import MissionData
+from game.plugins import LuaPluginManager
+
+
+def _base_work_order_files() -> list[str]:
+    base = next(
+        p for p in LuaPluginManager.plugins() if p.definition.identifier == "base"
+    )
+    return [work_order.filename for work_order in base.definition.work_orders]
+
+
+def test_water_relocate_registered_in_base_plugin() -> None:
+    assert "water_relocate.lua" in _base_work_order_files()
+
+
+def test_water_relocate_loaded_after_mist() -> None:
+    files = _base_work_order_files()
+    assert files.index("water_relocate.lua") > files.index("mist_4_5_126.lua")
+
+
+def test_water_relocate_injected_as_doscriptfile() -> None:
+    mission = Mission()
+    # inject_plugins only touches self.mission and self.plugin_scripts, so the
+    # game and mission_data arguments are unused here.
+    generator = LuaGenerator(cast(Game, None), mission, cast(MissionData, None))
+
+    generator.inject_plugins()
+
+    assert "water_relocate" in generator.plugin_scripts
+    load_triggers = [
+        trigger
+        for trigger in mission.triggerrules.triggers
+        if isinstance(trigger, TriggerStart)
+        and trigger.comment == "Load water_relocate"
+    ]
+    assert len(load_triggers) == 1
+    assert any(isinstance(action, DoScriptFile) for action in load_triggers[0].actions)


### PR DESCRIPTION
## Relocate ground units that spawn on water (#59)

### Problem
Ground units sometimes spawn on water — inland lakes/rivers or right at the
coastline — leaving them stranded or sunk and effectively dead on arrival.

### Fix
A small runtime Lua "nudge" in the mandatory **base** plugin
(`resources/plugins/base/water_relocate.lua`). At mission start it finds ground
units sitting on `WATER`/`SHALLOW_WATER` and respawns each affected group on the
nearest land (expanding-ring search, ≤ 2000 m), preserving the group's name,
units, route, tasks and skill.

- **Theater-agnostic** — keys off DCS's runtime `land.getSurfaceType`, not
  Retribution's landmap.
- **Loss-safe** — re-adds the group under the same name via
  `mist.getGroupData` + `mist.dynAdd`; `coalition.addGroup` with an existing
  name fires `S_EVENT_BIRTH` only, so none of the kill/loss events Retribution
  tracks are emitted.
- Registered last in `plugin.json` (after mist, which it requires).
- Units with no land within 2000 m are left in place with a warning.

### Testing
- **Automated (CI):** new `tests/missiongenerator/test_water_relocate_plugin.py`
  (registration, load-order-after-mist, DoScriptFile injection). All gates green
  — `black`, `mypy game`, `mypy tests`, `pytest`. A standalone Lua unit test of
  the real script under a mocked DCS/mist env also passes under both `lua` and
  `luajit`.
- **In-DCS acceptance (Caucasus):**
  - *Open water (Black Sea):* wet units relocate to shore; a far-offshore unit
    (>2 km from land) is correctly left in place + warned; on-land units
    untouched.
  - *Inland (Tbilisi Sea reservoir):* units spawned on the lake relocate to the
    shoreline; on-land units untouched.
  - *Loss-safety:* every relocated, un-engaged unit is alive at mission end —
    `dcs.log` shows the expected `relocating …` lines, and the debrief shows
    no spurious losses (no deaths, no graveyard entries).

Fixes #59.