### PR TITLE
Use Qt non-native dialogs to avoid QtWebEngine file-dialog deadlock

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 * **[AirWing]** Squadron dialog shows the aircraft type, an aircraft inventory (initial/current/destroyed/purchased), and buy/sell aircraft controls with price, on-order count and available parking slots
 
 ## Fixes
+* **[UI]** Use Qt's non-native file dialogs (`AA_DontUseNativeDialogs`) so opening a file picker no longer freezes the whole app. The native Windows dialog deadlocks on a synchronous Win32 message when the embedded web map (QtWebEngine) is alive — e.g. clicking "Manually submit" on the modal "waiting for mission result" window hung Retribution ("Not Responding").
 * **[Mission Generation]** Anti-Ship flights now attack the carrier group the flight plan routes to instead of the control point's first ground object, so strikes against carrier groups no longer leave the AI without a target (it would fly to the ingress point and turn back without engaging).
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -73,6 +73,14 @@ def run_ui(game: Optional[Game], ui_flags: UiFlags) -> None:
 
     app = QApplication(sys.argv)
 
+    # Use Qt's own (non-native) file/colour/font dialogs everywhere. The native
+    # Windows dialogs can deadlock when opened while the embedded QtWebEngine map
+    # is alive: the platform plugin issues a synchronous Win32 SendMessage that
+    # never returns, freezing the whole app. This bit us opening the "submit
+    # manually" file picker from the modal "waiting for mission result" dialog,
+    # but every native dialog launched over the map is at risk.
+    app.setAttribute(Qt.ApplicationAttribute.AA_DontUseNativeDialogs)
+
     # init the theme and load the stylesheet based on the theme index
     liberation_theme.init()
     with open(


### PR DESCRIPTION
## Problem
Opening a **native Windows file dialog while the embedded web map (`QWebEngineView`) is alive** can deadlock the whole app and freeze it ("Not Responding"): the Windows platform plugin issues a synchronous `SendMessage` that never returns while the (nested, modal) dialog is created.

Reproduced by clicking **"Manually submit"** on the modal "Waiting for mission completion" window (`QWaitingForMissionResultWindow.submit_manually` → `QFileDialog.getOpenFileName`). A `py-spy --native` dump of the hung process showed the main thread blocked under `QDialog::exec` at `NtUserMessageCall` / `GetSystemMetrics` / `CallWindowProcW` in `qwindows.dll`, with the Qt event loop no longer pumping messages.

It's not limited to that one button — every native dialog opened over the map is at risk.

## Fix
`AA_DontUseNativeDialogs`: file / colour / font choosers use Qt's own (non-native) implementations instead of the deadlocking native path.

## Trade-off
File dialogs use the Qt-styled chooser instead of the native Windows one.
