### PR TITLE
aewc: flip enemy AWACS orbit direction away from threat boundary

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * **[UX]** Show an "End of Mission Detected, processing Mission Data" busy dialog while turn results are processed, so the wait is not mistaken for a missed detection
 
 ## Fixes
+* **[AI]** Fixed enemy AWACS orbit placement — AI AWACS (A-50, etc.) was orbiting toward the threat boundary and loitering near the front line. It now orbits in the opposite direction, deep inside friendly airspace. Player-coalition AWACS keeps the existing forward-leaning behavior.
 * **[Mission]** Reliably auto-detect end of mission, even when DCS wrote the final state.json before the wait dialog started watching
 * **[Performance]** Faster post-mission turn processing
 * **[AirWing]** Track per-squadron campaign aircraft stats (initial/destroyed/purchased, save-compatible) and expose pilot experience level and living/dead pilot views for the UI

--- a/game/ato/flightplans/aewc.py
+++ b/game/ato/flightplans/aewc.py
@@ -6,6 +6,7 @@ from typing import Type
 from game.ato.flightplans.ibuilder import IBuilder
 from game.ato.flightplans.patrolling import PatrollingFlightPlan, PatrollingLayout
 from game.ato.flightplans.waypointbuilder import WaypointBuilder
+from game.ato.flighttype import FlightType
 from game.utils import Distance, Heading, Speed, knots, meters, nautical_miles
 
 
@@ -34,7 +35,7 @@ class AewcFlightPlan(PatrollingFlightPlan[PatrollingLayout]):
 
 class Builder(IBuilder[AewcFlightPlan, PatrollingLayout]):
     def layout(self) -> PatrollingLayout:
-        racetrack_half_distance = nautical_miles(30).meters
+        racetrack_half_distance = nautical_miles(30)
 
         location = self.package.target
 
@@ -45,40 +46,65 @@ class Builder(IBuilder[AewcFlightPlan, PatrollingLayout]):
         distance_to_threat = meters(
             location.position.distance_to_point(closest_boundary)
         )
-        # Station the orbit safely away from the threat zone.
+
         threat_buffer = nautical_miles(
             self.coalition.game.settings.aewc_threat_buffer_min_distance
         )
+
         if self.threat_zones.threatened(location.position):
-            # Target is inside the threat zone — pull the orbit out to safety,
-            # threat_buffer past the nearest boundary.
+            # Target inside the threat zone — escape to safety.
             orbit_heading = heading_to_threat_boundary
             orbit_distance = distance_to_threat + threat_buffer
-        elif self.coalition.player:
-            # Player-coalition AWACS (Blue): orbit as far forward as possible,
-            # threat_buffer short of the nearest threat boundary.  This keeps
-            # friendly AEW&C close enough to the front for maximum radar coverage.
+        elif self.coalition.player.is_blue:
+            # Player-coalition AWACS: orbit as far forward as the threat buffer
+            # allows for maximum radar coverage of the front.
             orbit_heading = heading_to_threat_boundary
             orbit_distance = distance_to_threat - threat_buffer
         else:
-            # Enemy/AI AWACS (Red): orbit in the OPPOSITE direction — away from
-            # the nearest threat boundary — so it stays deep inside protected
-            # airspace.  The A-50's long radar range means it can cover the
-            # target area from well inside friendly territory; there is no need
-            # to push it toward the front line.
+            # Enemy/AI AWACS: orbit deep inside friendly airspace, away from
+            # the threat boundary.  Long radar range means it can cover the
+            # front without pushing toward it.
             orbit_heading = heading_to_threat_boundary.opposite
             orbit_distance = threat_buffer
 
