### PR TITLE
add Scrambling flghts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[Mission]** Add reactive GCI scramble support. RED untasked, uncontrolled, air-to-air-capable aircraft can sit cold on the ramp as dormant interceptors; when a Blue aircraft is detected by the RED radar network, `reactive_scramble.lua` wakes the nearest available group and tasks it to intercept.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.
 * **[UX]** Avoid having escorts from wondering off too far while chasing a target.

--- a/game/missiongenerator/aircraft/aircraftgenerator.py
+++ b/game/missiongenerator/aircraft/aircraftgenerator.py
@@ -48,6 +48,9 @@ if TYPE_CHECKING:
     from game.squadrons import Squadron
 
 
+MAX_SCRAMBLE_GROUPS_PER_AIRFIELD = 4
+
+
 class AircraftGenerator:
     def __init__(
         self,
@@ -79,6 +82,7 @@ class AircraftGenerator:
         self.ground_spawns_roadbase = ground_spawns_roadbase
         self.ground_spawns_large = ground_spawns_large
         self.ground_spawns = ground_spawns
+        self.scramble_groups_by_control_point: dict[ControlPoint, int] = {}
 
         self.ewrj_package_dict: Dict[int, List[FlyingGroup[Any]]] = {}
         self.ewrj = settings.plugins.get("ewrj")
@@ -247,10 +251,33 @@ class AircraftGenerator:
         ):
             return
 
+        is_scramble_eligible_squadron = (
+            squadron.coalition.player.is_red
+            and (
+                squadron.aircraft.capable_of(FlightType.BARCAP)
+                or squadron.aircraft.capable_of(FlightType.SWEEP)
+            )
+            and not (
+                squadron.aircraft.flyable
+                and (
+                    self.game.settings.enable_squadron_pilot_limits
+                    or squadron.number_of_available_pilots > 0
+                )
+                and self.game.settings.untasked_opfor_client_slots
+            )
+        )
+
         for _ in range(squadron.untasked_aircraft):
+            scramble_group_count = self.scramble_groups_by_control_point.get(
+                squadron.location, 0
+            )
+            can_be_scramble = (
+                is_scramble_eligible_squadron
+                and scramble_group_count < MAX_SCRAMBLE_GROUPS_PER_AIRFIELD
+            )
             # Creating a flight even those this isn't a fragged mission lets us
-            # reuse the existing debriefing code.
-            # TODO: Special flight type?
+            # reuse the existing debriefing code. Use BARCAP for A/A loadout
+            # selection, but name idle RED fighters as Scramble/QRA assets.
             flight = Flight(
                 Package(squadron.location, self.game.db.flights),
                 squadron,
@@ -258,6 +285,9 @@ class AircraftGenerator:
                 FlightType.BARCAP,
                 StartType.COLD,
                 divert=None,
+                custom_name=(
+                    f"{squadron.location.name} Scramble" if can_be_scramble else None
+                ),
                 claim_inv=False,
             )
             flight.state = Completed(flight, self.game.settings)
@@ -287,6 +317,15 @@ class AircraftGenerator:
                     )
                     group.uncontrolled = False
                     group.units[0].skill = Skill.Client
+                # Reactive GCI scramble pool: a RED group left uncontrolled (cold
+                # on the ramp) that can fly air-to-air becomes a dormant
+                # interceptor. reactive_scramble.lua wakes the nearest one when a
+                # Blue threat is detected by the RED radar network.
+                if group.uncontrolled and can_be_scramble:
+                    self.mission_data.scramble_pool.append(group.name)
+                    self.scramble_groups_by_control_point[squadron.location] = (
+                        scramble_group_count + 1
+                    )
                 AircraftPainter(flight, group).apply_livery()
                 self.unit_map.add_aircraft(group, flight)
 

--- a/game/missiongenerator/luagenerator.py
+++ b/game/missiongenerator/luagenerator.py
@@ -41,10 +41,31 @@ class LuaGenerator:
             x for x in self.mission.triggerrules.triggers if isinstance(x, TriggerStart)
         ]
         self.generate_plugin_data()
+        # reactive_scramble.lua is injected below only when a scramble pool
+        # exists, so skip any plugin script work order to avoid double-loading.
+        self.bypass_plugin_script("scramble")
         self.inject_plugins()
