### PR TITLE
Cancel the selected package with the Delete key

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Features/Improvements
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
+* **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.
 * **[UX]** Avoid having escorts from wondering off too far while chasing a target.
 * **[UX]** Improved fast-forward settings with the ability to skip combat.
 * **[Data]** Add Refueling/Recovery tasks to A-6E Intruder mod

--- a/qt_ui/widgets/ato.py
+++ b/qt_ui/widgets/ato.py
@@ -13,6 +13,7 @@ from PySide6.QtCore import (
 from PySide6.QtGui import (
     QContextMenuEvent,
     QAction,
+    QKeyEvent,
 )
 from PySide6.QtWidgets import (
     QAbstractItemView,
@@ -379,6 +380,25 @@ class QPackageList(QListView):
         menu.addAction(delete_action)
 
         menu.exec_(event.globalPos())
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        # Delete/Supr cancels (deletes) the selected package, so several can be
+        # cleared in a row without reaching for the context menu each time.
+        if event.key() == Qt.Key.Key_Delete:
+            index = self.currentIndex()
+            if index.isValid():
+                row = index.row()
+                self.delete_package(index)
+                # Keep a package selected so repeated Delete clears consecutive
+                # packages: the same row now holds the next one (clamped to the
+                # new last row). If the package wasn't removed (its flights were
+                # only aborted, not cancelled), this re-selects it harmlessly.
+                remaining = self.model().rowCount()
+                if remaining:
+                    self.setCurrentIndex(self.model().index(min(row, remaining - 1), 0))
+                event.accept()
+                return
+        super().keyPressEvent(event)
 
 
 class QPackagePanel(QGroupBox):


### PR DESCRIPTION
Pressing **Delete** (Supr) with a package selected in the Packages list now cancels it — the same action as the context-menu "Delete" — instead of doing nothing. After deletion the next package is selected, so several packages can be cleared in a row.