-        racetrack_center = location.position.point_from_heading(
+        base_center = location.position.point_from_heading(
             orbit_heading.degrees, orbit_distance.meters
         )
 
-        racetrack_start = racetrack_center.point_from_heading(
-            orbit_heading.right.degrees, racetrack_half_distance
+        # When multiple AWACS are planned, spread their orbits laterally along
+        # the front so each covers a different section rather than stacking.
+        # Orbits are spaced one full racetrack width (2 * half_distance) apart,
+        # centered on the natural orbit point.
+        all_awacs = sorted(
+            [
+                f
+                for p in self.coalition.ato.packages
+                for f in p.flights
+                if f.flight_type is FlightType.AEWC
+            ],
+            key=lambda f: str(f.id),
         )
+        n = len(all_awacs)
+        try:
+            idx = next(i for i, f in enumerate(all_awacs) if f is self.flight)
+        except StopIteration:
+            idx = 0
 
+        lateral_m = (idx - (n - 1) / 2) * (racetrack_half_distance * 2).meters
+        if lateral_m >= 0:
+            racetrack_center = base_center.point_from_heading(
+                orbit_heading.right.degrees, lateral_m
+            )
+        else:
+            racetrack_center = base_center.point_from_heading(
+                orbit_heading.left.degrees, -lateral_m
+            )
+
+        racetrack_start = racetrack_center.point_from_heading(
+            orbit_heading.right.degrees, racetrack_half_distance.meters
+        )
         racetrack_end = racetrack_center.point_from_heading(
-            orbit_heading.left.degrees, racetrack_half_distance
+            orbit_heading.left.degrees, racetrack_half_distance.meters
         )
 
         builder = WaypointBuilder(self.flight)

--- a/game/ato/flightplans/aewc.py
+++ b/game/ato/flightplans/aewc.py
@@ -45,16 +45,29 @@ class Builder(IBuilder[AewcFlightPlan, PatrollingLayout]):
         distance_to_threat = meters(
             location.position.distance_to_point(closest_boundary)
         )
-        orbit_heading = heading_to_threat_boundary
-
-        # Station 80nm outside the threat zone.
+        # Station the orbit safely away from the threat zone.
         threat_buffer = nautical_miles(
             self.coalition.game.settings.aewc_threat_buffer_min_distance
         )
         if self.threat_zones.threatened(location.position):
+            # Target is inside the threat zone — pull the orbit out to safety,
+            # threat_buffer past the nearest boundary.
+            orbit_heading = heading_to_threat_boundary
             orbit_distance = distance_to_threat + threat_buffer
-        else:
+        elif self.coalition.player:
+            # Player-coalition AWACS (Blue): orbit as far forward as possible,
+            # threat_buffer short of the nearest threat boundary.  This keeps
+            # friendly AEW&C close enough to the front for maximum radar coverage.
+            orbit_heading = heading_to_threat_boundary
             orbit_distance = distance_to_threat - threat_buffer
+        else:
+            # Enemy/AI AWACS (Red): orbit in the OPPOSITE direction — away from
+            # the nearest threat boundary — so it stays deep inside protected
+            # airspace.  The A-50's long radar range means it can cover the
+            # target area from well inside friendly territory; there is no need
+            # to push it toward the front line.
+            orbit_heading = heading_to_threat_boundary.opposite
+            orbit_distance = threat_buffer
 
         racetrack_center = location.position.point_from_heading(
             orbit_heading.degrees, orbit_distance.meters

--- a/game/ato/flightplans/theaterrefueling.py
+++ b/game/ato/flightplans/theaterrefueling.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Type
 
+from game.ato.flighttype import FlightType
 from game.utils import Heading, meters, nautical_miles
 from .ibuilder import IBuilder
 from .patrolling import PatrollingLayout
@@ -17,7 +18,7 @@ class TheaterRefuelingFlightPlan(RefuelingFlightPlan):
 
 class Builder(IBuilder[TheaterRefuelingFlightPlan, PatrollingLayout]):
     def layout(self) -> PatrollingLayout:
-        racetrack_half_distance = nautical_miles(20).meters
+        racetrack_half_distance = nautical_miles(20)
 
         location = self.package.target
 
@@ -28,27 +29,63 @@ class Builder(IBuilder[TheaterRefuelingFlightPlan, PatrollingLayout]):
         distance_to_threat = meters(
             location.position.distance_to_point(closest_boundary)
         )
-        orbit_heading = heading_to_threat_boundary
 
-        # Station 70nm outside the threat zone.
         threat_buffer = nautical_miles(
             self.coalition.game.settings.tanker_threat_buffer_min_distance
         )
-        if self.threat_zones.threatened(location.position):
-            orbit_distance = distance_to_threat + threat_buffer
-        else:
-            orbit_distance = distance_to_threat - threat_buffer
 
-        racetrack_center = location.position.point_from_heading(
+        if self.threat_zones.threatened(location.position):
+            # Target inside the threat zone — escape to safety.
+            orbit_heading = heading_to_threat_boundary
+            orbit_distance = distance_to_threat + threat_buffer
+        elif self.coalition.player.is_blue:
+            # Player-coalition tankers: orbit as far forward as the threat buffer
+            # allows so strike packages don't have to fly far for fuel.  Clamp to
+            # zero so we never end up behind the reference point.
+            orbit_heading = heading_to_threat_boundary
+            orbit_distance = max(meters(0), distance_to_threat - threat_buffer)
+        else:
+            # Enemy/AI tankers: orbit well inside friendly airspace, away from
+            # the threat boundary.
+            orbit_heading = heading_to_threat_boundary.opposite
+            orbit_distance = threat_buffer
+
+        base_center = location.position.point_from_heading(
             orbit_heading.degrees, orbit_distance.meters
         )
 
-        racetrack_start = racetrack_center.point_from_heading(
-            orbit_heading.right.degrees, racetrack_half_distance
+        # Deconflict multiple tankers: spread orbits laterally along the front
+        # so each covers a different slice of the strike corridor.
+        all_tankers = sorted(
+            [
+                f
+                for p in self.coalition.ato.packages
+                for f in p.flights
+                if f.flight_type is FlightType.REFUELING
+            ],
+            key=lambda f: str(f.id),
         )
+        n = len(all_tankers)
+        try:
+            idx = next(i for i, f in enumerate(all_tankers) if f is self.flight)
+        except StopIteration:
+            idx = 0
 
+        lateral_m = (idx - (n - 1) / 2) * (racetrack_half_distance * 2).meters
+        if lateral_m >= 0:
+            racetrack_center = base_center.point_from_heading(
+                orbit_heading.right.degrees, lateral_m
+            )
+        else:
+            racetrack_center = base_center.point_from_heading(
+                orbit_heading.left.degrees, -lateral_m
+            )
+
+        racetrack_start = racetrack_center.point_from_heading(
+            orbit_heading.right.degrees, racetrack_half_distance.meters
+        )
         racetrack_end = racetrack_center.point_from_heading(
-            orbit_heading.left.degrees, racetrack_half_distance
+            orbit_heading.left.degrees, racetrack_half_distance.meters
         )
 
         builder = WaypointBuilder(self.flight)


### PR DESCRIPTION
Blue AEW&C keeps the existing forward-leaning orbit (as close to the threat boundary as the buffer allows, maximising radar coverage).

Enemy/AI AWACS (Red A-50) now orbits in the OPPOSITE direction — threat_buffer distance BEHIND the target, away from the nearest Blue threat boundary.  Previously the same toward-threat heading was used for both coalitions, which placed the A-50 near the front line or even inside contested airspace.  With this change it stays deep inside the Kola Peninsula, covered by layered Soviet SAMs, while its long-range radar still reaches the target area.

The threatened() edge case (target already inside the threat zone) continues to use the toward-boundary + buffer escape logic for both coalitions since that path is genuinely rare and the correct response is always "move to safety".

Pull requests should be made against the `dev` branch. Any backports
necessary will be handled by the development team.

Pull requests should be focused on one task. Multiple bug fixes should be
multiple PRs, or at the very least split over multiple (isolated) commits.
We cannot merge half a PR, and combined PRs are more
difficult to review. PRs that do not adhere to this may have their review
delayed.

Prefer rebase to merge, and squash commits as needed to preserve a readable
commit history. This project maintains linear history in the `dev` branch, so
we will either rebase or squash your PR when merging. It is much easier for us
if your branch already has a readable commit history (ensure that your commit
subject lines are clear enough to identify the patch in the git log). An
exception to this is made for large PRs that are likely to require multiple
rounds of review; in that case it's easier if you **don't** do this (GitHub
does not preserve the history of old commits, so we cannot filter a PR for only
new changes if a branch is force pushed) and we will squash it when merging.

New features and bug fixes are usually worth mentioning in the changelog.
Exceptions are fixes for bugs that never shipped (were only present in a canary
build), and changes with no intended user observable behavior, such as a
refactor. If you're comfortable writing the note yourself, add it to
`changelog.md` in the root of the project in the section for the upcoming
release.