+        self._inject_scramble_script()
         for t in ewrj_triggers:
             self.mission.triggerrules.triggers.remove(t)
             self.mission.triggerrules.triggers.append(t)
+
+    def _inject_scramble_script(self) -> None:
+        """Inject reactive_scramble.lua as a core mission script."""
+        if not self.mission_data.scramble_pool:
+            return
+        script_path = Path("./resources/plugins/scramble/reactive_scramble.lua")
+        if not script_path.exists():
+            logging.error(
+                "reactive_scramble.lua not found at %s - RED scramble pool will "
+                "stay dormant",
+                script_path.resolve(),
+            )
+            return
+        trigger = TriggerStart(comment="Load reactive_scramble (core GCI)")
+        fileref = self.mission.map_resource.add_resource_file(script_path.resolve())
+        trigger.add_action(DoScriptFile(fileref))
+        self.mission.triggerrules.triggers.append(trigger)
 
     def generate_plugin_data(self) -> None:
         lua_data = LuaData("dcsRetribution")
@@ -294,6 +315,19 @@ class LuaGenerator:
         trigger = TriggerStart(comment="Set DCS Retribution data")
         trigger.add_action(DoScript(String(lua_data.create_operations_lua())))
         self.mission.triggerrules.triggers.append(trigger)
+
+        # Emit the RED reactive-GCI scramble pool: names of uncontrolled untasked
+        # A/A groups collected in AircraftGenerator._spawn_unused_for.
+        if self.mission_data.scramble_pool:
+            lines = ["dcsRetribution.scramble_pool = {}"]
+            for name in self.mission_data.scramble_pool:
+                lines.append(
+                    "dcsRetribution.scramble_pool[#dcsRetribution.scramble_pool + 1]"
+                    f' = "{escape_string_for_lua(name)}"'
+                )
+            pool_trigger = TriggerStart(comment="Set DCS Retribution scramble pool")
+            pool_trigger.add_action(DoScript(String("\n".join(lines))))
+            self.mission.triggerrules.triggers.append(pool_trigger)
 
     def inject_lua_trigger(self, contents: str, comment: str) -> None:
         trigger = TriggerStart(comment=comment)

--- a/game/missiongenerator/missiondata.py
+++ b/game/missiongenerator/missiondata.py
@@ -125,3 +125,7 @@ class MissionData:
     cp_stack: dict[UUID, Distance] = field(default_factory=dict)
     player_frontline_groups: list[FrontlineUnitGroupsInfo] = field(default_factory=list)
     enemy_frontline_groups: list[FrontlineUnitGroupsInfo] = field(default_factory=list)
+    # Names of RED uncontrolled untasked A/A groups eligible for reactive GCI
+    # scramble. Emitted to the mission as dcsRetribution.scramble_pool and read
+    # by reactive_scramble.lua.
+    scramble_pool: list[str] = field(default_factory=list)

--- a/resources/plugins/plugins.json
+++ b/resources/plugins/plugins.json
@@ -6,13 +6,14 @@
     "bigeye",
     "dismounts",
     "ewrj",
+    "scramble",
     "ewrs",
     "herculescargo",
     "lotatc",
     "skynetiads",
     "splashdamage3",
     "airboss",
-    "MooseSoundhandler",    
+    "MooseSoundhandler",
     "MooseAutolase",
     "MooseMarkerOps"
 ]

--- a/resources/plugins/scramble/plugin.json
+++ b/resources/plugins/scramble/plugin.json
@@ -1,0 +1,23 @@
+{
+    "skipUI": false,
+    "nameInUI": "GCI Scramble",
+    "defaultValue": true,
+    "specificOptions": [
+        {
+            "nameInUI": "Intercept radius (NM)",
+            "mnemonic": "engageRadius",
+            "defaultValue": 51,
+            "minimumValue": 10,
+            "maximumValue": 160
+        },
+        {
+            "nameInUI": "Re-engage cooldown (seconds)",
+            "mnemonic": "reengageDelay",
+            "defaultValue": 180,
+            "minimumValue": 30,
+            "maximumValue": 600
+        }
+    ],
+    "scriptsWorkOrders": [],
+    "configurationWorkOrders": []
+}

