### PR TITLE
aewc: flip enemy AWACS orbit direction away from threat boundary

### DIFF
--- a/game/ato/flightplans/aewc.py
+++ b/game/ato/flightplans/aewc.py
@@ -45,16 +45,29 @@ class Builder(IBuilder[AewcFlightPlan, PatrollingLayout]):
         distance_to_threat = meters(
             location.position.distance_to_point(closest_boundary)
         )
-        orbit_heading = heading_to_threat_boundary
-
-        # Station 80nm outside the threat zone.
+        # Station the orbit safely away from the threat zone.
         threat_buffer = nautical_miles(
             self.coalition.game.settings.aewc_threat_buffer_min_distance
         )
         if self.threat_zones.threatened(location.position):
+            # Target is inside the threat zone — pull the orbit out to safety,
+            # threat_buffer past the nearest boundary.
+            orbit_heading = heading_to_threat_boundary
             orbit_distance = distance_to_threat + threat_buffer
-        else:
+        elif self.coalition.player:
+            # Player-coalition AWACS (Blue): orbit as far forward as possible,
+            # threat_buffer short of the nearest threat boundary.  This keeps
+            # friendly AEW&C close enough to the front for maximum radar coverage.
+            orbit_heading = heading_to_threat_boundary
             orbit_distance = distance_to_threat - threat_buffer
+        else:
+            # Enemy/AI AWACS (Red): orbit in the OPPOSITE direction — away from
+            # the nearest threat boundary — so it stays deep inside protected
+            # airspace.  The A-50's long radar range means it can cover the
+            # target area from well inside friendly territory; there is no need
+            # to push it toward the front line.
+            orbit_heading = heading_to_threat_boundary.opposite
+            orbit_distance = threat_buffer
 
         racetrack_center = location.position.point_from_heading(
             orbit_heading.degrees, orbit_distance.meters


### PR DESCRIPTION
Blue AEW&C keeps the existing forward-leaning orbit (as close to the threat boundary as the buffer allows, maximising radar coverage).

Enemy/AI AWACS (Red A-50) now orbits in the OPPOSITE direction — threat_buffer distance BEHIND the target, away from the nearest Blue threat boundary.  Previously the same toward-threat heading was used for both coalitions, which placed the A-50 near the front line or even inside contested airspace.  With this change it stays deep inside the Kola Peninsula, covered by layered Soviet SAMs, while its long-range radar still reaches the target area.

The threatened() edge case (target already inside the threat zone) continues to use the toward-boundary + buffer escape logic for both coalitions since that path is genuinely rare and the correct response is always "move to safety".

Pull requests should be made against the `dev` branch. Any backports
necessary will be handled by the development team.

Pull requests should be focused on one task. Multiple bug fixes should be
multiple PRs, or at the very least split over multiple (isolated) commits.
We cannot merge half a PR, and combined PRs are more
difficult to review. PRs that do not adhere to this may have their review
delayed.

Prefer rebase to merge, and squash commits as needed to preserve a readable
commit history. This project maintains linear history in the `dev` branch, so
we will either rebase or squash your PR when merging. It is much easier for us
if your branch already has a readable commit history (ensure that your commit
subject lines are clear enough to identify the patch in the git log). An
exception to this is made for large PRs that are likely to require multiple
rounds of review; in that case it's easier if you **don't** do this (GitHub
does not preserve the history of old commits, so we cannot filter a PR for only
new changes if a branch is force pushed) and we will squash it when merging.

New features and bug fixes are usually worth mentioning in the changelog.
Exceptions are fixes for bugs that never shipped (were only present in a canary
build), and changes with no intended user observable behavior, such as a
refactor. If you're comfortable writing the note yourself, add it to
`changelog.md` in the root of the project in the section for the upcoming
release.
