### PR TITLE
Enhance tactical map in retribution UI to reflect AI flight actions 

### DIFF
--- a/client/src/api/_liberationApi.ts
+++ b/client/src/api/_liberationApi.ts
@@ -70,12 +70,12 @@ const injectedRtkApi = api.injectEndpoints({
         params: { with_waypoints: queryArg.withWaypoints },
       }),
     }),
-    getCommitBoundaryForFlight: build.query<
-      GetCommitBoundaryForFlightApiResponse,
-      GetCommitBoundaryForFlightApiArg
+    getTacticalOverlayForFlight: build.query<
+      GetTacticalOverlayForFlightApiResponse,
+      GetTacticalOverlayForFlightApiArg
     >({
       query: (queryArg) => ({
-        url: `/flights/${queryArg.flightId}/commit-boundary`,
+        url: `/flights/${queryArg.flightId}/tactical-overlay`,
       }),
     }),
     listFrontLines: build.query<
@@ -262,9 +262,9 @@ export type GetFlightByIdApiArg = {
   flightId: string;
   withWaypoints?: boolean;
 };
-export type GetCommitBoundaryForFlightApiResponse =
-  /** status 200 Successful Response */ LatLng[][];
-export type GetCommitBoundaryForFlightApiArg = {
+export type GetTacticalOverlayForFlightApiResponse =
+  /** status 200 Successful Response */ TacticalOverlay;
+export type GetTacticalOverlayForFlightApiArg = {
   flightId: string;
 };
 export type ListFrontLinesApiResponse =
@@ -409,6 +409,18 @@ export type FrontLine = {
   id: string;
   extents: LatLng[];
 };
+export type TacticalReach = {
+  polygon: LatLng[][];
+  filled: boolean;
+};
+export type TacticalTarget = {
+  position: LatLng;
+};
+export type TacticalOverlay = {
+  reach: TacticalReach[];
+  actual_path?: LatLng[];
+  targets: TacticalTarget[];
+};
 export type Tgo = {
   id: string;
   name: string;
@@ -497,7 +509,7 @@ export const {
   useGetDebugJoinZonesQuery,
   useListFlightsQuery,
   useGetFlightByIdQuery,
-  useGetCommitBoundaryForFlightQuery,
+  useGetTacticalOverlayForFlightQuery,
   useListFrontLinesQuery,
   useGetFrontLineByIdQuery,
   useGetGameStateQuery,

--- a/client/src/api/liberationApi.ts
+++ b/client/src/api/liberationApi.ts
@@ -36,7 +36,7 @@ export const liberationApi = _liberationApi.enhanceEndpoints({
       ],
     },
     // /flights/
-    getCommitBoundaryForFlight: {
+    getTacticalOverlayForFlight: {
       providesTags: (result, error, arg) => [
         { type: Tags.FLIGHT_PLAN, id: arg.flightId },
       ],

--- a/client/src/components/flightplan/FlightPlan.tsx
+++ b/client/src/components/flightplan/FlightPlan.tsx
@@ -1,12 +1,12 @@
 import { Flight } from "../../api/liberationApi";
 import {
-  useGetCommitBoundaryForFlightQuery,
+  useGetTacticalOverlayForFlightQuery,
   useSelectFlightMutation,
 } from "../../api/liberationApi";
 import WaypointMarker from "../waypointmarker";
 import { Polyline as LPolyline } from "leaflet";
 import { ReactElement, useEffect, useRef } from "react";
-import { Polyline } from "react-leaflet";
+import { CircleMarker, Polygon, Polyline } from "react-leaflet";
 
 const BLUE_PATH = "#0084ff";
 const RED_PATH = "#c85050";
@@ -120,47 +120,75 @@ const WaypointMarkers = (props: FlightPlanProps) => {
   return <>{markers}</>;
 };
 
-interface CommitBoundaryProps {
-  flightId: string;
-  selected: boolean;
+const ENGAGEMENT = "#ffff00"; // unchanged: existing engagement-zone yellow
+const TARGET = "#ff5a5a"; // attack-target marker
+
+interface TacticalOverlayProps {
+  flight: Flight;
 }
 
-function CommitBoundary(props: CommitBoundaryProps) {
-  const { data, error, isLoading } = useGetCommitBoundaryForFlightQuery(
-    {
-      flightId: props.flightId,
-    },
-    // RTK Query doesn't seem to allow us to invalidate the cache from anything
-    // but a mutation, but this data can be invalidated by events from the
-    // websocket. Just disable the cache for this.
-    //
-    // This isn't perfect. It won't redraw until the component remounts. There
-    // doesn't appear to be a better way.
+function TacticalOverlayLayer(props: TacticalOverlayProps) {
+  const { data, error } = useGetTacticalOverlayForFlightQuery(
+    { flightId: props.flight.id },
+    // RTK Query can only invalidate caches from mutations, but this data is
+    // invalidated by websocket events. Disable the cache and refetch on
+    // (re)mount instead. It won't redraw until the component remounts; there
+    // doesn't appear to be a better hook.
     { refetchOnMountOrArgChange: true }
   );
-  if (isLoading) {
-    return <></>;
-  }
   if (error) {
-    console.error(`Error loading commit boundary for ${props.flightId}`, error);
-    return <></>;
-  }
-  if (!data) {
-    console.log(
-      `Null response data when loading commit boundary for ${props.flightId}`
+    console.error(
+      `Error loading tactical overlay for ${props.flight.id}`,
+      error
     );
     return <></>;
   }
+  if (!data) {
+    return <></>;
+  }
+  const teamColor = props.flight.blue ? BLUE_PATH : RED_PATH;
   return (
-    <Polyline positions={data} color="#ffff00" weight={1} interactive={false} />
+    <>
+      {data.reach.map((shape, idx) => (
+        <Polygon
+          key={`reach-${idx}`}
+          positions={shape.polygon}
+          pathOptions={
+            shape.filled
+              ? { color: ENGAGEMENT, weight: 1.5, fillOpacity: 0.15 }
+              : { color: ENGAGEMENT, weight: 1.5, fill: false }
+          }
+          interactive={false}
+        />
+      ))}
+      {data.actual_path && (
+        <Polyline
+          positions={data.actual_path}
+          pathOptions={{ color: teamColor }}
+          interactive={false}
+        />
+      )}
+      {data.targets.map((t, idx) => (
+        <CircleMarker
+          key={`tgt-${idx}`}
+          center={t.position}
+          radius={6}
+          pathOptions={{ color: TARGET, weight: 2, fill: false }}
+          interactive={false}
+        />
+      ))}
+    </>
   );
 }
 
-function CommitBoundaryIfSelected(props: CommitBoundaryProps) {
+function TacticalOverlayIfSelected(props: {
+  flight: Flight;
+  selected: boolean;
+}) {
   if (!props.selected) {
     return <></>;
   }
-  return <CommitBoundary {...props} />;
+  return <TacticalOverlayLayer flight={props.flight} />;
 }
 
 export default function FlightPlan(props: FlightPlanProps) {
@@ -168,8 +196,8 @@ export default function FlightPlan(props: FlightPlanProps) {
     <>
       <FlightPlanPath {...props} />
       <WaypointMarkers {...props} />
-      <CommitBoundaryIfSelected
-        flightId={props.flight.id}
+      <TacticalOverlayIfSelected
+        flight={props.flight}
         selected={props.selected}
       />
     </>

--- a/game/ato/flightplans/antiship.py
+++ b/game/ato/flightplans/antiship.py
@@ -10,14 +10,22 @@ from .formationattack import (
     FormationAttackLayout,
 )
 from .invalidobjectivelocation import InvalidObjectiveLocation
+from .tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay, attack_run_overlay
 from .waypointbuilder import StrikeTarget
 from ..flightwaypointtype import FlightWaypointType
 
 
-class AntiShipFlightPlan(FormationAttackFlightPlan):
+class AntiShipFlightPlan(FormationAttackFlightPlan, TacticalOverlayDisplay):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        return attack_run_overlay(
+            self.layout.ingress.position,
+            self.package.target.position,
+            self.layout.split.position,
+        )
 
 
 class Builder(FormationAttackBuilder[AntiShipFlightPlan, FormationAttackLayout]):

--- a/game/ato/flightplans/armedrecon.py
+++ b/game/ato/flightplans/armedrecon.py
@@ -7,12 +7,15 @@ from .formationattack import (
     FormationAttackFlightPlan,
     FormationAttackLayout,
 )
+from .tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay, attack_run_overlay
 from .uizonedisplay import UiZone, UiZoneDisplay
 from ..flightwaypointtype import FlightWaypointType
 from ...utils import nautical_miles
 
 
-class ArmedReconFlightPlan(FormationAttackFlightPlan, UiZoneDisplay):
+class ArmedReconFlightPlan(
+    FormationAttackFlightPlan, UiZoneDisplay, TacticalOverlayDisplay
+):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
@@ -23,6 +26,13 @@ class ArmedReconFlightPlan(FormationAttackFlightPlan, UiZoneDisplay):
             nautical_miles(
                 self.flight.coalition.game.settings.armed_recon_engagement_range_distance
             ),
+        )
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        return attack_run_overlay(
+            self.layout.ingress.position,
+            self.package.target.position,
+            self.layout.split.position,
         )
 
 

--- a/game/ato/flightplans/bai.py
+++ b/game/ato/flightplans/bai.py
@@ -9,14 +9,22 @@ from .formationattack import (
     FormationAttackLayout,
 )
 from .invalidobjectivelocation import InvalidObjectiveLocation
+from .tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay, attack_run_overlay
 from .waypointbuilder import StrikeTarget
 from ..flightwaypointtype import FlightWaypointType
 
 
-class BaiFlightPlan(FormationAttackFlightPlan):
+class BaiFlightPlan(FormationAttackFlightPlan, TacticalOverlayDisplay):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        return attack_run_overlay(
+            self.layout.ingress.position,
+            self.package.target.position,
+            self.layout.split.position,
+        )
 
 
 class Builder(FormationAttackBuilder[BaiFlightPlan, FormationAttackLayout]):

--- a/game/ato/flightplans/barcap.py
+++ b/game/ato/flightplans/barcap.py
@@ -8,10 +8,11 @@ from game.utils import Distance, Speed
 from .capbuilder import CapBuilder
 from .invalidobjectivelocation import InvalidObjectiveLocation
 from .patrolling import PatrollingFlightPlan, PatrollingLayout
+from .tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay, cap_overlay
 from .waypointbuilder import WaypointBuilder
 
 
-class BarCapFlightPlan(PatrollingFlightPlan[PatrollingLayout]):
+class BarCapFlightPlan(PatrollingFlightPlan[PatrollingLayout], TacticalOverlayDisplay):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
@@ -29,6 +30,9 @@ class BarCapFlightPlan(PatrollingFlightPlan[PatrollingLayout]):
     @property
     def engagement_distance(self) -> Distance:
         return self.flight.coalition.doctrine.cap_engagement_range
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        return cap_overlay(self)
 
 
 class Builder(CapBuilder[BarCapFlightPlan, PatrollingLayout]):

--- a/game/ato/flightplans/cas.py
+++ b/game/ato/flightplans/cas.py
@@ -11,6 +11,7 @@ from game.utils import nautical_miles
 from .ibuilder import IBuilder
 from .invalidobjectivelocation import InvalidObjectiveLocation
 from .patrolling import PatrollingFlightPlan, PatrollingLayout
+from .tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay, cas_overlay
 from .uizonedisplay import UiZone, UiZoneDisplay
 from .waypointbuilder import WaypointBuilder
 from ..flightwaypointtype import FlightWaypointType
@@ -40,7 +41,9 @@ class CasLayout(PatrollingLayout):
         yield from self.custom_waypoints
 
 
-class CasFlightPlan(PatrollingFlightPlan[CasLayout], UiZoneDisplay):
+class CasFlightPlan(
+    PatrollingFlightPlan[CasLayout], UiZoneDisplay, TacticalOverlayDisplay
+):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
@@ -79,6 +82,13 @@ class CasFlightPlan(PatrollingFlightPlan[CasLayout], UiZoneDisplay):
         return UiZone(
             [midpoint],
             self.engagement_distance,
+        )
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        return cas_overlay(
+            patrol_start=self.layout.patrol_start.position,
+            patrol_end=self.layout.patrol_end.position,
+            engagement_range=self.engagement_distance,
         )
 
 

--- a/game/ato/flightplans/dead.py
+++ b/game/ato/flightplans/dead.py
@@ -13,13 +13,21 @@ from .formationattack import (
     FormationAttackLayout,
 )
 from .invalidobjectivelocation import InvalidObjectiveLocation
+from .tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay, attack_run_overlay
 from ..flightwaypointtype import FlightWaypointType
 
 
-class DeadFlightPlan(FormationAttackFlightPlan):
+class DeadFlightPlan(FormationAttackFlightPlan, TacticalOverlayDisplay):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        return attack_run_overlay(
+            self.layout.ingress.position,
+            self.package.target.position,
+            self.layout.split.position,
+        )
 
 
 class Builder(FormationAttackBuilder[DeadFlightPlan, FormationAttackLayout]):

--- a/game/ato/flightplans/escort.py
+++ b/game/ato/flightplans/escort.py
@@ -10,16 +10,33 @@ from .formationattack import (
     FormationAttackFlightPlan,
     FormationAttackLayout,
 )
+from .tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay, escort_overlay
 from .waypointbuilder import WaypointBuilder
 from .. import FlightType
 from ..packagewaypoints import PackageWaypoints
 from ...utils import feet
 
 
-class EscortFlightPlan(FormationAttackFlightPlan):
+class EscortFlightPlan(FormationAttackFlightPlan, TacticalOverlayDisplay):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        doctrine = self.flight.coalition.doctrine
+        rng = (
+            doctrine.sead_escort_engagement_range
+            if self.flight.flight_type is FlightType.SEAD_ESCORT
+            else doctrine.escort_engagement_range
+        )
+        # AI escorts skip the ingress/target waypoints (only_for_player) and turn
+        # for home at the escort-hold anchor, ~7-9nm short of the target, without
+        # loitering. So the honest reach is the join->escort-hold leg, not a
+        # corridor all the way to the target and out to split.
+        hold = self.layout.initial
+        far = hold.position if hold is not None else self.package.target.position
+        route = [self.layout.join.position, far]
+        return escort_overlay(route=route, engagement_range=rng)
 
     @property
     def split_time(self) -> datetime:

--- a/game/ato/flightplans/ocaaircraft.py
+++ b/game/ato/flightplans/ocaaircraft.py
@@ -10,13 +10,21 @@ from .formationattack import (
     FormationAttackLayout,
 )
 from .invalidobjectivelocation import InvalidObjectiveLocation
+from .tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay, attack_run_overlay
 from ..flightwaypointtype import FlightWaypointType
 
 
-class OcaAircraftFlightPlan(FormationAttackFlightPlan):
+class OcaAircraftFlightPlan(FormationAttackFlightPlan, TacticalOverlayDisplay):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        return attack_run_overlay(
+            self.layout.ingress.position,
+            self.package.target.position,
+            self.layout.split.position,
+        )
 
 
 class Builder(FormationAttackBuilder[OcaAircraftFlightPlan, FormationAttackLayout]):

--- a/game/ato/flightplans/ocarunway.py
+++ b/game/ato/flightplans/ocarunway.py
@@ -10,13 +10,21 @@ from .formationattack import (
     FormationAttackLayout,
 )
 from .invalidobjectivelocation import InvalidObjectiveLocation
+from .tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay, attack_run_overlay
 from ..flightwaypointtype import FlightWaypointType
 
 
-class OcaRunwayFlightPlan(FormationAttackFlightPlan):
+class OcaRunwayFlightPlan(FormationAttackFlightPlan, TacticalOverlayDisplay):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        return attack_run_overlay(
+            self.layout.ingress.position,
+            self.package.target.position,
+            self.layout.split.position,
+        )
 
 
 class Builder(FormationAttackBuilder[OcaRunwayFlightPlan, FormationAttackLayout]):

--- a/game/ato/flightplans/sead.py
+++ b/game/ato/flightplans/sead.py
@@ -8,16 +8,54 @@ from .formationattack import (
     FormationAttackFlightPlan,
     FormationAttackLayout,
 )
+from .tacticaloverlay import (
+    TacticalOverlay,
+    TacticalOverlayDisplay,
+    loiter_overlay,
+    orbit_radius,
+)
+from .uizonedisplay import UiZone, UiZoneDisplay
+from ..flightwaypoint import FlightWaypoint
 from ..flightwaypointtype import FlightWaypointType
+from ...utils import Distance, nautical_miles
 
 
-class SeadFlightPlan(FormationAttackFlightPlan):
+class SeadFlightPlan(FormationAttackFlightPlan, UiZoneDisplay, TacticalOverlayDisplay):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
 
     def default_tot_offset(self) -> timedelta:
         return -timedelta(minutes=1)
+
+    @property
+    def _loiter_anchor(self) -> FlightWaypoint:
+        # Standoff loiter point (the "SEAD Search" anchor); fall back to the
+        # target if the layout has no standoff anchor.
+        return self.layout.initial or self.tot_waypoint
+
+    @property
+    def _engagement_range(self) -> Distance:
+        return nautical_miles(
+            self.flight.coalition.game.settings.sead_sweep_engagement_range_distance
+        )
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        # SEAD loiters at standoff and reacts to radars near its own position, so
+        # both the orbit and the engagement bubble sit on the loiter anchor.
+        anchor = self._loiter_anchor
+        return loiter_overlay(
+            orbit_center=anchor.position,
+            loiter_radius=orbit_radius(
+                self.flight.unit_type.preferred_patrol_speed(anchor.alt)
+            ),
+            engagement_center=anchor.position,
+            engagement_range=self._engagement_range,
+            target_position=self.tot_waypoint.position,
+        )
+
+    def ui_zone(self) -> UiZone:
+        return UiZone([self._loiter_anchor.position], self._engagement_range)
 
 
 class Builder(FormationAttackBuilder[SeadFlightPlan, FormationAttackLayout]):

--- a/game/ato/flightplans/seadsweep.py
+++ b/game/ato/flightplans/seadsweep.py
@@ -8,12 +8,21 @@ from .formationattack import (
     FormationAttackFlightPlan,
     FormationAttackLayout,
 )
+from .tacticaloverlay import (
+    TacticalOverlay,
+    TacticalOverlayDisplay,
+    loiter_overlay,
+    orbit_radius,
+)
 from .uizonedisplay import UiZoneDisplay, UiZone
+from ..flightwaypoint import FlightWaypoint
 from ..flightwaypointtype import FlightWaypointType
-from ...utils import nautical_miles
+from ...utils import Distance, nautical_miles
 
 
-class SeadSweepFlightPlan(FormationAttackFlightPlan, UiZoneDisplay):
+class SeadSweepFlightPlan(
+    FormationAttackFlightPlan, UiZoneDisplay, TacticalOverlayDisplay
+):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
@@ -21,13 +30,32 @@ class SeadSweepFlightPlan(FormationAttackFlightPlan, UiZoneDisplay):
     def default_tot_offset(self) -> timedelta:
         return -timedelta(minutes=2)
 
-    def ui_zone(self) -> UiZone:
-        return UiZone(
-            [self.tot_waypoint.position],
-            nautical_miles(
-                self.flight.coalition.game.settings.sead_sweep_engagement_range_distance
-            ),
+    @property
+    def _loiter_anchor(self) -> FlightWaypoint:
+        return self.layout.initial or self.tot_waypoint
+
+    @property
+    def _engagement_range(self) -> Distance:
+        return nautical_miles(
+            self.flight.coalition.game.settings.sead_sweep_engagement_range_distance
         )
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        # Sweep orbits at standoff but its EngageTargetsInZone bubble is centered
+        # on the target, so the orbit ring and the bubble sit in different places.
+        anchor = self._loiter_anchor
+        return loiter_overlay(
+            orbit_center=anchor.position,
+            loiter_radius=orbit_radius(
+                self.flight.unit_type.preferred_patrol_speed(anchor.alt)
+            ),
+            engagement_center=self.tot_waypoint.position,
+            engagement_range=self._engagement_range,
+            target_position=self.tot_waypoint.position,
+        )
+
+    def ui_zone(self) -> UiZone:
+        return UiZone([self.tot_waypoint.position], self._engagement_range)
 
 
 class Builder(FormationAttackBuilder[SeadSweepFlightPlan, FormationAttackLayout]):

--- a/game/ato/flightplans/strike.py
+++ b/game/ato/flightplans/strike.py
@@ -9,15 +9,23 @@ from .formationattack import (
     FormationAttackLayout,
 )
 from .invalidobjectivelocation import InvalidObjectiveLocation
+from .tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay, attack_run_overlay
 from .waypointbuilder import StrikeTarget
 from ..flightwaypointtype import FlightWaypointType
 from ...theater.theatergroup import SceneryUnit
 
 
-class StrikeFlightPlan(FormationAttackFlightPlan):
+class StrikeFlightPlan(FormationAttackFlightPlan, TacticalOverlayDisplay):
     @staticmethod
     def builder_type() -> Type[Builder]:
         return Builder
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        return attack_run_overlay(
+            self.layout.ingress.position,
+            self.package.target.position,
+            self.layout.split.position,
+        )
 
 
 class Builder(FormationAttackBuilder[StrikeFlightPlan, FormationAttackLayout]):

--- a/game/ato/flightplans/tacticaloverlay.py
+++ b/game/ato/flightplans/tacticaloverlay.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import abc
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from dcs import Point
+from shapely.geometry import LineString, Point as ShapelyPoint, Polygon
+from shapely.ops import unary_union
+
+from game.utils import Distance, Speed, meters
+
+
+@dataclass(frozen=True)
+class ReachShape:
+    """Engagement geometry. filled=True -> shaded 'actually projected';
+    filled=False -> outline-only 'planned but barely used'."""
+
+    geometry: Polygon
+    filled: bool
+
+
+@dataclass(frozen=True)
+class TacticalTarget:
+    position: Point
+
+
+@dataclass(frozen=True)
+class TacticalOverlay:
+    """What an AI flight actually does, for honest map rendering."""
+
+    reach: list[ReachShape] = field(default_factory=list)
+    actual_path: list[Point] | None = None
+    targets: list[TacticalTarget] = field(default_factory=list)
+
+
+class TacticalOverlayDisplay(abc.ABC):
+    @abc.abstractmethod
+    def tactical_overlay(self) -> TacticalOverlay: ...
+
+
+# ---- pure geometry helpers (all in DCS x/y meter space) ----
+
+
+def reach_circle(center: Point, radius: Distance) -> Polygon:
+    return ShapelyPoint(center.x, center.y).buffer(radius.meters)
+
+
+def asymmetric_capsule(a: Point, b: Point, r_a: Distance, r_b: Distance) -> Polygon:
+    """Convex hull of two disks of differing radii -> a stadium fat at one end."""
+    disk_a = ShapelyPoint(a.x, a.y).buffer(r_a.meters)
+    disk_b = ShapelyPoint(b.x, b.y).buffer(r_b.meters)
+    return unary_union([disk_a, disk_b]).convex_hull
+
+
+def reach_corridor(points: list[Point], radius: Distance) -> Polygon:
+    return LineString([(p.x, p.y) for p in points]).buffer(radius.meters)
+
+
+def orbit_loop(center: Point, radius: Distance, segments: int = 24) -> list[Point]:
+    r = radius.meters
+    return [
+        center.new_in_same_map(
+            center.x + r * math.cos(2 * math.pi * i / segments),
+            center.y + r * math.sin(2 * math.pi * i / segments),
+        )
+        for i in range(segments + 1)
+    ]
+
+
+def orbit_radius(speed: Speed, bank_deg: float = 25.0) -> Distance:
+    """Level-turn radius r = v^2 / (g * tan(bank))."""
+    v = speed.meters_per_second
+    return meters(v * v / (9.81 * math.tan(math.radians(bank_deg))))
+
+
+def attack_run_overlay(
+    ingress: Point, target_position: Point, split: Point
+) -> TacticalOverlay:
+    return TacticalOverlay(
+        reach=[],
+        actual_path=[ingress, target_position, split],
+        targets=[TacticalTarget(position=target_position)],
+    )
+
+
+if TYPE_CHECKING:
+    from game.ato.flightplans.patrolling import PatrollingFlightPlan
+
+
+def _orbit_anchor(
+    flight_plan: "PatrollingFlightPlan[Any]",
+) -> Point:
+    # Confirmed in-DCS: CAP orbits the END (discrepancy log D6).
+    return flight_plan.layout.patrol_end.position
+
+
+def cap_overlay(
+    flight_plan: "PatrollingFlightPlan[Any]",
+) -> TacticalOverlay:
+    anchor = _orbit_anchor(flight_plan)
+    eng = flight_plan.engagement_distance
+    r_orbit = orbit_radius(flight_plan.patrol_speed)
+    far = meters(eng.meters + r_orbit.meters)
+    outline = asymmetric_capsule(
+        flight_plan.layout.patrol_start.position, anchor, eng, far
+    )
+    return TacticalOverlay(
+        reach=[
+            ReachShape(geometry=outline, filled=False),
+            ReachShape(geometry=reach_circle(anchor, far), filled=True),
+        ],
+        actual_path=orbit_loop(anchor, r_orbit),
+    )
+
+
+def loiter_overlay(
+    orbit_center: Point,
+    loiter_radius: Distance,
+    engagement_center: Point,
+    engagement_range: Distance,
+    target_position: Point,
+) -> TacticalOverlay:
+    """Loiter-and-react overlay: an orbit ring at the standoff loiter point, a
+    filled engagement bubble, and the revealed target. Used by the SEAD family,
+    which orbits at standoff and engages air-defence radars reactively."""
+    return TacticalOverlay(
+        reach=[
+            ReachShape(
+                geometry=reach_circle(engagement_center, engagement_range), filled=True
+            )
+        ],
+        actual_path=orbit_loop(orbit_center, loiter_radius),
+        targets=[TacticalTarget(position=target_position)],
+    )
+
+
+def escort_overlay(route: list[Point], engagement_range: Distance) -> TacticalOverlay:
+    return TacticalOverlay(
+        reach=[
+            ReachShape(geometry=reach_corridor(route, engagement_range), filled=True)
+        ],
+    )
+
+
+def cas_overlay(
+    patrol_start: Point, patrol_end: Point, engagement_range: Distance
+) -> TacticalOverlay:
+    # Loiters ALONG the front line, so the reach is a corridor down the FLOT
+    # bounds, not a single circle at the midpoint.
+    return TacticalOverlay(
+        reach=[
+            ReachShape(
+                geometry=reach_corridor([patrol_start, patrol_end], engagement_range),
+                filled=True,
+            )
+        ],
+    )

--- a/game/ato/flightplans/tarcap.py
+++ b/game/ato/flightplans/tarcap.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Type
 from game.utils import Distance, Speed
 from .capbuilder import CapBuilder
 from .patrolling import PatrollingFlightPlan, PatrollingLayout
+from .tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay, cap_overlay
 from .waypointbuilder import WaypointBuilder
 
 if TYPE_CHECKING:
@@ -41,7 +42,7 @@ class TarCapLayout(PatrollingLayout):
         return False
 
 
-class TarCapFlightPlan(PatrollingFlightPlan[TarCapLayout]):
+class TarCapFlightPlan(PatrollingFlightPlan[TarCapLayout], TacticalOverlayDisplay):
     @property
     def patrol_duration(self) -> timedelta:
         # Note that this duration only has an effect if there are no
@@ -59,6 +60,9 @@ class TarCapFlightPlan(PatrollingFlightPlan[TarCapLayout]):
     @property
     def engagement_distance(self) -> Distance:
         return self.flight.coalition.doctrine.cap_engagement_range
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        return cap_overlay(self)
 
     @staticmethod
     def builder_type() -> Type[Builder]:

--- a/game/ato/flightroledescription.py
+++ b/game/ato/flightroledescription.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from game.ato.flighttype import FlightType
+from game.utils import nautical_miles
+
+if TYPE_CHECKING:
+    from game.ato.flight import Flight
+
+
+def role_description(flight: "Flight") -> str:
+    doctrine = flight.coalition.doctrine
+    settings = flight.coalition.game.settings
+    ft = flight.flight_type
+    cap = doctrine.cap_engagement_range
+    if ft is FlightType.BARCAP:
+        return (
+            f"Orbits at the far end of its racetrack, holding back from enemy SAM "
+            f"threat, and engages enemy aircraft within {cap.nautical_miles:.0f}nm of its orbit."
+        )
+    if ft is FlightType.TARCAP:
+        return (
+            f"Orbits over the target area on a short racetrack and engages enemy "
+            f"aircraft within {cap.nautical_miles:.0f}nm of its orbit."
+        )
+    if ft is FlightType.DEAD:
+        return "Flies in and attacks a specific SAM/EWR site (ARM/ASM/guided bombs) to destroy it."
+    if ft is FlightType.SEAD_SWEEP:
+        rng = nautical_miles(settings.sead_sweep_engagement_range_distance)
+        return (
+            f"Loiters near the target and engages any air-defence within {rng.nautical_miles:.0f}nm of the "
+            f"target — including front-line SAMs inside the bubble."
+        )
+    if ft is FlightType.ESCORT:
+        return (
+            f"Flies formation with the package and engages enemy fighters within "
+            f"{doctrine.escort_engagement_range.nautical_miles:.0f}nm; reactive only, disengages at split."
+        )
+    if ft is FlightType.SEAD_ESCORT:
+        return (
+            f"Flies formation with the package and engages SAM-radar threats within "
+            f"{doctrine.sead_escort_engagement_range.nautical_miles:.0f}nm; reactive only, disengages at split."
+        )
+    if ft is FlightType.CAS:
+        rng = nautical_miles(settings.cas_engagement_range_distance)
+        return f"Loiters along the front line and engages ground targets within {rng.nautical_miles:.0f}nm; no racetrack orbit."
+    if ft is FlightType.SEAD:
+        rng = nautical_miles(settings.sead_sweep_engagement_range_distance)
+        return (
+            f"Loiters at standoff near the target and reactively fires anti-radiation "
+            f"missiles at air-defence radars within {rng.nautical_miles:.0f}nm as they "
+            f"come up; suppresses rather than destroys."
+        )
+    if ft in {
+        FlightType.BAI,
+        FlightType.ANTISHIP,
+        FlightType.STRIKE,
+        FlightType.OCA_AIRCRAFT,
+        FlightType.OCA_RUNWAY,
+        FlightType.ARMED_RECON,
+    }:
+        return "Flies in and attacks the assigned target."
+    # Everything else: no descriptor.
+    return ""

--- a/game/server/flights/models.py
+++ b/game/server/flights/models.py
@@ -4,16 +4,96 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 from pydantic import BaseModel
+from shapely.geometry import LineString, Point as ShapelyPoint
 
+from game.ato.flightplans.tacticaloverlay import TacticalOverlay, TacticalOverlayDisplay
+from game.ato.flightplans.uizonedisplay import UiZone, UiZoneDisplay
 from game.ato.flightstate import InFlight
 from game.ato.flightstate.killed import Killed
-from game.server.leaflet import LeafletPoint
+from game.server.leaflet import LeafletLine, LeafletPoint, LeafletPoly, ShapelyUtil
 from game.server.waypoints.models import FlightWaypointJs
 from game.server.waypoints.routes import waypoints_for_flight
 
 if TYPE_CHECKING:
     from game import Game
     from game.ato import Flight
+    from game.theater import ConflictTheater
+
+
+class TacticalReachJs(BaseModel):
+    polygon: LeafletPoly
+    filled: bool
+
+    class Config:
+        title = "TacticalReach"
+
+
+class TacticalTargetJs(BaseModel):
+    position: LeafletPoint
+
+    class Config:
+        title = "TacticalTarget"
+
+
+class TacticalOverlayJs(BaseModel):
+    reach: list[TacticalReachJs]
+    actual_path: LeafletLine | None = None
+    targets: list[TacticalTargetJs]
+
+    class Config:
+        title = "TacticalOverlay"
+
+    @staticmethod
+    def from_overlay(
+        overlay: TacticalOverlay, theater: ConflictTheater
+    ) -> TacticalOverlayJs:
+        reach = [
+            TacticalReachJs(
+                polygon=ShapelyUtil.poly_to_leaflet(shape.geometry, theater),
+                filled=shape.filled,
+            )
+            for shape in overlay.reach
+        ]
+        actual_path: LeafletLine | None = None
+        if overlay.actual_path:
+            line = LineString([(p.x, p.y) for p in overlay.actual_path])
+            actual_path = ShapelyUtil.line_to_leaflet(line, theater)
+        targets = [
+            TacticalTargetJs(position=LeafletPoint.from_latlng(t.position.latlng()))
+            for t in overlay.targets
+        ]
+        return TacticalOverlayJs(reach=reach, actual_path=actual_path, targets=targets)
+
+    @staticmethod
+    def from_ui_zone(zone: UiZone, theater: ConflictTheater) -> TacticalOverlayJs:
+        # Preserve the legacy commit-boundary look (a thin outline) for flights that only
+        # expose ui_zone: players, support flights, and AI types without a bespoke overlay.
+        if len(zone.points) == 1:
+            center: ShapelyPoint | LineString = ShapelyPoint(
+                zone.points[0].x, zone.points[0].y
+            )
+        else:
+            center = LineString([(p.x, p.y) for p in zone.points])
+        poly = center.buffer(zone.radius.meters)
+        return TacticalOverlayJs(
+            reach=[
+                TacticalReachJs(
+                    polygon=ShapelyUtil.poly_to_leaflet(poly, theater), filled=False
+                )
+            ],
+            actual_path=None,
+            targets=[],
+        )
+
+    @staticmethod
+    def for_flight(flight: Flight, game: Game) -> TacticalOverlayJs:
+        empty = TacticalOverlayJs(reach=[], actual_path=None, targets=[])
+        plan = flight.flight_plan
+        if flight.client_count == 0 and isinstance(plan, TacticalOverlayDisplay):
+            return TacticalOverlayJs.from_overlay(plan.tactical_overlay(), game.theater)
+        if isinstance(plan, UiZoneDisplay):
+            return TacticalOverlayJs.from_ui_zone(plan.ui_zone(), game.theater)
+        return empty
 
 
 class FlightJs(BaseModel):

--- a/game/server/flights/routes.py
+++ b/game/server/flights/routes.py
@@ -1,13 +1,10 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
-from shapely.geometry import LineString, Point as ShapelyPoint
 
 from game import Game
-from game.ato.flightplans.uizonedisplay import UiZoneDisplay
 from game.server import GameContext
-from game.server.flights.models import FlightJs
-from game.server.leaflet import LeafletPoly, ShapelyUtil
+from game.server.flights.models import FlightJs, TacticalOverlayJs
 
 router: APIRouter = APIRouter(prefix="/flights")
 
@@ -30,20 +27,12 @@ def get_flight(
 
 
 @router.get(
-    "/{flight_id}/commit-boundary",
-    operation_id="get_commit_boundary_for_flight",
-    response_model=LeafletPoly,
+    "/{flight_id}/tactical-overlay",
+    operation_id="get_tactical_overlay_for_flight",
+    response_model=TacticalOverlayJs,
 )
-def commit_boundary(
+def tactical_overlay(
     flight_id: UUID, game: Game = Depends(GameContext.require)
-) -> LeafletPoly:
+) -> TacticalOverlayJs:
     flight = game.db.flights.get(flight_id)
-    if not isinstance(flight.flight_plan, UiZoneDisplay):
-        return []
-    zone = flight.flight_plan.ui_zone()
-    if len(zone.points) == 1:
-        center = ShapelyPoint(zone.points[0].x, zone.points[0].y)
-    else:
-        center = LineString([ShapelyPoint(p.x, p.y) for p in zone.points])
-    bubble = center.buffer(zone.radius.meters)
-    return ShapelyUtil.poly_to_leaflet(bubble, game.theater)
+    return TacticalOverlayJs.for_flight(flight, game)

--- a/qt_ui/windows/mission/flight/settings/QFlightTypeTaskInfo.py
+++ b/qt_ui/windows/mission/flight/settings/QFlightTypeTaskInfo.py
@@ -1,5 +1,6 @@
 from PySide6.QtWidgets import QLabel, QGroupBox, QGridLayout
 
+from game.ato.flightroledescription import role_description
 from qt_ui.uiconstants import AIRCRAFT_ICONS
 
 
@@ -25,5 +26,11 @@ class QFlightTypeTaskInfo(QGroupBox):
 
         layout.addWidget(self.task, 1, 0)
         layout.addWidget(self.task_type, 1, 1)
+
+        role_text = role_description(flight)
+        if role_text:
+            self.role = QLabel(role_text)
+            self.role.setWordWrap(True)
+            layout.addWidget(self.role, 2, 0, 1, 2)
 
         self.setLayout(layout)

--- a/tests/ato/flightplans/test_attack_run_overlay.py
+++ b/tests/ato/flightplans/test_attack_run_overlay.py
@@ -1,0 +1,18 @@
+from dcs import Point
+from dcs.terrain import Caucasus
+
+from game.ato.flightplans.tacticaloverlay import attack_run_overlay
+
+
+def _p(x: float, y: float) -> Point:
+    return Point(x, y, Caucasus())
+
+
+def test_attack_run_reveals_target_and_detour() -> None:
+    ingress = _p(0, 0)
+    target = _p(10000, 5000)
+    split = _p(20000, 0)
+    overlay = attack_run_overlay(ingress, target, split)
+    assert overlay.reach == []
+    assert overlay.targets[0].position == target
+    assert overlay.actual_path == [ingress, target, split]

--- a/tests/ato/flightplans/test_cap_overlay.py
+++ b/tests/ato/flightplans/test_cap_overlay.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+from dcs import Point
+from dcs.terrain import Caucasus
+
+from game.ato.flightplans.patrolling import PatrollingFlightPlan, PatrollingLayout
+from game.ato.flightplans.tacticaloverlay import cap_overlay
+from game.ato.flightwaypoint import FlightWaypoint
+from game.ato.flightwaypointtype import FlightWaypointType
+from game.utils import Distance, Speed, kph, nautical_miles
+
+
+def _wp(name: str, x: float, y: float, kind: FlightWaypointType) -> FlightWaypoint:
+    return FlightWaypoint(name, kind, Point(x, y, Caucasus()))
+
+
+class _Cap(PatrollingFlightPlan[PatrollingLayout]):
+    @property
+    def patrol_duration(self) -> timedelta:
+        return timedelta(minutes=30)
+
+    @property
+    def patrol_speed(self) -> Speed:
+        return kph(700)
+
+    @property
+    def engagement_distance(self) -> Distance:
+        return nautical_miles(35)
+
+
+def _plan() -> _Cap:
+    layout = PatrollingLayout(
+        departure=_wp("dep", 0, 0, FlightWaypointType.TAKEOFF),
+        custom_waypoints=[],
+        arrival=_wp("arr", 0, 0, FlightWaypointType.LANDING_POINT),
+        divert=None,
+        bullseye=_wp("bull", 0, 0, FlightWaypointType.BULLSEYE),
+        nav_to=[],
+        nav_from=[],
+        patrol_start=_wp("ps", 0, 0, FlightWaypointType.PATROL_TRACK),
+        patrol_end=_wp("pe", 100000, 0, FlightWaypointType.PATROL),
+    )
+    flight = SimpleNamespace(
+        package=SimpleNamespace(time_over_target=datetime(2020, 1, 1))
+    )
+    return _Cap(flight, layout)  # type: ignore[arg-type]
+
+
+def test_cap_overlay_shapes() -> None:
+    overlay = cap_overlay(_plan())
+    filled = [r for r in overlay.reach if r.filled]
+    outline = [r for r in overlay.reach if not r.filled]
+    assert len(filled) == 1 and len(outline) == 1
+    fminx, _, fmaxx, _ = filled[0].geometry.bounds
+    assert (fminx + fmaxx) / 2 > 90000
+    assert overlay.actual_path is not None
+    assert overlay.actual_path[0].x == overlay.actual_path[-1].x
+    assert overlay.targets == []

--- a/tests/ato/flightplans/test_escort_cas_overlay.py
+++ b/tests/ato/flightplans/test_escort_cas_overlay.py
@@ -1,0 +1,35 @@
+from dcs import Point
+from dcs.terrain import Caucasus
+from shapely.geometry import Point as ShapelyPoint
+
+from game.ato.flightplans.tacticaloverlay import cas_overlay, escort_overlay
+from game.utils import nautical_miles
+
+
+def _p(x: float, y: float) -> Point:
+    return Point(x, y, Caucasus())
+
+
+def test_escort_corridor_follows_route() -> None:
+    overlay = escort_overlay(
+        route=[_p(0, 0), _p(50000, 10000), _p(100000, 0)],
+        engagement_range=nautical_miles(20),
+    )
+    assert len(overlay.reach) == 1 and overlay.reach[0].filled
+    assert overlay.reach[0].geometry.contains(ShapelyPoint(50000, 10000))
+    assert overlay.targets == []
+
+
+def test_cas_corridor_spans_the_flot() -> None:
+    overlay = cas_overlay(
+        patrol_start=_p(0, 0),
+        patrol_end=_p(40000, 0),
+        engagement_range=nautical_miles(10),
+    )
+    assert len(overlay.reach) == 1 and overlay.reach[0].filled
+    geom = overlay.reach[0].geometry
+    # Corridor down the whole FLOT, not just a circle at the midpoint.
+    assert geom.contains(ShapelyPoint(0, 0))
+    assert geom.contains(ShapelyPoint(20000, 0))
+    assert geom.contains(ShapelyPoint(40000, 0))
+    assert overlay.actual_path is None

--- a/tests/ato/flightplans/test_loiter_overlay.py
+++ b/tests/ato/flightplans/test_loiter_overlay.py
@@ -1,0 +1,54 @@
+import math
+
+from dcs import Point
+from dcs.terrain import Caucasus
+
+from game.ato.flightplans.sead import SeadFlightPlan
+from game.ato.flightplans.seadsweep import SeadSweepFlightPlan
+from game.ato.flightplans.tacticaloverlay import TacticalOverlayDisplay, loiter_overlay
+from game.ato.flightplans.uizonedisplay import UiZoneDisplay
+from game.utils import nautical_miles
+
+
+def _p(x: float, y: float) -> Point:
+    return Point(x, y, Caucasus())
+
+
+def test_loiter_overlay_bubble_on_engagement_center() -> None:
+    target = _p(50000, 0)
+    overlay = loiter_overlay(
+        orbit_center=_p(0, 0),
+        loiter_radius=nautical_miles(3),
+        engagement_center=target,
+        engagement_range=nautical_miles(30),
+        target_position=target,
+    )
+    assert len(overlay.reach) == 1 and overlay.reach[0].filled
+    minx, _, maxx, _ = overlay.reach[0].geometry.bounds
+    assert (minx + maxx) / 2 == 50000  # bubble centered on engagement_center
+    assert overlay.targets[0].position == target
+
+
+def test_loiter_overlay_orbit_ring_on_anchor() -> None:
+    anchor = _p(10000, 20000)
+    overlay = loiter_overlay(
+        orbit_center=anchor,
+        loiter_radius=nautical_miles(3),
+        engagement_center=anchor,
+        engagement_range=nautical_miles(30),
+        target_position=_p(50000, 0),
+    )
+    ring = overlay.actual_path
+    assert ring is not None
+    # Closed ring of loiter_radius centered on the orbit anchor.
+    assert math.isclose(ring[0].x, ring[-1].x) and math.isclose(ring[0].y, ring[-1].y)
+    for p in ring:
+        assert math.isclose(
+            anchor.distance_to_point(p), nautical_miles(3).meters, rel_tol=1e-6
+        )
+
+
+def test_sead_family_are_overlay_and_uizone_displays() -> None:
+    for cls in (SeadFlightPlan, SeadSweepFlightPlan):
+        assert issubclass(cls, TacticalOverlayDisplay)
+        assert issubclass(cls, UiZoneDisplay)

--- a/tests/ato/flightplans/test_tactical_overlay_geometry.py
+++ b/tests/ato/flightplans/test_tactical_overlay_geometry.py
@@ -1,0 +1,54 @@
+import math
+
+from dcs import Point
+from dcs.terrain import Caucasus
+from shapely.geometry import Point as ShapelyPoint
+
+from game.ato.flightplans.tacticaloverlay import (
+    asymmetric_capsule,
+    orbit_loop,
+    orbit_radius,
+    reach_circle,
+    reach_corridor,
+)
+from game.utils import knots, nautical_miles
+
+
+def _p(x: float, y: float) -> Point:
+    return Point(x, y, Caucasus())
+
+
+def test_reach_circle_radius() -> None:
+    poly = reach_circle(_p(0, 0), nautical_miles(10))
+    minx, miny, maxx, maxy = poly.bounds
+    assert maxx == nautical_miles(10).meters
+    assert math.isclose(maxx, -minx, rel_tol=1e-9)
+
+
+def test_asymmetric_capsule_is_fatter_at_b() -> None:
+    cap = asymmetric_capsule(
+        _p(0, 0), _p(10000, 0), nautical_miles(5), nautical_miles(15)
+    )
+    minx, miny, maxx, maxy = cap.bounds
+    assert maxy == nautical_miles(15).meters
+    assert cap.contains(ShapelyPoint(10000, 0))
+
+
+def test_corridor_follows_the_line() -> None:
+    poly = reach_corridor([_p(0, 0), _p(10000, 0)], nautical_miles(2))
+    assert poly.contains(ShapelyPoint(5000, 0))
+    assert not poly.contains(ShapelyPoint(5000, nautical_miles(3).meters))
+
+
+def test_orbit_loop_is_closed_ring_on_center() -> None:
+    loop = orbit_loop(_p(100, 200), nautical_miles(3), segments=24)
+    assert len(loop) == 25
+    assert math.isclose(loop[0].x, loop[-1].x) and math.isclose(loop[0].y, loop[-1].y)
+    for p in loop:
+        assert math.isclose(
+            _p(100, 200).distance_to_point(p), nautical_miles(3).meters, rel_tol=1e-6
+        )
+
+
+def test_orbit_radius_grows_with_speed() -> None:
+    assert orbit_radius(knots(500)).meters > orbit_radius(knots(300)).meters > 0

--- a/tests/ato/flightplans/test_tactical_overlay_model.py
+++ b/tests/ato/flightplans/test_tactical_overlay_model.py
@@ -1,0 +1,28 @@
+from dcs import Point
+from dcs.terrain import Caucasus
+from shapely.geometry import Point as ShapelyPoint
+
+from game.ato.flightplans.tacticaloverlay import (
+    ReachShape,
+    TacticalOverlay,
+    TacticalTarget,
+)
+
+
+def test_overlay_defaults_are_empty() -> None:
+    overlay = TacticalOverlay()
+    assert overlay.reach == []
+    assert overlay.actual_path is None
+    assert overlay.targets == []
+
+
+def test_reach_shape_carries_fill_flag() -> None:
+    shape = ReachShape(geometry=ShapelyPoint(0, 0).buffer(1.0), filled=True)
+    assert shape.filled is True
+    assert not shape.geometry.is_empty
+
+
+def test_target_carries_position() -> None:
+    position = Point(1000.0, 2000.0, Caucasus())
+    target = TacticalTarget(position=position)
+    assert target.position == position

--- a/tests/ato/test_flight_role_description.py
+++ b/tests/ato/test_flight_role_description.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+from game.ato import FlightType
+from game.ato.flightroledescription import role_description
+from game.utils import nautical_miles
+
+
+def _flight(flight_type: FlightType) -> SimpleNamespace:
+    doctrine = SimpleNamespace(
+        cap_engagement_range=nautical_miles(35),
+        escort_engagement_range=nautical_miles(20),
+        sead_escort_engagement_range=nautical_miles(25),
+    )
+    settings = SimpleNamespace(
+        sead_sweep_engagement_range_distance=30, cas_engagement_range_distance=10
+    )
+    return SimpleNamespace(
+        flight_type=flight_type,
+        coalition=SimpleNamespace(
+            doctrine=doctrine, game=SimpleNamespace(settings=settings)
+        ),
+    )
+
+
+def test_barcap_role_mentions_orbit() -> None:
+    text = role_description(_flight(FlightType.BARCAP))  # type: ignore[arg-type]
+    assert "orbit" in text.lower()
+    assert "35" in text
+
+
+def test_sead_sweep_role_mentions_hunt() -> None:
+    text = role_description(_flight(FlightType.SEAD_SWEEP))  # type: ignore[arg-type]
+    assert "air-defence" in text.lower() or "air defence" in text.lower()
+
+
+def test_plain_sead_role_mentions_anti_radiation() -> None:
+    text = role_description(_flight(FlightType.SEAD))  # type: ignore[arg-type]
+    assert "anti-radiation" in text.lower()
+    assert "30" in text

--- a/tests/server/test_tactical_overlay_route.py
+++ b/tests/server/test_tactical_overlay_route.py
@@ -1,0 +1,100 @@
+from types import SimpleNamespace
+
+from dcs import Point
+from dcs.terrain import Caucasus
+
+from game.ato.flightplans.tacticaloverlay import (
+    ReachShape,
+    TacticalOverlay,
+    TacticalOverlayDisplay,
+    TacticalTarget,
+    reach_circle,
+)
+from game.ato.flightplans.uizonedisplay import UiZone, UiZoneDisplay
+from game.server.flights.models import TacticalOverlayJs
+from game.utils import nautical_miles
+
+
+class _Theater:
+    terrain = Caucasus()
+
+
+_GAME = SimpleNamespace(theater=_Theater())
+
+
+def test_overlay_js_from_overlay() -> None:
+    target = Point(1000.0, 2000.0, Caucasus())
+    overlay = TacticalOverlay(
+        reach=[
+            ReachShape(
+                geometry=reach_circle(Point(0, 0, Caucasus()), nautical_miles(5)),
+                filled=True,
+            )
+        ],
+        actual_path=[Point(0, 0, Caucasus()), Point(100, 0, Caucasus())],
+        targets=[TacticalTarget(position=target)],
+    )
+    js = TacticalOverlayJs.from_overlay(overlay, _Theater())  # type: ignore[arg-type]
+    assert js.reach[0].filled is True
+    assert len(js.reach[0].polygon) >= 1
+    assert js.actual_path is not None and len(js.actual_path) == 2
+    assert len(js.targets) == 1
+
+
+def test_overlay_js_from_ui_zone_is_outline() -> None:
+    zone = UiZone([Point(0, 0, Caucasus())], nautical_miles(10))
+    js = TacticalOverlayJs.from_ui_zone(zone, _Theater())  # type: ignore[arg-type]
+    assert len(js.reach) == 1 and js.reach[0].filled is False
+    assert js.actual_path is None and js.targets == []
+
+
+def test_empty_overlay_js() -> None:
+    js = TacticalOverlayJs.from_overlay(TacticalOverlay(), _Theater())  # type: ignore[arg-type]
+    assert js.reach == [] and js.actual_path is None and js.targets == []
+
+
+# ---- for_flight dispatch ----
+
+
+class _OverlayAndBridgePlan(TacticalOverlayDisplay, UiZoneDisplay):
+    """A plan that exposes both a bespoke overlay and a legacy ui_zone."""
+
+    def tactical_overlay(self) -> TacticalOverlay:
+        return TacticalOverlay(
+            reach=[
+                ReachShape(
+                    geometry=reach_circle(Point(0, 0, Caucasus()), nautical_miles(5)),
+                    filled=True,
+                )
+            ],
+            targets=[TacticalTarget(position=Point(1000, 2000, Caucasus()))],
+        )
+
+    def ui_zone(self) -> UiZone:
+        return UiZone([Point(0, 0, Caucasus())], nautical_miles(10))
+
+
+class _BarePlan:
+    """Neither a TacticalOverlayDisplay nor a UiZoneDisplay."""
+
+
+def _flight(client_count: int, plan: object) -> SimpleNamespace:
+    return SimpleNamespace(client_count=client_count, flight_plan=plan)
+
+
+def test_for_flight_ai_uses_bespoke_overlay() -> None:
+    js = TacticalOverlayJs.for_flight(_flight(0, _OverlayAndBridgePlan()), _GAME)  # type: ignore[arg-type]
+    assert any(r.filled for r in js.reach)
+    assert len(js.targets) == 1
+
+
+def test_for_flight_player_falls_back_to_ui_zone() -> None:
+    # client_count > 0 -> player flight keeps the legacy outline, not the overlay.
+    js = TacticalOverlayJs.for_flight(_flight(1, _OverlayAndBridgePlan()), _GAME)  # type: ignore[arg-type]
+    assert len(js.reach) == 1 and js.reach[0].filled is False
+    assert js.targets == []
+
+
+def test_for_flight_no_display_is_empty() -> None:
+    js = TacticalOverlayJs.for_flight(_flight(0, _BarePlan()), _GAME)  # type: ignore[arg-type]
+    assert js.reach == [] and js.actual_path is None and js.targets == []


### PR DESCRIPTION
Show, for AI-only flights, where they actually fly, what they can reach, and their role on the map — visualization only, no AI-behavior change. Helps planners visualize what AI-only fights will actually fly + engage, so they don't assume race-track behavior, hold points that don't exist, etc. 

  - CAP (BARCAP/TARCAP): orbit loop at the END + filled reach circle (orbit_radius + engagement) + asymmetric planned-leg outline
  - attack-run (DEAD/BAI/ANTISHIP/STRIKE/OCA_AIRCRAFT/OCA_RUNWAY/ ARMED_RECON): reveal the target + draw the ingress->target->split run
  - SEAD / SEAD_SWEEP: loiter overlay — an orbit ring at the standoff anchor plus a filled engagement bubble (on the loiter anchor for plain SEAD; on the target for SEAD_SWEEP's EngageTargetsInZone) + the target
  - ESCORT/SEAD_ESCORT: reach corridor along join->escort-hold (AI escorts skip the player-only ingress/target and turn for home at the hold, short of the target, without loitering)
  - CAS: reach corridor along the FLOT bounds