--- a/resources/plugins/scramble/reactive_scramble.lua
+++ b/resources/plugins/scramble/reactive_scramble.lua
@@ -1,0 +1,224 @@
+-- ============================================================================
+-- REACTIVE SCRAMBLE v2.0 (Retribution GCI Scramble Plugin)
+-- Bundled automatically into every Retribution-generated .miz that has a
+-- non-empty RED untasked-aircraft scramble pool.
+-- ============================================================================
+--
+-- Retribution spawns each RED squadron's leftover untasked aircraft cold on the
+-- ramp as uncontrolled groups. The mission generator records the air-to-air
+-- capable groups in dcsRetribution.scramble_pool.
+--
+-- This script holds those groups dormant until a Blue aircraft is detected by
+-- the RED radar network within CFG_engageRadius, then wakes the nearest
+-- available one with StartUncontrolled and tasks it to intercept.
+--
+-- Cold-ramp behavior is intentional: an idle group starts cold, taxis, takes
+-- off, and hunts. Nothing flies until a threat appears.
+-- ============================================================================
+
+local CFG_scanInterval  = 15      -- seconds between threat scans
+local CFG_engageRadius  = 95000   -- metres, about 51 nm
+local CFG_reengageDelay = 180     -- seconds before a busy group re-qualifies
+local CFG_spawnDelay    = 1.0     -- seconds between Start command and setTask
+
+-- Retribution plugin config override. The config table is written by the
+-- mission-start data trigger, so read it on the next tick.
+timer.scheduleFunction(function()
+    if not (dcsRetribution and dcsRetribution.plugins and dcsRetribution.plugins.scramble) then return end
+    local c = dcsRetribution.plugins.scramble
+    if c.engageRadius ~= nil then CFG_engageRadius = c.engageRadius * 1852 end
+    if c.reengageDelay ~= nil then CFG_reengageDelay = c.reengageDelay end
+end, nil, timer.getTime() + 0)
+
+local _groups = {} -- name -> record
+
+local function log(msg)
+    BASE:E("=== SCRAMBLE: " .. tostring(msg))
+end
+
+local function dist3D(p1, p2)
+    local dx = p1.x - p2.x
+    local dy = (p1.y or 0) - (p2.y or 0)
+    local dz = p1.z - p2.z
+    return math.sqrt(dx * dx + dy * dy + dz * dz)
+end
+
+local function taskIntercept(rec)
+    local mg = GROUP:FindByName(rec.name)
+    if not mg or not mg:IsAlive() then return end
+
+    rec.group = mg
+    mg:OptionROEWeaponFree()
+    mg:OptionROTEvadeFire()
+
+    local ctrl = mg:GetController()
+    if ctrl then
+        ctrl:setTask({
+            id = "EngageTargets",
+            params = {
+                targetTypes = { "Air" },
+                maxDist = CFG_engageRadius,
+                priority = 0,
+            },
+        })
+    end
+end
+
+-- Wake a dormant uncontrolled group, then task it after a short delay so DCS
+-- finishes processing the Start command before setTask fires.
+local function spawnAndIntercept(rec)
+    local mg = GROUP:FindByName(rec.name)
+    if not mg then
+        log("ERROR: cannot find pool group: " .. rec.name)
+        return
+    end
+
+    rec.group = mg
+    rec.spawned = true
+    mg:StartUncontrolled()
+    log("Waking dormant group: " .. rec.name)
+
+    timer.scheduleFunction(function()
+        taskIntercept(rec)
+    end, nil, timer.getTime() + CFG_spawnDelay)
+end
+
+-- The pool table is written by a TriggerStart DoScript. Read it on the next
+-- tick so it is populated before registration.
+timer.scheduleFunction(function()
+    local pool = dcsRetribution and dcsRetribution.scramble_pool
+    if not pool then
+        log("WARNING: dcsRetribution.scramble_pool not available - no interceptors registered")
+        return
+    end
+
+    for _, name in ipairs(pool) do
+        if not _groups[name] then
+            local mg = GROUP:FindByName(name)
+            _groups[name] = {
+                name = name,
+                group = mg,
+                busy = false,
+                lastTasked = 0,
+                spawned = false,
+            }
+            log("Registered dormant interceptor: " .. name)
+        end
+    end
+end, nil, timer.getTime() + 0.1)
+
+local function getRedRadarPositions()
+    local pts = {}
+    for _, cat in ipairs({ Group.Category.GROUND, Group.Category.SHIP }) do
+        for _, g in ipairs(coalition.getGroups(coalition.side.RED, cat) or {}) do
+            if g and g:isExist() then
+                for _, u in ipairs(g:getUnits() or {}) do
+                    if u and u:isExist() then
+                        local d = u:getDesc()
+                        if d and d.sensor and d.sensor.radar then
+                            pts[#pts + 1] = u:getPoint()
+                            break
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return pts
+end
+
+local function detectBlueThreats(radarPts)
+    local threats = {}
+    local seen = {}
+
+    for _, g in ipairs(coalition.getGroups(coalition.side.BLUE, Group.Category.AIRPLANE) or {}) do
+        if g and g:isExist() and not seen[g:getName()] then
+            local units = g:getUnits()
+            local u = units and units[1]
+            if u and u:isExist() then
+                local pos = u:getPoint()
+                for _, rp in ipairs(radarPts) do
+                    if dist3D(pos, rp) <= CFG_engageRadius then
+                        threats[#threats + 1] = { group = g, pos = pos }
+                        seen[g:getName()] = true
+                        break
+                    end
+                end
+            end
+        end
+    end
+
+    return threats
+end
+
+-- Pick the nearest available pool group to the threat. Dormant groups report
+-- their parked position, so distance ranking works before they wake.
+local function selectGroup(threatPos)
+    local now = timer.getTime()
+    local best = nil
+    local bestDist = math.huge
+
+    for _, rec in pairs(_groups) do
+        local available = not rec.busy or (now - rec.lastTasked) > CFG_reengageDelay
+        local mg = rec.group or GROUP:FindByName(rec.name)
+        if available and mg and mg:IsAlive() then
+            rec.group = mg
+            local u1 = mg:GetUnit(1)
+            if u1 and u1:IsAlive() then
+                local d = dist3D(u1:GetVec3(), threatPos)
+                if d < bestDist then
+                    best = rec
+                    bestDist = d
+                end
+            end
+        end
+    end
+
+    return best
+end
+
+SCHEDULER:New(nil, function()
+    local radars = getRedRadarPositions()
+    if #radars == 0 then return end
+
+    local threats = detectBlueThreats(radars)
+
+    if #threats == 0 then
+        local now = timer.getTime()
+        for _, rec in pairs(_groups) do
+            if rec.busy and (now - rec.lastTasked) > CFG_reengageDelay then
+                rec.busy = false
+                log("Released: " .. rec.name)
+            end
+        end
+        return
+    end
+
+    for _, threat in ipairs(threats) do
+        local rec = selectGroup(threat.pos)
+        if rec then
+            local now = timer.getTime()
+            if not rec.busy or (now - rec.lastTasked) > CFG_reengageDelay then
+                rec.busy = true
+                rec.lastTasked = now
+
+                if rec.spawned then
+                    taskIntercept(rec)
+                else
+                    spawnAndIntercept(rec)
+                end
+
+                log("Scramble: " .. rec.name .. " -> " .. threat.group:getName())
+                MESSAGE:New("SCRAMBLE: interceptors launching!", 12):ToAll()
+            end
+        end
+    end
+end, {}, 10, CFG_scanInterval)
+
+timer.scheduleFunction(function()
+    local n = 0
+    for _ in pairs(_groups) do n = n + 1 end
+    log(string.format("ONLINE - %d dormant interceptor group(s)", n))
+    MESSAGE:New(string.format(
+        "REACTIVE SCRAMBLE ONLINE: %d dormant interceptor group(s)", n), 12):ToAll()
+end, nil, timer.getTime() + 2)


### PR DESCRIPTION
Adds reactive GCI scramble support using idle RED aircraft already generated by Retribution.
What changed:
Collects eligible RED untasked, uncontrolled, air-to-air-capable aircraft into a generated dcsRetribution.scramble_pool.
Names eligible dormant groups as <Airfield> Scramble.
Caps scramble assets to 4 dormant interceptor groups per airfield to avoid flooding missions with interceptors.
Injects reactive_scramble.lua only when the mission has a non-empty scramble pool.
Adds a GCI Scramble plugin entry with tunable intercept radius and re-engage cooldown.
Runtime Lua wakes the nearest available cold-ramp interceptor when Blue aircraft are detected by the RED radar network.
Reviewer notes:
This does not add a new FlightType.SCRAMBLE; it reuses existing idle BARCAP-capable aircraft and keeps them cold until triggered.
Lua behavior was checked by review and previous in-game testing
Python compile and import checks passed locally.