### PR TITLE
Fix IndexError crash when flight exits combat at last waypoint

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * **[UX]** Show an "End of Mission Detected, processing Mission Data" busy dialog while turn results are processed, so the wait is not mistaken for a missed detection
 
 ## Fixes
+* **[Flight Plans]** Fixed IndexError crash when a flight exits combat at its last waypoint
 * **[Mission]** Reliably auto-detect end of mission, even when DCS wrote the final state.json before the wait dialog started watching
 * **[Performance]** Faster post-mission turn processing
 * **[AirWing]** Track per-squadron campaign aircraft stats (initial/destroyed/purchased, save-compatible) and expose pilot experience level and living/dead pilot views for the UI

--- a/game/ato/flightstate/inflight.py
+++ b/game/ato/flightstate/inflight.py
@@ -33,7 +33,18 @@ class InFlight(FlightState, ABC):
         self.waypoint_index = waypoint_index
         self.has_aborted = has_aborted
         self.current_waypoint = waypoints[self.waypoint_index]
-        # TODO: Error checking for flight plans without landing waypoints.
+        # Guard against flight plans that have no landing waypoint or whose
+        # waypoint list ends earlier than expected (e.g. SCRAMBLE BarCap plans
+        # that exit combat at the last waypoint).  next_waypoint_state() now
+        # catches this before creating InFlight subclasses, but keep the check
+        # here too so any future call sites get a clear error rather than a
+        # confusing IndexError.
+        if self.waypoint_index + 1 >= len(waypoints):
+            raise ValueError(
+                f"Flight {self.flight.flight_plan} has no waypoint after index "
+                f"{self.waypoint_index} (plan has {len(waypoints)} waypoints). "
+                "The flight plan is missing a terminal landing waypoint."
+            )
         self.next_waypoint = waypoints[self.waypoint_index + 1]
         self.total_time_to_next_waypoint = self.travel_time_between_waypoints()
         self.elapsed_time = elapsed_time
@@ -89,6 +100,14 @@ class InFlight(FlightState, ABC):
             return RaceTrack(self.flight, self.settings, new_index)
         if self.next_waypoint.waypoint_type is FlightWaypointType.LOITER:
             return Loiter(self.flight, self.settings, new_index)
+        # Guard: if new_index is the last waypoint there is no [new_index + 1]
+        # and Navigating.__init__ will crash.  This happens when a flight exits
+        # combat at or past its final waypoint (e.g. a SCRAMBLE BarCap orbit
+        # whose plan has no explicit LANDING_POINT, or whose landing waypoint
+        # was already consumed before the combat state was entered).
+        # Complete the flight rather than crashing.
+        if new_index + 1 >= len(self.flight.flight_plan.waypoints):
+            return Completed(self.flight, self.settings)
         return Navigating(self.flight, self.settings, new_index)
 
     def advance_to_next_waypoint(self) -> FlightState:


### PR DESCRIPTION
next_waypoint_state() was calling Navigating(new_index) even when new_index was the last waypoint in the plan, causing InFlight.__init__ to crash on waypoints[new_index + 1].

Triggered by SCRAMBLE flights whose BarCap plan exits combat at or past the final waypoint before a LANDING_POINT is reached.

Fixes both layers:
- next_waypoint_state(): return Completed when new_index+1 is out of bounds rather than constructing a Navigating that will immediately crash
- InFlight.__init__: replace the TODO comment with a clear ValueError so any future call site gets a useful message instead of IndexError

Pull requests should be made against the `dev` branch. Any backports
necessary will be handled by the development team.

Pull requests should be focused on one task. Multiple bug fixes should be
multiple PRs, or at the very least split over multiple (isolated) commits.
We cannot merge half a PR, and combined PRs are more
difficult to review. PRs that do not adhere to this may have their review
delayed.

Prefer rebase to merge, and squash commits as needed to preserve a readable
commit history. This project maintains linear history in the `dev` branch, so
we will either rebase or squash your PR when merging. It is much easier for us
if your branch already has a readable commit history (ensure that your commit
subject lines are clear enough to identify the patch in the git log). An
exception to this is made for large PRs that are likely to require multiple
rounds of review; in that case it's easier if you **don't** do this (GitHub
does not preserve the history of old commits, so we cannot filter a PR for only
new changes if a branch is force pushed) and we will squash it when merging.

New features and bug fixes are usually worth mentioning in the changelog.
Exceptions are fixes for bugs that never shipped (were only present in a canary
build), and changes with no intended user observable behavior, such as a
refactor. If you're comfortable writing the note yourself, add it to
`changelog.md` in the root of the project in the section for the upcoming
release.
