### PR TITLE
feat(intercept-qra): per-squadron QRA interceptors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[Mission Generator]** Per-squadron QRA interceptor reserve: OPFOR (and opt-in OWNFOR) squadrons scramble in-air interceptors via the Moose AI_A2A_DISPATCHER against incoming air-to-ground raids detected by the IADS/EWR network. Scramble/engage radius, spawn altitude, grouping, and radio callouts are campaign-doctrine settings.
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.

--- a/game/campaignloader/defaultsquadronassigner.py
+++ b/game/campaignloader/defaultsquadronassigner.py
@@ -5,6 +5,7 @@ import random
 from typing import Optional, TYPE_CHECKING
 
 from game.squadrons import Squadron
+from game.squadrons.intercept_reserve import seeded_intercept_reserve
 from game.squadrons.squadrondef import SquadronDef
 from .campaignairwingconfig import CampaignAirWingConfig, SquadronConfig
 from ..ato.flighttype import FlightType
@@ -49,6 +50,16 @@ class DefaultSquadronAssigner:
                     control_point,
                     self.coalition,
                     self.game,
+                )
+                if self.coalition.player.is_blue:
+                    default_qra_reserve = self.game.settings.ownfor_default_qra_reserve
+                else:
+                    default_qra_reserve = self.game.settings.opfor_default_qra_reserve
+                squadron.intercept_reserve = seeded_intercept_reserve(
+                    squadron.capable_of(FlightType.BARCAP),
+                    squadron.intercept_reserve,
+                    default_qra_reserve,
+                    squadron.max_size,
                 )
                 squadron.set_auto_assignable_mission_types(
                     squadron_config.auto_assignable

--- a/game/campaignloader/squadrondefgenerator.py
+++ b/game/campaignloader/squadrondefgenerator.py
@@ -55,6 +55,7 @@ class SquadronDefGenerator:
             operating_bases=OperatingBases.default_for_aircraft(aircraft),
             female_pilot_percentage=6,
             pilot_pool=[],
+            intercept_reserve=0,
         )
 
     @staticmethod

--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -167,9 +167,12 @@ class StateData:
             else:
                 killed_ground_units.append(unit)
 
-        intercept_survivors = {
-            str(k): int(v) for k, v in data.get("intercept_survivors", {}).items()
-        }
+        raw_survivors = data.get("intercept_survivors", {})
+        # An empty Lua table serializes to a JSON array ([]) rather than an
+        # object, so coerce any non-dict to an empty mapping before iterating.
+        if not isinstance(raw_survivors, dict):
+            raw_survivors = {}
+        intercept_survivors = {str(k): int(v) for k, v in raw_survivors.items()}
 
         return cls(
             mission_ended=data.get("mission_ended", False),

--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -18,6 +18,10 @@ from uuid import UUID
 
 from game.dcs.aircrafttype import AircraftType
 from game.dcs.groundunittype import GroundUnitType
+from game.missiongenerator.interceptattrition import (
+    fielded_qra_by_squadron,
+    reconcile_intercept_losses,
+)
 from game.theater import Airfield, ControlPoint, Player
 
 if TYPE_CHECKING:
@@ -127,6 +131,10 @@ class StateData:
     #: Mangled names of bases that were captured during the mission.
     base_capture_events: List[str]
 
+    #: Per-squadron QRA survivor counts reported by the intercept plugin,
+    #: keyed by stringified squadron UUID.
+    intercept_survivors: dict[str, int]
+
     @classmethod
     def from_json(cls, data: Dict[str, Any], unit_map: UnitMap) -> StateData:
         def clean_unit_list(unit_list: List[Any]) -> List[str]:
@@ -159,12 +167,17 @@ class StateData:
             else:
                 killed_ground_units.append(unit)
 
+        intercept_survivors = {
+            str(k): int(v) for k, v in data.get("intercept_survivors", {}).items()
+        }
+
         return cls(
             mission_ended=data.get("mission_ended", False),
             killed_aircraft=killed_aircraft,
             killed_ground_units=killed_ground_units,
             destroyed_statics=data.get("destroyed_objects_positions", []),
             base_capture_events=data.get("base_capture_events", []),
+            intercept_survivors=intercept_survivors,
         )
 
 
@@ -315,6 +328,43 @@ class Debriefing:
             losses_by_type[loss.trigger_zone.name] += 1
         return losses_by_type
 
+    def qra_losses_by_type(self, player: Player) -> Dict[AircraftType, int]:
+        """QRA interceptor losses for one coalition, keyed by aircraft type.
+
+        QRA groups are Moose-spawned, not ATO flights, so they never appear in
+        dead_aircraft()/air_losses and would otherwise be missing from the debrief
+        report (the squadron inventory is still debited by
+        MissionResultsProcessor.commit_intercept_losses). Their attrition is
+        survivor-count based; mirror that computation here so the debrief totals and
+        breakdown include them. This runs pre-commit (debrief_current_state, before
+        process_results), so owned_aircraft still reflects what was fielded.
+        """
+        survivors = self.state_data.intercept_survivors
+        squadrons = (
+            self.game.blue.air_wing.iter_squadrons()
+            if player.is_blue
+            else self.game.red.air_wing.iter_squadrons()
+        )
+        # Same fielded baseline as commit_intercept_losses, via the shared helper,
+        # so the reported losses match what the inventory is debited by.
+        fielded_by_squadron, squadrons_by_id = fielded_qra_by_squadron(squadrons)
+        losses_by_type: Dict[AircraftType, int] = defaultdict(int)
+        for squadron_id, loss in reconcile_intercept_losses(
+            fielded_by_squadron, survivors
+        ).items():
+            if loss > 0:
+                losses_by_type[squadrons_by_id[squadron_id].aircraft] += loss
+        return losses_by_type
+
+    def aircraft_losses_by_type(self, player: Player) -> Dict[AircraftType, int]:
+        """Aircraft losses by type including survivor-based QRA losses."""
+        merged: Dict[AircraftType, int] = defaultdict(int)
+        for unit_type, count in self.air_losses.by_type(player).items():
+            merged[unit_type] += count
+        for unit_type, count in self.qra_losses_by_type(player).items():
+            merged[unit_type] += count
+        return dict(merged)
+
     def loss_counts(self, player: Player) -> SideLossCounts:
         gl = self.ground_losses
         if player.is_blue:
@@ -338,7 +388,7 @@ class Debriefing:
             scenery = gl.enemy_scenery
             airfields = gl.enemy_airfields
         return SideLossCounts(
-            aircraft=len(air),
+            aircraft=len(air) + sum(self.qra_losses_by_type(player).values()),
             front_line=len(front_line),
             motorpool=len(motorpool),
             convoy=len(convoy),

--- a/game/game.py
+++ b/game/game.py
@@ -231,6 +231,20 @@ class Game:
     def air_wing_for(self, player: Player) -> AirWing:
         return self.coalition_for(player).air_wing
 
+    def repropagate_qra_reserves(self, old_ownfor: int, old_opfor: int) -> None:
+        """Re-apply changed QRA-reserve defaults to existing squadrons.
+
+        Called when the OWNFOR/OPFOR QRA defaults are edited mid-campaign. The
+        ``old_*`` values are the defaults before the change; the new values are
+        read from the current settings. OWNFOR maps to the blue wing, OPFOR to red.
+        """
+        self.blue.air_wing.repropagate_qra_reserve(
+            old_ownfor, self.settings.ownfor_default_qra_reserve
+        )
+        self.red.air_wing.repropagate_qra_reserve(
+            old_opfor, self.settings.opfor_default_qra_reserve
+        )
+
     @property
     def neutral_country(self) -> Country:
         """Return the best fitting country to use for the neutral coalition.

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -159,7 +159,12 @@ class Migrator:
                     if f.squadron == s:
                         count += f.count
                 s.return_all_pilots_and_aircraft()
-                new_claim = min(count, s.owned_aircraft)
+                # Claim against untasked_aircraft, not owned_aircraft: QRA squadrons
+                # hold intercept_reserve airframes back (untasked = owned - reserve),
+                # so an old save whose flights were planned against the full owned
+                # count would otherwise over-claim and raise in claim_inventory. For
+                # non-QRA squadrons (reserve 0) untasked == owned, so this is a no-op.
+                new_claim = min(count, s.untasked_aircraft)
                 s.claim_inventory(new_claim)
                 for i in range(new_claim):
                     s.claim_available_pilot()

--- a/game/missiongenerator/aircraft/aircraftgenerator.py
+++ b/game/missiongenerator/aircraft/aircraftgenerator.py
@@ -26,7 +26,12 @@ from game.ato.flighttype import FlightType
 from game.ato.package import Package
 from game.ato.starttype import StartType
 from game.missiongenerator.countryassigner import CountryAssigner
+from game.missiongenerator.interceptluadata import (
+    DEFAULT_BACKSTOP_EWR_TYPE,
+    InterceptEntry,
+)
 from game.missiongenerator.missiondata import MissionData
+from game.squadrons.intercept_reserve import qra_resource_count
 from game.radio.radios import RadioRegistry
 from game.radio.tacan import TacanRegistry
 from game.runways import RunwayData
@@ -229,6 +234,117 @@ class AircraftGenerator:
                 except NoParkingSlotError:
                     # If we run out of parking, stop spawning aircraft at this base.
                     break
+
+    def spawn_intercept_templates(
+        self, player_country: Country, enemy_country: Country
+    ) -> None:
+        """Emits a late-activated QRA template group for every Airfield squadron with
+        a QRA reserve and appends an InterceptEntry to mission_data.
+
+        Template groups are placed with late_activation=True so that the Moose
+        AI_A2A_DISPATCHER can spawn live intercept flights from them. FOBs and
+        other non-Airfield control points are silently skipped — the QRA system
+        only supports proper runways. Nothing is emitted when no squadron has a
+        QRA reserve (resource_count <= 0); the reserve is then left plannable
+        instead — see Squadron.return_all_pilots_and_aircraft.
+
+        QRA tuning (scramble radius, engagement range, radio callouts) is read
+        from the Campaign Doctrine settings and copied onto each InterceptEntry,
+        which carries it into the dcsRetribution.Intercept Lua table. Moose is
+        always loaded (base plugin), so there is no plugin to gate on — the QRA
+        reserves are the on/off switch.
+        """
+        engagement_range_nm = self.game.settings.qra_engagement_range_nm
+        gci_max_radius_nm = self.game.settings.qra_gci_max_radius_nm
+        comms_enabled = self.game.settings.qra_comms_enabled
+
+        for control_point in self.game.theater.controlpoints:
+            if not isinstance(control_point, Airfield):
+                continue
+
+            base_is_blue = control_point.captured.is_blue
+            country = player_country if base_is_blue else enemy_country
+
+            for squadron in control_point.squadrons:
+                if not squadron.capable_of(FlightType.BARCAP):
+                    continue
+
+                available_pilots = (
+                    squadron.number_of_available_pilots
+                    if squadron.pilot_limits_enabled
+                    else None
+                )
+                resource_count = qra_resource_count(
+                    squadron.intercept_reserve,
+                    squadron.owned_aircraft,
+                    available_pilots,
+                )
+                if resource_count <= 0:
+                    continue
+
+                template_prefix = f"Intercept|{control_point.name}|{squadron.id}"
+
+                flight = Flight(
+                    Package(squadron.location, self.game.db.flights),
+                    squadron,
+                    2,
+                    FlightType.BARCAP,
+                    StartType.COLD,
+                    divert=None,
+                    claim_inv=False,
+                )
+                flight.state = Completed(flight, self.game.settings)
+
+                try:
+                    group = FlightGroupSpawner(
+                        flight,
+                        country,
+                        self.mission,
+                        self.helipads,
+                        self.ground_spawns_roadbase,
+                        self.ground_spawns_large,
+                        self.ground_spawns,
+                        self.mission_data,
+                    ).create_intercept_template(template_prefix)
+                except NoParkingSlotError:
+                    logging.warning(
+                        f"No parking slots available for QRA template at "
+                        f"{control_point.name} ({squadron}); skipping intercept entry."
+                    )
+                    # Skip just this squadron's QRA template and continue with others
+                    # at this base; unlike untasked filler we don't abandon the whole
+                    # base.
+                    continue
+                else:
+                    if group is None:
+                        # create_intercept_template returns None for non-Airfield CPs;
+                        # this branch should not be reached since we filtered above.
+                        continue
+
+                    self.mission_data.intercept_entries.append(
+                        InterceptEntry(
+                            squadron_id=str(squadron.id),
+                            squadron_name=str(squadron),
+                            airbase_name=control_point.name,
+                            template_prefix=template_prefix,
+                            coalition="BLUE" if base_is_blue else "RED",
+                            resource_count=resource_count,
+                            engagement_range_nm=engagement_range_nm,
+                            gci_max_radius_nm=gci_max_radius_nm,
+                            comms_enabled=comms_enabled,
+                            country_id=country.id,
+                            backstop_ewr_type=DEFAULT_BACKSTOP_EWR_TYPE[
+                                "BLUE" if base_is_blue else "RED"
+                            ],
+                        )
+                    )
+                finally:
+                    # The template Flight claimed pilots from the squadron via its
+                    # roster (count=2); return them so they are not missing from the
+                    # QRA loss baseline at mission end. Generation and results
+                    # processing share one Game, and pilots are otherwise only
+                    # returned at end-of-turn, after losses commit.
+                    flight.roster.clear()
 
     def _spawn_unused_for(self, squadron: Squadron, country: Country) -> None:
         assert isinstance(squadron.location, Airfield) or isinstance(

--- a/game/missiongenerator/aircraft/aircraftgenerator.py
+++ b/game/missiongenerator/aircraft/aircraftgenerator.py
@@ -258,6 +258,15 @@ class AircraftGenerator:
         for control_point in self.game.theater.controlpoints:
             if not isinstance(control_point, Airfield):
                 continue
+            # A cratered runway cannot launch jets, so field no QRA there; the
+            # reserve auto-resumes once the runway repairs. Mirrors the normal-
+            # flight runway guard in generate_flights. debug, not warning: a downed
+            # runway skipping QRA is expected and recurs every turn until repair.
+            if not control_point.runway_is_operational():
+                logging.debug(
+                    f"Runway not operational, skipping QRA at {control_point.name}"
+                )
+                continue
 
             base_is_blue = control_point.captured.is_blue
             country = player_country if base_is_blue else enemy_country

--- a/game/missiongenerator/aircraft/aircraftgenerator.py
+++ b/game/missiongenerator/aircraft/aircraftgenerator.py
@@ -26,10 +26,7 @@ from game.ato.flighttype import FlightType
 from game.ato.package import Package
 from game.ato.starttype import StartType
 from game.missiongenerator.countryassigner import CountryAssigner
-from game.missiongenerator.interceptluadata import (
-    DEFAULT_BACKSTOP_EWR_TYPE,
-    InterceptEntry,
-)
+from game.missiongenerator.interceptluadata import InterceptEntry
 from game.missiongenerator.missiondata import MissionData
 from game.squadrons.intercept_reserve import qra_resource_count
 from game.radio.radios import RadioRegistry
@@ -332,10 +329,6 @@ class AircraftGenerator:
                             engagement_range_nm=engagement_range_nm,
                             gci_max_radius_nm=gci_max_radius_nm,
                             comms_enabled=comms_enabled,
-                            country_id=country.id,
-                            backstop_ewr_type=DEFAULT_BACKSTOP_EWR_TYPE[
-                                "BLUE" if base_is_blue else "RED"
-                            ],
                         )
                     )
                 finally:

--- a/game/missiongenerator/aircraft/flightgroupspawner.py
+++ b/game/missiongenerator/aircraft/flightgroupspawner.py
@@ -58,6 +58,14 @@ RTB_ALTITUDE = meters(800)
 RTB_DISTANCE = 5000
 HELI_ALT = 500
 
+#: Initial air-start speed (m/s) seeded onto QRA interceptor templates. Moose's
+#: in-air spawn (AI_A2A_DISPATCHER SetDefaultTakeoffInAir) applies the template's
+#: first-waypoint speed as starting velocity but sets none of its own; a parked
+#: template's waypoint speed is ~0, which stalls high-stall-speed early jets (e.g.
+#: MiG-19P) before the dispatcher tasks them ~5s later. 150 m/s (~291 kt) clears
+#: their stall margin without being excessive. DCS waypoint speed is m/s.
+QRA_AIRSTART_SPEED_MS = 150.0
+
 
 class FlightGroupSpawner:
     def __init__(
@@ -125,33 +133,62 @@ class FlightGroupSpawner:
                 cp=self.flight.squadron.location,
             )
         elif isinstance(cp, Airfield):
-            # TODO: remove hack when fixed in DCS
-            slots = None
-            if self._check_nevatim_hack(cp):
-                ac_type = self.flight.unit_type.dcs_unit_type
-                slots = [
-                    slot
-                    for slot in cp.dcs_airport.free_parking_slots(ac_type)
-                    if slot.slot_name in [str(n) for n in range(55, 66)]
-                ]
-            elif self._check_ramon_airbase_hack(cp):
-                ac_type = self.flight.unit_type.dcs_unit_type
-                slots = [
-                    slot
-                    for slot in cp.dcs_airport.free_parking_slots(ac_type)
-                    if slot.slot_name
-                    not in [
-                        str(n) for n in [1, 2, 3, 4, 5, 6, 13, 14, 15, 16, 17, 18, 61]
-                    ]
-                ]
             group = self._generate_at_airfield(
                 name=namegen.next_aircraft_name(self.country, self.flight),
                 airfield=cp,
-                parking_slots=slots,
+                parking_slots=self._restricted_parking_slots(cp),
             )
         if group:
             group.uncontrolled = True
         return group
+
+    def create_intercept_template(self, group_name: str) -> Optional[FlyingGroup[Any]]:
+        """Creates a late-activated QRA template group for Moose AI_A2A_DISPATCHER.
+
+        The group is placed at the airfield (it still needs a valid parking slot
+        for the .miz, hence _restricted_parking_slots) with late_activation=True;
+        the dispatcher then fresh-spawns live intercept flights from it in-air on
+        scramble (SetDefaultTakeoffInAir — see intercept-config.lua for why every
+        ground spawn was abandoned). The caller builds a Flight with count=2 (the
+        standard Moose dispatcher grouping) before constructing this spawner.
+
+        Returns None when the squadron is not based at an Airfield (e.g. FOBs
+        are not supported by the QRA system).
+        """
+        cp = self.flight.squadron.location
+        if not isinstance(cp, Airfield):
+            return None
+        group = self._generate_at_airfield(
+            name=group_name,
+            airfield=cp,
+            parking_slots=self._restricted_parking_slots(cp),
+        )
+        # Seed a real air-start speed so Moose's in-air scramble (which copies the
+        # template's waypoint speed and sets none itself) does not drop the jets in
+        # at ~0 and stall early types like the MiG-19P. See QRA_AIRSTART_SPEED_MS.
+        for point in group.points:
+            point.speed = QRA_AIRSTART_SPEED_MS
+        group.late_activation = True
+        return group
+
+    def _restricted_parking_slots(self, cp: Airfield) -> Optional[List[ParkingSlot]]:
+        # TODO: remove hack when fixed in DCS
+        if self._check_nevatim_hack(cp):
+            ac_type = self.flight.unit_type.dcs_unit_type
+            return [
+                slot
+                for slot in cp.dcs_airport.free_parking_slots(ac_type)
+                if slot.slot_name in [str(n) for n in range(55, 66)]
+            ]
+        if self._check_ramon_airbase_hack(cp):
+            ac_type = self.flight.unit_type.dcs_unit_type
+            return [
+                slot
+                for slot in cp.dcs_airport.free_parking_slots(ac_type)
+                if slot.slot_name
+                not in [str(n) for n in [1, 2, 3, 4, 5, 6, 13, 14, 15, 16, 17, 18, 61]]
+            ]
+        return None
 
     @property
     def start_type(self) -> StartType:

--- a/game/missiongenerator/aircraft/flightgroupspawner.py
+++ b/game/missiongenerator/aircraft/flightgroupspawner.py
@@ -150,7 +150,9 @@ class FlightGroupSpawner:
         the dispatcher then fresh-spawns live intercept flights from it in-air on
         scramble (SetDefaultTakeoffInAir — see intercept-config.lua for why every
         ground spawn was abandoned). The caller builds a Flight with count=2 (the
-        standard Moose dispatcher grouping) before constructing this spawner.
+        max dispatcher grouping; Moose spawns 1 or 2 per scramble via
+        InitGrouping, set per squadron in intercept-config.lua) before building
+        this spawner.
 
         Returns None when the squadron is not based at an Airfield (e.g. FOBs
         are not supported by the QRA system).

--- a/game/missiongenerator/interceptattrition.py
+++ b/game/missiongenerator/interceptattrition.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable, Mapping
+
+from game.squadrons.intercept_reserve import qra_resource_count
+
+if TYPE_CHECKING:
+    from game.squadrons.squadron import Squadron
+
+
+def fielded_qra_by_squadron(
+    squadrons: Iterable["Squadron"],
+) -> tuple[dict[str, int], dict[str, "Squadron"]]:
+    """QRA airframes actually fielded on alert, keyed by stringified squadron id.
+
+    The "fielded" baseline is the reserve capped by owned airframes and untasked
+    pilots — what the dispatcher was seeded with and what the Lua bounds survivors
+    by. Squadrons with no reserve, or that can field nothing (no airframes/pilots),
+    are omitted. Returns the fielded counts plus an id -> squadron lookup.
+
+    Single source of truth so the debrief loss report (``qra_losses_by_type``) and
+    the inventory debit (``commit_intercept_losses``) compute the same baseline; if
+    they drifted, the reported totals and the committed losses would diverge.
+    """
+    fielded_by_squadron: dict[str, int] = {}
+    squadrons_by_id: dict[str, "Squadron"] = {}
+    for squadron in squadrons:
+        if squadron.intercept_reserve <= 0:
+            continue
+        available_pilots = (
+            squadron.number_of_available_pilots
+            if squadron.pilot_limits_enabled
+            else None
+        )
+        fielded = qra_resource_count(
+            squadron.intercept_reserve, squadron.owned_aircraft, available_pilots
+        )
+        if fielded <= 0:
+            continue
+        fielded_by_squadron[str(squadron.id)] = fielded
+        squadrons_by_id[str(squadron.id)] = squadron
+    return fielded_by_squadron, squadrons_by_id
+
+
+def reconcile_intercept_losses(
+    fielded_by_squadron: Mapping[str, int],
+    survivors_by_squadron: Mapping[str, int],
+) -> dict[str, int]:
+    """QRA losses per squadron = fielded airframes − survivors reported by Lua.
+
+    ``fielded_by_squadron`` is the count actually put on alert (the reserve capped
+    by owned airframes and untasked pilots), which is what the dispatcher was
+    seeded with and what the Lua bounds survivors by. The survivor map is the
+    authoritative record of which squadrons actually flew QRA: a squadron *absent*
+    from the map never participated (carrier/FOB, no detection sources, plugin
+    disabled, or no parking) and takes no loss. A squadron *present* with zero
+    survivors is a genuine total loss. Survivor counts are clamped to the fielded
+    count so a stale over-count cannot credit phantom airframes. Squadrons present
+    only in the survivor map are ignored.
+    """
+    losses: dict[str, int] = {}
+    for squadron_id, fielded in fielded_by_squadron.items():
+        if squadron_id not in survivors_by_squadron:
+            continue
+        survivors = max(0, min(survivors_by_squadron[squadron_id], fielded))
+        losses[squadron_id] = fielded - survivors
+    return losses

--- a/game/missiongenerator/interceptluadata.py
+++ b/game/missiongenerator/interceptluadata.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Iterable
+
+if TYPE_CHECKING:
+    from game.missiongenerator.luagenerator import LuaData
+
+
+#: Fallback backstop-EWR DCS type per coalition. These are stock EWR units that
+#: ship with the base game; the Lua skips a base's backstop if the type is not
+#: present in the running DCS build (see intercept-config.lua).
+DEFAULT_BACKSTOP_EWR_TYPE = {"BLUE": "FPS-117", "RED": "55G6 EWR"}
+
+
+@dataclass(frozen=True)
+class InterceptEntry:
+    squadron_id: str
+    squadron_name: str
+    airbase_name: str
+    template_prefix: str
+    coalition: str  # "BLUE" or "RED"
+    resource_count: int
+    engagement_range_nm: int
+    gci_max_radius_nm: int
+    comms_enabled: bool
+    #: DCS country id, used by the Lua to spawn the per-base backstop EWR in the
+    #: correct coalition.
+    country_id: int
+    #: DCS unit type for the per-base backstop EWR.
+    backstop_ewr_type: str
+
+
+def populate_intercept_lua(root: "LuaData", entries: Iterable[InterceptEntry]) -> None:
+    """Build the ``dcsRetribution.Intercept`` subtree (mirrors the IADS pattern).
+
+    Always creates BLUE and RED buckets so the Lua side can iterate them
+    unconditionally, then appends one record per reserved squadron.
+    """
+    intercept = root.add_item("Intercept")
+    buckets = {
+        "BLUE": intercept.get_or_create_item("BLUE"),
+        "RED": intercept.get_or_create_item("RED"),
+    }
+    for entry in entries:
+        record = buckets[entry.coalition].add_item()
+        record.add_key_value("squadronId", entry.squadron_id)
+        record.add_key_value("squadronName", entry.squadron_name)
+        record.add_key_value("airbaseName", entry.airbase_name)
+        record.add_key_value("templatePrefix", entry.template_prefix)
+        record.add_key_value("resourceCount", str(entry.resource_count))
+        record.add_key_value("engagementRangeNm", str(entry.engagement_range_nm))
+        record.add_key_value("gciMaxRadiusNm", str(entry.gci_max_radius_nm))
+        record.add_key_value("commsEnabled", "true" if entry.comms_enabled else "false")
+        record.add_key_value("countryId", str(entry.country_id))
+        record.add_key_value("backstopEwrType", entry.backstop_ewr_type)

--- a/game/missiongenerator/interceptluadata.py
+++ b/game/missiongenerator/interceptluadata.py
@@ -7,12 +7,6 @@ if TYPE_CHECKING:
     from game.missiongenerator.luagenerator import LuaData
 
 
-#: Fallback backstop-EWR DCS type per coalition. These are stock EWR units that
-#: ship with the base game; the Lua skips a base's backstop if the type is not
-#: present in the running DCS build (see intercept-config.lua).
-DEFAULT_BACKSTOP_EWR_TYPE = {"BLUE": "FPS-117", "RED": "55G6 EWR"}
-
-
 @dataclass(frozen=True)
 class InterceptEntry:
     squadron_id: str
@@ -24,11 +18,6 @@ class InterceptEntry:
     engagement_range_nm: int
     gci_max_radius_nm: int
     comms_enabled: bool
-    #: DCS country id, used by the Lua to spawn the per-base backstop EWR in the
-    #: correct coalition.
-    country_id: int
-    #: DCS unit type for the per-base backstop EWR.
-    backstop_ewr_type: str
 
 
 def populate_intercept_lua(root: "LuaData", entries: Iterable[InterceptEntry]) -> None:
@@ -52,5 +41,3 @@ def populate_intercept_lua(root: "LuaData", entries: Iterable[InterceptEntry]) -
         record.add_key_value("engagementRangeNm", str(entry.engagement_range_nm))
         record.add_key_value("gciMaxRadiusNm", str(entry.gci_max_radius_nm))
         record.add_key_value("commsEnabled", "true" if entry.comms_enabled else "false")
-        record.add_key_value("countryId", str(entry.country_id))
-        record.add_key_value("backstopEwrType", entry.backstop_ewr_type)

--- a/game/missiongenerator/luagenerator.py
+++ b/game/missiongenerator/luagenerator.py
@@ -18,6 +18,7 @@ from game.plugins import LuaPluginManager
 from game.theater import TheaterGroundObject
 from game.theater.iadsnetwork.iadsrole import IadsRole
 from game.utils import escape_string_for_lua
+from .interceptluadata import populate_intercept_lua
 from .missiondata import MissionData
 
 if TYPE_CHECKING:
@@ -228,6 +229,8 @@ class LuaGenerator:
                     iads_element.add_key_value(property, value)
             for role, connections in node.connections.items():
                 iads_element.add_data_array(role, connections)
+
+        populate_intercept_lua(lua_data, self.mission_data.intercept_entries)
 
         # Add artillery and support units info
         artillery_object = lua_data.add_item("artilleryGroups")

--- a/game/missiongenerator/missiondata.py
+++ b/game/missiongenerator/missiondata.py
@@ -10,6 +10,7 @@ from dcs.unitgroup import ShipGroup
 from game.dcs.aircrafttype import AircraftType
 from game.dcs.groundunittype import GroundUnitType
 from game.missiongenerator.aircraft.flightdata import FlightData
+from game.missiongenerator.interceptluadata import InterceptEntry
 from game.runways import RunwayData
 
 if TYPE_CHECKING:
@@ -125,3 +126,4 @@ class MissionData:
     cp_stack: dict[UUID, Distance] = field(default_factory=dict)
     player_frontline_groups: list[FrontlineUnitGroupsInfo] = field(default_factory=list)
     enemy_frontline_groups: list[FrontlineUnitGroupsInfo] = field(default_factory=list)
+    intercept_entries: list[InterceptEntry] = field(default_factory=list)

--- a/game/missiongenerator/missiongenerator.py
+++ b/game/missiongenerator/missiongenerator.py
@@ -304,6 +304,11 @@ class MissionGenerator:
             self.game.red.ato,
             tgo_generator.runways,
         )
+        # QRA alert jets claim parking before untasked filler aircraft.
+        aircraft_generator.spawn_intercept_templates(
+            self.p_country,
+            self.e_country,
+        )
         aircraft_generator.spawn_unused_aircraft()
 
         self.mission_data.flights = aircraft_generator.flights

--- a/game/naming.py
+++ b/game/naming.py
@@ -479,10 +479,14 @@ class NameGenerator:
     @classmethod
     def next_aircraft_name(cls, country: Country, flight: Flight) -> str:
         cls.aircraft_number += 1
-        if flight.custom_name:
-            name_str = flight.custom_name
-        else:
-            name_str = "{} {}".format(flight.package.target.name, flight.flight_type)
+        # Always append the flight type so the first "|"-field keeps the
+        # "<name> <task>" convention debrief attribution and the Moose QRA
+        # task-type filter (dr-99hm) rely on. A custom name alone would drop the
+        # task, making a custom-named flight unclassifiable downstream.
+        prefix = (
+            flight.custom_name if flight.custom_name else flight.package.target.name
+        )
+        name_str = "{} {}".format(prefix, flight.flight_type)
         return "{}|{}|{}|{}|".format(
             name_str, country.id, cls.aircraft_number, flight.unit_type.variant_id
         )

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -210,6 +210,67 @@ class Settings:
         detail="Implicitly determines the number of BARCAPs planned by taking the mission duration"
         " and dividing it by the desired on-station time.",
     )
+    ownfor_default_qra_reserve: int = bounded_int_option(
+        "Default QRA reserve per OWNFOR interceptor squadron",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=0,
+        min=0,
+        max=12,
+        detail=(
+            "At new-game start, seeds this many QRA (hot-alert intercept) aircraft "
+            "for each BARCAP-capable OWNFOR squadron. Per-squadron values can be "
+            "edited afterward and are saved with the campaign."
+        ),
+    )
+    opfor_default_qra_reserve: int = bounded_int_option(
+        "Default QRA reserve per OPFOR interceptor squadron",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=0,
+        min=0,
+        max=12,
+        detail=(
+            "At new-game start, seeds this many QRA (hot-alert intercept) aircraft "
+            "for each BARCAP-capable OPFOR squadron. Lets OPFOR lean on interception "
+            "independently of OWNFOR. Per-squadron values can be edited afterward."
+        ),
+    )
+    qra_gci_max_radius_nm: int = bounded_int_option(
+        "QRA GCI max scramble radius (NM)",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=100,
+        min=1,
+        max=400,
+        detail=(
+            "Caps how close a detected raid must be to a defended base before that "
+            "base's QRA scrambles. Detection range itself comes from the IADS/EWR "
+            "network; this only gates the scramble trigger distance."
+        ),
+    )
+    qra_engagement_range_nm: int = bounded_int_option(
+        "QRA interceptor engagement range (NM)",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=60,
+        min=1,
+        max=200,
+        detail=(
+            "How far a scrambled interceptor chases a target (Moose SetEngageRadius) "
+            "before disengaging."
+        ),
+    )
+    qra_comms_enabled: bool = boolean_option(
+        "QRA radio scramble callouts",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=True,
+        detail=(
+            "Enables the dispatcher's defender-POV radio/text callouts (scramble, "
+            "wheels up, engaging, RTB) on the coalition F10 menu and radio TTS."
+        ),
+    )
     desired_awacs_mission_duration: timedelta = minutes_option(
         "Desired AWACS on-station time",
         page=CAMPAIGN_DOCTRINE_PAGE,

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -240,7 +240,7 @@ class Settings:
         "QRA GCI max scramble radius (NM)",
         page=CAMPAIGN_DOCTRINE_PAGE,
         section=GENERAL_SECTION,
-        default=100,
+        default=60,
         min=1,
         max=400,
         detail=(
@@ -253,7 +253,7 @@ class Settings:
         "QRA interceptor engagement range (NM)",
         page=CAMPAIGN_DOCTRINE_PAGE,
         section=GENERAL_SECTION,
-        default=60,
+        default=38,
         min=1,
         max=200,
         detail=(

--- a/game/sim/missionresultsprocessor.py
+++ b/game/sim/missionresultsprocessor.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING
 
 from game.debriefing import Debriefing
 from game.ground_forces.combat_stance import CombatStance
+from game.missiongenerator.interceptattrition import (
+    fielded_qra_by_squadron,
+    reconcile_intercept_losses,
+)
 from game.profiling import logged_duration
+from game.squadrons.squadron import Squadron
 from game.theater import ControlPoint
 from .gameupdateevents import GameUpdateEvents
 from ..ato.airtaaskingorder import AirTaskingOrder
@@ -27,6 +32,8 @@ class MissionResultsProcessor:
         with logged_duration("Committing mission results"):
             with logged_duration("commit_air_losses"):
                 self.commit_air_losses(debriefing)
+            with logged_duration("commit_intercept_losses"):
+                self.commit_intercept_losses(debriefing)
             with logged_duration("commit_pilot_experience"):
                 self.commit_pilot_experience()
             with logged_duration("commit_front_line_losses"):
@@ -75,6 +82,32 @@ class MissionResultsProcessor:
             logging.info(f"{aircraft} destroyed from {squadron}")
             squadron.owned_aircraft -= 1
             squadron.destroyed_aircraft += 1
+
+    def commit_intercept_losses(self, debriefing: Debriefing) -> None:
+        all_squadrons: list[Squadron] = list(
+            self.game.blue.air_wing.iter_squadrons()
+        ) + list(self.game.red.air_wing.iter_squadrons())
+
+        # Shared baseline (see fielded_qra_by_squadron): the count actually fielded
+        # on alert, matching what the dispatcher was seeded with and what the Lua
+        # bounds survivors by, and identical to the debrief report's computation.
+        fielded_by_squadron, squadrons_by_id = fielded_qra_by_squadron(all_squadrons)
+
+        if not fielded_by_squadron:
+            return
+
+        losses = reconcile_intercept_losses(
+            fielded_by_squadron, debriefing.state_data.intercept_survivors
+        )
+        for squadron_id, loss in losses.items():
+            if loss <= 0:
+                continue
+            squadron = squadrons_by_id.get(squadron_id)
+            if squadron is None:
+                continue
+            logging.info(f"{loss} QRA aircraft lost from {squadron}")
+            squadron.owned_aircraft = max(0, squadron.owned_aircraft - loss)
+            squadron.lose_pilots(loss)
 
     @staticmethod
     def _commit_pilot_experience(ato: AirTaskingOrder) -> None:

--- a/game/squadrons/airwing.py
+++ b/game/squadrons/airwing.py
@@ -161,6 +161,27 @@ class AirWing:
     def iter_squadrons(self) -> Iterator[Squadron]:
         return itertools.chain.from_iterable(self.squadrons.values())
 
+    def repropagate_qra_reserve(self, old_default: int, new_default: int) -> None:
+        """Re-apply a changed QRA-reserve default to this wing's squadrons.
+
+        BARCAP-capable squadrons still carrying the (clamped) old default move to
+        the clamped new default; everything else is untouched. No-op when the
+        default did not change.
+        """
+        if old_default == new_default:
+            return
+        from ..ato.flighttype import FlightType
+        from .intercept_reserve import repropagated_intercept_reserve
+
+        for squadron in self.iter_squadrons():
+            squadron.intercept_reserve = repropagated_intercept_reserve(
+                squadron.capable_of(FlightType.BARCAP),
+                squadron.intercept_reserve,
+                old_default,
+                new_default,
+                squadron.max_size,
+            )
+
     def squadron_at_index(self, index: int) -> Squadron:
         return list(self.iter_squadrons())[index]
 

--- a/game/squadrons/airwing.py
+++ b/game/squadrons/airwing.py
@@ -174,12 +174,17 @@ class AirWing:
         from .intercept_reserve import repropagated_intercept_reserve
 
         for squadron in self.iter_squadrons():
-            squadron.intercept_reserve = repropagated_intercept_reserve(
-                squadron.capable_of(FlightType.BARCAP),
-                squadron.intercept_reserve,
-                old_default,
-                new_default,
-                squadron.max_size,
+            # set_intercept_reserve (not a direct write) so untasked_aircraft stays
+            # in sync: this runs from the settings window mid-turn with no following
+            # initialize_turn, so a bare assignment would leave the planner pool stale.
+            squadron.set_intercept_reserve(
+                repropagated_intercept_reserve(
+                    squadron.capable_of(FlightType.BARCAP),
+                    squadron.intercept_reserve,
+                    old_default,
+                    new_default,
+                    squadron.max_size,
+                )
             )
 
     def squadron_at_index(self, index: int) -> Squadron:

--- a/game/squadrons/intercept_reserve.py
+++ b/game/squadrons/intercept_reserve.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Optional
+
+
+def clamp_intercept_reserve(value: int, max_size: int) -> int:
+    """Constrain a QRA reserve to ``0 <= reserve <= max_size``.
+
+    Applied when a reserve enters a ``Squadron`` from an external source (a
+    squadron definition / campaign YAML) where the value is not bounded by the
+    UI spinner.
+    """
+    return max(0, min(value, max_size))
+
+
+def qra_resource_count(
+    intercept_reserve: int,
+    owned_aircraft: int,
+    available_pilots: Optional[int] = None,
+) -> int:
+    """Airframes actually fielded on QRA: the reserve capped by what can fly it.
+
+    ``intercept_reserve`` is a fixed setting, but a squadron cannot field more QRA
+    jets than it has airframes (``owned_aircraft``, which falls with attrition) or
+    untasked pilots to fly them. ``available_pilots`` is the untasked pilot count;
+    pass ``None`` when pilot limits are disabled (pilots are then unconstrained).
+    """
+    count = max(0, min(intercept_reserve, owned_aircraft))
+    if available_pilots is not None:
+        count = min(count, max(0, available_pilots))
+    return count
+
+
+def seeded_intercept_reserve(
+    capable_of_barcap: bool,
+    current_reserve: int,
+    default_reserve: int,
+    max_size: int,
+) -> int:
+    """Return the QRA reserve a squadron should start a new campaign with.
+
+    The per-side ``ownfor_default_qra_reserve`` / ``opfor_default_qra_reserve`` settings seed BARCAP-capable squadrons
+    that do not already carry an explicit reserve. A squadron that cannot fly
+    BARCAP, or one already carrying an explicit non-zero reserve (e.g. from a
+    squadron definition), is left unchanged. The result never exceeds
+    ``max_size``.
+    """
+    if not capable_of_barcap:
+        return current_reserve
+    if current_reserve != 0:
+        return current_reserve
+    return min(default_reserve, max_size)
+
+
+def repropagated_intercept_reserve(
+    capable_of_barcap: bool,
+    current_reserve: int,
+    old_default: int,
+    new_default: int,
+    max_size: int,
+) -> int:
+    """QRA reserve after a coalition default changes old -> new on a live campaign.
+
+    Symmetric with ``seeded_intercept_reserve`` but for a default edited
+    mid-campaign rather than at new-game seeding. A BARCAP-capable squadron whose
+    reserve still equals the *clamped* old default is moved to the clamped new
+    default; squadrons that cannot fly BARCAP, or that the user has set to any
+    other value, are left unchanged. The result never exceeds ``max_size``.
+    """
+    if not capable_of_barcap:
+        return current_reserve
+    if current_reserve != clamp_intercept_reserve(old_default, max_size):
+        return current_reserve
+    return clamp_intercept_reserve(new_default, max_size)

--- a/game/squadrons/intercept_reserve.py
+++ b/game/squadrons/intercept_reserve.py
@@ -48,7 +48,7 @@ def max_intercept_reserve(
 
 
 def untasked_after_reserve_change(
-    old_reserve: int, new_reserve: int, untasked_aircraft: int
+    old_reserve: int, new_reserve: int, untasked_aircraft: int, owned_aircraft: int
 ) -> int:
     """Plannable-aircraft count after a mid-turn QRA reserve edit.
 
@@ -57,10 +57,17 @@ def untasked_after_reserve_change(
     between turns must reflect in the plannable pool immediately, but a full
     reset would return airframes already tasked to flights this turn. Adjust by
     the reserve delta instead: freeing reserve (``old > new``) releases jets into
-    the pool; raising it benches only jets that are still untasked. Floored at 0 —
-    already-tasked flights are never retroactively un-planned.
+    the pool; raising it benches only jets that are still untasked.
+
+    Bounded on both ends: floored at 0 (already-tasked flights are never
+    retroactively un-planned) and capped at ``owned_aircraft - new_reserve`` (the
+    airframes that actually exist beyond the new reserve). The cap matters after
+    attrition leaves ``owned < reserve``: ``return_all_pilots_and_aircraft`` floors
+    that to untasked 0, discarding the negative, so the delta alone would inflate
+    the pool above the jets on hand.
     """
-    return max(0, untasked_aircraft + (old_reserve - new_reserve))
+    adjusted = untasked_aircraft + (old_reserve - new_reserve)
+    return max(0, min(adjusted, owned_aircraft - new_reserve))
 
 
 def seeded_intercept_reserve(

--- a/game/squadrons/intercept_reserve.py
+++ b/game/squadrons/intercept_reserve.py
@@ -31,6 +31,22 @@ def qra_resource_count(
     return count
 
 
+def max_intercept_reserve(
+    untasked_aircraft: int, intercept_reserve: int, max_size: int
+) -> int:
+    """Highest QRA reserve settable given aircraft already tasked this turn.
+
+    Aircraft tasked to flights cannot be pulled onto QRA, so the reserve can only
+    rise to the unplanned airframes plus what is already reserved:
+    ``untasked_aircraft + intercept_reserve`` equals ``owned - tasked`` by the turn
+    invariant (``tasked + untasked + reserve == owned``). This sum is stable under
+    ``untasked_after_reserve_change`` (which trades untasked for reserve), so it is
+    a fixed ceiling while the reserve spinner is edited. Also bounded by
+    ``max_size``.
+    """
+    return min(max_size, untasked_aircraft + intercept_reserve)
+
+
 def untasked_after_reserve_change(
     old_reserve: int, new_reserve: int, untasked_aircraft: int
 ) -> int:

--- a/game/squadrons/intercept_reserve.py
+++ b/game/squadrons/intercept_reserve.py
@@ -31,6 +31,22 @@ def qra_resource_count(
     return count
 
 
+def untasked_after_reserve_change(
+    old_reserve: int, new_reserve: int, untasked_aircraft: int
+) -> int:
+    """Plannable-aircraft count after a mid-turn QRA reserve edit.
+
+    ``untasked_aircraft`` is only recomputed from ``owned - reserve`` at
+    ``return_all_pilots_and_aircraft`` (turn init). Editing the reserve spinner
+    between turns must reflect in the plannable pool immediately, but a full
+    reset would return airframes already tasked to flights this turn. Adjust by
+    the reserve delta instead: freeing reserve (``old > new``) releases jets into
+    the pool; raising it benches only jets that are still untasked. Floored at 0 —
+    already-tasked flights are never retroactively un-planned.
+    """
+    return max(0, untasked_aircraft + (old_reserve - new_reserve))
+
+
 def seeded_intercept_reserve(
     capable_of_barcap: bool,
     current_reserve: int,

--- a/game/squadrons/squadron.py
+++ b/game/squadrons/squadron.py
@@ -17,6 +17,7 @@ from game.ato import Flight, FlightType, Package
 from game.settings import AutoAtoBehavior, Settings
 from game.theater import ParkingType
 from game.theater.player import Player
+from .intercept_reserve import clamp_intercept_reserve
 from .pilot import Pilot, PilotStatus
 from .pilotnames import faker_for_country
 from ..db.database import Database
@@ -82,6 +83,9 @@ class Squadron:
 
     use_livery_set: bool = False  # if livery-set should be used when present
 
+    #: Number of airframes held on QRA (hot-alert intercept). 0 = none.
+    intercept_reserve: int = 0
+
     def __setstate__(self, state: dict[str, Any]) -> None:
         if "id" not in state:
             state["id"] = uuid4()
@@ -95,6 +99,8 @@ class Squadron:
             state["destroyed_aircraft"] = 0
         if "purchased_aircraft" not in state:
             state["purchased_aircraft"] = 0
+        if "intercept_reserve" not in state:
+            state["intercept_reserve"] = 0
         self.__dict__.update(state)
 
     def __str__(self) -> str:
@@ -265,7 +271,31 @@ class Squadron:
 
     def return_all_pilots_and_aircraft(self) -> None:
         self.available_pilots = list(self.active_pilots)
-        self.untasked_aircraft = self.owned_aircraft
+        # QRA-reserved airframes are held hot on alert by the intercept dispatcher,
+        # so they are not available to the auto-planner or spawned as ramp filler.
+        # The reserve (intercept_reserve > 0) is the single on/off switch for the
+        # whole QRA system: emission (spawn_intercept_templates) and loss commit
+        # (commit_intercept_losses) gate on it alone, so benching must too — gating
+        # this one site on the plugin flag would let a reserve be both ATO-plannable
+        # and fielded as QRA. A zero reserve leaves the full count untasked.
+        self.untasked_aircraft = max(0, self.owned_aircraft - self.intercept_reserve)
+
+    def lose_pilots(self, count: int) -> None:
+        """Kill ``count`` pilots to account for lost airframes (e.g. QRA attrition).
+
+        Only *untasked* pilots (``available_pilots``) are eligible: pilots claimed
+        by a flight this turn flew a different mission and must not die for a QRA
+        loss. QRA jets are AI-flown, so AI pilots are killed first to spare the
+        player's named pilots; player pilots are only killed when not protected by
+        ``invulnerable_player_pilots``. Kills fewer than ``count`` if too few
+        untasked pilots remain.
+        """
+        candidates = [p for p in self.available_pilots if not p.player]
+        if not self.settings.invulnerable_player_pilots:
+            candidates += [p for p in self.available_pilots if p.player]
+        for pilot in candidates[:count]:
+            pilot.kill()
+            self.available_pilots.remove(pilot)
 
     @staticmethod
     def send_on_leave(pilot: Pilot) -> None:
@@ -614,4 +644,7 @@ class Squadron:
             game.db.flights,
             game.settings,
             base,
+            intercept_reserve=clamp_intercept_reserve(
+                squadron_def.intercept_reserve, max_size
+            ),
         )

--- a/game/squadrons/squadron.py
+++ b/game/squadrons/squadron.py
@@ -294,7 +294,7 @@ class Squadron:
         flights.
         """
         self.untasked_aircraft = untasked_after_reserve_change(
-            self.intercept_reserve, value, self.untasked_aircraft
+            self.intercept_reserve, value, self.untasked_aircraft, self.owned_aircraft
         )
         self.intercept_reserve = value
 

--- a/game/squadrons/squadron.py
+++ b/game/squadrons/squadron.py
@@ -17,7 +17,10 @@ from game.ato import Flight, FlightType, Package
 from game.settings import AutoAtoBehavior, Settings
 from game.theater import ParkingType
 from game.theater.player import Player
-from .intercept_reserve import clamp_intercept_reserve
+from .intercept_reserve import (
+    clamp_intercept_reserve,
+    untasked_after_reserve_change,
+)
 from .pilot import Pilot, PilotStatus
 from .pilotnames import faker_for_country
 from ..db.database import Database
@@ -279,6 +282,21 @@ class Squadron:
         # this one site on the plugin flag would let a reserve be both ATO-plannable
         # and fielded as QRA. A zero reserve leaves the full count untasked.
         self.untasked_aircraft = max(0, self.owned_aircraft - self.intercept_reserve)
+
+    def set_intercept_reserve(self, value: int) -> None:
+        """Set the QRA reserve and reflect the change in the plannable pool now.
+
+        The planner reads ``untasked_aircraft``, which is otherwise only
+        recomputed at turn init. Editing the reserve between turns adjusts the
+        pool by the delta so freed jets are immediately available (and newly
+        reserved jets immediately benched) without a full
+        ``return_all_pilots_and_aircraft`` reset that would return already-tasked
+        flights.
+        """
+        self.untasked_aircraft = untasked_after_reserve_change(
+            self.intercept_reserve, value, self.untasked_aircraft
+        )
+        self.intercept_reserve = value
 
     def lose_pilots(self, count: int) -> None:
         """Kill ``count`` pilots to account for lost airframes (e.g. QRA attrition).

--- a/game/squadrons/squadrondef.py
+++ b/game/squadrons/squadrondef.py
@@ -34,6 +34,8 @@ class SquadronDef:
     female_pilot_percentage: int
     pilot_pool: list[Pilot]
     claimed: bool = False
+    #: Number of airframes held on QRA (hot-alert intercept). 0 = none.
+    intercept_reserve: int = 0
 
     def __str__(self) -> str:
         if self.nickname is None:
@@ -110,4 +112,5 @@ class SquadronDef:
             operating_bases=OperatingBases.from_yaml(unit_type, data.get("bases", {})),
             female_pilot_percentage=female_pilot_percentage,
             pilot_pool=pilots,
+            intercept_reserve=data.get("intercept_reserve", 0),
         )

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -256,6 +256,23 @@ class SquadronConfigurationBox(QGroupBox):
         self.max_size_selector.valueChanged.connect(self.update_max_size)
         size_column.addWidget(self.max_size_selector)
 
+        size_column.addWidget(QLabel("QRA reserve:"))
+        self.qra_reserve_selector = QSpinBox(self)
+        self.qra_reserve_selector.lineEdit().setEnabled(False)
+        self.qra_reserve_selector.setToolTip(
+            "Aircraft held on quick-reaction alert; scramble airborne to intercept. "
+            "Bounded by the squadron's max size."
+        )
+        self.qra_reserve_selector.setMinimum(0)
+        self.qra_reserve_selector.setMaximum(self.squadron.max_size)
+        self.qra_reserve_selector.setValue(self.squadron.intercept_reserve)
+        if not self.squadron.capable_of(FlightType.BARCAP):
+            self.qra_reserve_selector.setEnabled(False)
+            self.qra_reserve_selector.setToolTip(
+                "QRA is only available for fixed-wing squadrons capable of BARCAP."
+            )
+        size_column.addWidget(self.qra_reserve_selector)
+
         task_column = QVBoxLayout()
         task_and_size_row.addLayout(task_column)
         task_column.addWidget(QLabel("Primary task:"))
@@ -326,6 +343,8 @@ class SquadronConfigurationBox(QGroupBox):
             index = self.livery_selector.findText(self.squadron.livery)
             self.livery_selector.setCurrentIndex(index)
             self.max_size_selector.setValue(self.squadron.max_size)
+            self.qra_reserve_selector.setMaximum(self.squadron.max_size)
+            self.qra_reserve_selector.setValue(self.squadron.intercept_reserve)
             self.base_selector.setCurrentText(self.squadron.location.name)
             self.player_list.setText(
                 "<br />".join(p.name for p in self.claim_players_from_squadron())
@@ -357,6 +376,11 @@ class SquadronConfigurationBox(QGroupBox):
 
     def update_max_size(self) -> None:
         self.squadron.max_size = self.max_size_selector.value()
+        self.qra_reserve_selector.setMaximum(self.max_size_selector.value())
+        # max_size is written to the model live (above); mirror the now-clamped
+        # reserve so the model never transiently holds intercept_reserve > max_size
+        # between here and apply(). setMaximum has already clamped the spinner value.
+        self.squadron.intercept_reserve = self.qra_reserve_selector.value()
         self.parking_tracker.signal_change()
 
     def relocate_squadron(self) -> None:
@@ -433,6 +457,7 @@ class SquadronConfigurationBox(QGroupBox):
         self.squadron.name = self.name_edit.text()
         self.squadron.nickname = self.nickname_edit.text()
         self.squadron.max_size = self.max_size_selector.value()
+        self.squadron.intercept_reserve = self.qra_reserve_selector.value()
         if (primary_task := self.primary_task_selector.selected_task) is not None:
             self.squadron.primary_task = primary_task
         else:

--- a/qt_ui/windows/AirWingConfigurationDialog.py
+++ b/qt_ui/windows/AirWingConfigurationDialog.py
@@ -380,7 +380,9 @@ class SquadronConfigurationBox(QGroupBox):
         # max_size is written to the model live (above); mirror the now-clamped
         # reserve so the model never transiently holds intercept_reserve > max_size
         # between here and apply(). setMaximum has already clamped the spinner value.
-        self.squadron.intercept_reserve = self.qra_reserve_selector.value()
+        # Route through set_intercept_reserve so untasked_aircraft stays consistent
+        # even if the dialog is rejected (reject does not re-run initialize_turn).
+        self.squadron.set_intercept_reserve(self.qra_reserve_selector.value())
         self.parking_tracker.signal_change()
 
     def relocate_squadron(self) -> None:
@@ -457,7 +459,11 @@ class SquadronConfigurationBox(QGroupBox):
         self.squadron.name = self.name_edit.text()
         self.squadron.nickname = self.nickname_edit.text()
         self.squadron.max_size = self.max_size_selector.value()
-        self.squadron.intercept_reserve = self.qra_reserve_selector.value()
+        # Route through set_intercept_reserve (not a bare write) so untasked_aircraft
+        # stays in sync. accept() re-runs initialize_turn only at turn > 0; the turn-0
+        # setup path and save_config's apply() have no reinit, so a direct write would
+        # leave the planner pool stale.
+        self.squadron.set_intercept_reserve(self.qra_reserve_selector.value())
         if (primary_task := self.primary_task_selector.selected_task) is not None:
             self.squadron.primary_task = primary_task
         else:

--- a/qt_ui/windows/QDebriefingWindow.py
+++ b/qt_ui/windows/QDebriefingWindow.py
@@ -25,7 +25,7 @@ class LossGrid(QGridLayout):
         super().__init__()
 
         self.add_loss_rows(
-            debriefing.air_losses.by_type(player), lambda u: u.display_name
+            debriefing.aircraft_losses_by_type(player), lambda u: u.display_name
         )
         self.add_loss_rows(
             debriefing.front_line_losses_by_type(player), lambda u: str(u)

--- a/qt_ui/windows/SquadronDialog.py
+++ b/qt_ui/windows/SquadronDialog.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QListView,
     QPushButton,
+    QSpinBox,
     QVBoxLayout,
     QApplication,
     QInputDialog,
@@ -331,6 +332,24 @@ class SquadronDialog(QDialog):
 
             self._refresh_aircraft_controls()
 
+        left_column.addWidget(QLabel("QRA reserve"))
+        self.qra_reserve_selector = QSpinBox()
+        self.qra_reserve_selector.lineEdit().setEnabled(False)
+        self.qra_reserve_selector.setToolTip(
+            "Aircraft held on quick-reaction alert; scramble airborne to intercept. "
+            "Bounded by the squadron's max size."
+        )
+        self.qra_reserve_selector.setMinimum(0)
+        self.qra_reserve_selector.setMaximum(self.squadron.max_size)
+        self.qra_reserve_selector.setValue(self.squadron.intercept_reserve)
+        if not self.squadron.capable_of(FlightType.BARCAP):
+            self.qra_reserve_selector.setEnabled(False)
+            self.qra_reserve_selector.setToolTip(
+                "QRA is only available for fixed-wing squadrons capable of BARCAP."
+            )
+        self.qra_reserve_selector.valueChanged.connect(self.on_qra_reserve_changed)
+        left_column.addWidget(self.qra_reserve_selector)
+
         auto_assigned_tasks = AutoAssignedTaskControls(squadron_model)
         left_column.addLayout(auto_assigned_tasks)
 
@@ -387,6 +406,9 @@ class SquadronDialog(QDialog):
     @property
     def squadron(self) -> Squadron:
         return self.squadron_model.squadron
+
+    def on_qra_reserve_changed(self, value: int) -> None:
+        self.squadron.intercept_reserve = value
 
     def _aircraft_stats_text(self) -> str:
         s = self.squadron

--- a/qt_ui/windows/SquadronDialog.py
+++ b/qt_ui/windows/SquadronDialog.py
@@ -408,7 +408,10 @@ class SquadronDialog(QDialog):
         return self.squadron_model.squadron
 
     def on_qra_reserve_changed(self, value: int) -> None:
-        self.squadron.intercept_reserve = value
+        # set_intercept_reserve also updates untasked_aircraft so the freed (or
+        # newly reserved) jets are immediately available to the planner this turn,
+        # rather than only after the next turn's return_all_pilots_and_aircraft.
+        self.squadron.set_intercept_reserve(value)
 
     def _aircraft_stats_text(self) -> str:
         s = self.squadron

--- a/qt_ui/windows/SquadronDialog.py
+++ b/qt_ui/windows/SquadronDialog.py
@@ -29,6 +29,7 @@ from game.purchaseadapter import AircraftPurchaseAdapter, TransactionError
 from game.server import EventStream
 from game.sim import GameUpdateEvents
 from game.squadrons import Pilot, Squadron
+from game.squadrons.intercept_reserve import max_intercept_reserve
 from game.theater import ConflictTheater, ControlPoint, ParkingType
 from qt_ui.delegates import TwoColumnRowDelegate
 from qt_ui.errorreporter import report_errors
@@ -337,10 +338,18 @@ class SquadronDialog(QDialog):
         self.qra_reserve_selector.lineEdit().setEnabled(False)
         self.qra_reserve_selector.setToolTip(
             "Aircraft held on quick-reaction alert; scramble airborne to intercept. "
-            "Bounded by the squadron's max size."
+            "Capped at the airframes not already tasked to flights this turn."
         )
         self.qra_reserve_selector.setMinimum(0)
-        self.qra_reserve_selector.setMaximum(self.squadron.max_size)
+        # Aircraft already tasked to flights cannot be pulled onto QRA, so cap the
+        # reserve at the unplanned airframes (owned - tasked = untasked + reserve).
+        self.qra_reserve_selector.setMaximum(
+            max_intercept_reserve(
+                self.squadron.untasked_aircraft,
+                self.squadron.intercept_reserve,
+                self.squadron.max_size,
+            )
+        )
         self.qra_reserve_selector.setValue(self.squadron.intercept_reserve)
         if not self.squadron.capable_of(FlightType.BARCAP):
             self.qra_reserve_selector.setEnabled(False)

--- a/qt_ui/windows/basemenu/QBaseMenu2.py
+++ b/qt_ui/windows/basemenu/QBaseMenu2.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
 
 from game import Game
 from game.ato.flighttype import FlightType
+from game.squadrons.intercept_reserve import qra_resource_count
 from game.config import RUNWAY_REPAIR_COST
 from game.radio.ICLSContainer import ICLSContainer
 from game.radio.RadioFrequencyContainer import RadioFrequencyContainer
@@ -332,10 +333,23 @@ class QBaseMenu2(QDialog):
         mixed_parking = [
             slot for slot in self.cp.parking_slots if slot.helicopter and slot.airplanes
         ]
+        qra_alert = sum(
+            qra_resource_count(
+                squadron.intercept_reserve,
+                squadron.owned_aircraft,
+                (
+                    squadron.number_of_available_pilots
+                    if squadron.pilot_limits_enabled
+                    else None
+                ),
+            )
+            for squadron in self.cp.squadrons
+        )
         self.intel_summary.setText(
             "\n".join(
                 [
                     f"{aircraft}/{parking} aircraft",
+                    f"{qra_alert} on QRA alert",
                     f"{len(fixed_wing_airfield_parking)} fixed-wing only parking",
                     f"{len(rotary_wing_airfield_parking) + helipads} rotary-wing only parking",
                     f"{len(mixed_parking)} mixed parking",

--- a/qt_ui/windows/basemenu/QBaseMenu2.py
+++ b/qt_ui/windows/basemenu/QBaseMenu2.py
@@ -333,17 +333,24 @@ class QBaseMenu2(QDialog):
         mixed_parking = [
             slot for slot in self.cp.parking_slots if slot.helicopter and slot.airplanes
         ]
-        qra_alert = sum(
-            qra_resource_count(
-                squadron.intercept_reserve,
-                squadron.owned_aircraft,
-                (
-                    squadron.number_of_available_pilots
-                    if squadron.pilot_limits_enabled
-                    else None
-                ),
+        # A destroyed runway suppresses QRA entirely at mission generation
+        # (see AircraftGenerator.spawn_intercept_templates), so report 0 here
+        # rather than a phantom alert count the base can no longer scramble.
+        qra_alert = (
+            sum(
+                qra_resource_count(
+                    squadron.intercept_reserve,
+                    squadron.owned_aircraft,
+                    (
+                        squadron.number_of_available_pilots
+                        if squadron.pilot_limits_enabled
+                        else None
+                    ),
+                )
+                for squadron in self.cp.squadrons
             )
-            for squadron in self.cp.squadrons
+            if self.cp.runway_is_operational()
+            else 0
         )
         self.intel_summary.setText(
             "\n".join(

--- a/qt_ui/windows/basemenu/airfield/QAircraftRecruitmentMenu.py
+++ b/qt_ui/windows/basemenu/airfield/QAircraftRecruitmentMenu.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Set
 
 from PySide6.QtCore import Qt
@@ -7,10 +8,12 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QScrollArea,
+    QSpinBox,
     QVBoxLayout,
     QWidget,
 )
 
+from game.ato.flighttype import FlightType
 from game.dcs.aircrafttype import AircraftType
 from game.purchaseadapter import AircraftPurchaseAdapter
 from game.squadrons import Squadron
@@ -50,6 +53,7 @@ class QAircraftRecruitmentMenu(UnitTransactionFrame[Squadron]):
         )
         for row, squadron in enumerate(sorted_squadrons):
             self.add_purchase_row(squadron, task_box_layout, row)
+            task_box_layout.addLayout(self._qra_control(squadron), row, 4)
 
         stretch = QVBoxLayout()
         stretch.addStretch()
@@ -80,6 +84,36 @@ class QAircraftRecruitmentMenu(UnitTransactionFrame[Squadron]):
             main_layout.addWidget(transfer_box)
 
         self.setLayout(main_layout)
+
+    def _qra_control(self, squadron: Squadron) -> QVBoxLayout:
+        layout = QVBoxLayout()
+        label = QLabel("QRA")
+        label.setToolTip(
+            "Aircraft held on quick-reaction alert; scramble airborne to intercept."
+        )
+        layout.addWidget(label)
+        spinner = QSpinBox()
+        spinner.lineEdit().setEnabled(False)
+        spinner.setMinimum(0)
+        spinner.setMaximum(squadron.max_size)
+        spinner.setValue(squadron.intercept_reserve)
+        # Carry the descriptive tooltip on the spinner too (matching the other QRA
+        # dialogs); the non-BARCAP branch below overrides it with its own.
+        spinner.setToolTip(
+            "Aircraft held on quick-reaction alert; scramble airborne to intercept."
+        )
+        if not squadron.capable_of(FlightType.BARCAP):
+            spinner.setEnabled(False)
+            spinner.setToolTip(
+                "QRA is only available for fixed-wing squadrons capable of BARCAP."
+            )
+        spinner.valueChanged.connect(partial(self._set_reserve, squadron))
+        layout.addWidget(spinner)
+        return layout
+
+    @staticmethod
+    def _set_reserve(squadron: Squadron, value: int) -> None:
+        squadron.intercept_reserve = value
 
     def sell_tooltip(self, is_enabled: bool) -> str:
         if is_enabled:

--- a/qt_ui/windows/basemenu/airfield/QAircraftRecruitmentMenu.py
+++ b/qt_ui/windows/basemenu/airfield/QAircraftRecruitmentMenu.py
@@ -17,6 +17,7 @@ from game.ato.flighttype import FlightType
 from game.dcs.aircrafttype import AircraftType
 from game.purchaseadapter import AircraftPurchaseAdapter
 from game.squadrons import Squadron
+from game.squadrons.intercept_reserve import max_intercept_reserve
 from game.theater import ControlPoint, ParkingType
 from qt_ui.models import GameModel
 from qt_ui.uiconstants import ICONS
@@ -95,7 +96,15 @@ class QAircraftRecruitmentMenu(UnitTransactionFrame[Squadron]):
         spinner = QSpinBox()
         spinner.lineEdit().setEnabled(False)
         spinner.setMinimum(0)
-        spinner.setMaximum(squadron.max_size)
+        # Cap at unplanned airframes (owned - tasked = untasked + reserve); aircraft
+        # already tasked to flights this turn cannot be pulled onto QRA.
+        spinner.setMaximum(
+            max_intercept_reserve(
+                squadron.untasked_aircraft,
+                squadron.intercept_reserve,
+                squadron.max_size,
+            )
+        )
         spinner.setValue(squadron.intercept_reserve)
         # Carry the descriptive tooltip on the spinner too (matching the other QRA
         # dialogs); the non-BARCAP branch below overrides it with its own.
@@ -113,7 +122,9 @@ class QAircraftRecruitmentMenu(UnitTransactionFrame[Squadron]):
 
     @staticmethod
     def _set_reserve(squadron: Squadron, value: int) -> None:
-        squadron.intercept_reserve = value
+        # Route through set_intercept_reserve so untasked_aircraft (the planner's
+        # pool) updates immediately, instead of going stale until turn advance.
+        squadron.set_intercept_reserve(value)
 
     def sell_tooltip(self, is_enabled: bool) -> str:
         if is_enabled:

--- a/qt_ui/windows/settings/QSettingsWindow.py
+++ b/qt_ui/windows/settings/QSettingsWindow.py
@@ -348,6 +348,10 @@ class QSettingsWindow(QDialog):
     def __init__(self, game: Game):
         super().__init__()
         self.game = game
+        self._qra_reserve_baseline = (
+            game.settings.ownfor_default_qra_reserve,
+            game.settings.opfor_default_qra_reserve,
+        )
         self.setLayout(QSettingsWidget(game.settings, game).layout)
 
         self.setModal(True)
@@ -356,8 +360,17 @@ class QSettingsWindow(QDialog):
         self.setMinimumSize(840, 480)
 
     def closeEvent(self, event: QCloseEvent) -> None:
+        self._propagate_qra_reserve_changes()
         self._handle_mod_settings()
         super().closeEvent(event)
+
+    def _propagate_qra_reserve_changes(self) -> None:
+        old_ownfor, old_opfor = self._qra_reserve_baseline
+        if (
+            old_ownfor != self.game.settings.ownfor_default_qra_reserve
+            or old_opfor != self.game.settings.opfor_default_qra_reserve
+        ):
+            self.game.repropagate_qra_reserves(old_ownfor, old_opfor)
 
     def _handle_mod_settings(self) -> None:
         if self.game.settings.use_bandit_clouds:

--- a/resources/plugins/base/dcs_retribution.lua
+++ b/resources/plugins/base/dcs_retribution.lua
@@ -47,6 +47,7 @@ function write_state()
 		["kill_events"] = kill_events,
         ["mission_ended"] = mission_ended,
         ["destroyed_objects_positions"] = destroyed_objects_positions,
+        ["intercept_survivors"] = intercept_survivors or {},
     }
     local ok, write_error = pcall(function()
         fp:write(json:encode(game_state))

--- a/resources/plugins/intercept/intercept-config.lua
+++ b/resources/plugins/intercept/intercept-config.lua
@@ -1,0 +1,374 @@
+-- Intercept (QRA) — drives AI_A2A_DISPATCHER per coalition from
+-- dcsRetribution.Intercept. Aircraft are placed as late-activated template
+-- groups by the mission generator; ParkDefender spawns parked instances and
+-- recycles them on RTB, consuming a resource permanently on a kill.
+--
+-- Detection (dr-ktw0): the dispatcher's DETECTION_AREAS is fed from the real
+-- EWR/SAM-as-EWR group names published in dcsRetribution.IADS for the
+-- coalition (the same source Skynet uses). The previous FilterPrefixes("EWR")
+-- matched almost nothing, because DCS EWR group names are suffix-form
+-- ("1L13 EWR", "55G6 EWR").
+--
+-- Detection has two sources: the IADS EWR/SAM-as-EWR network (primary, wide
+-- area) and a hidden/invisible/immortal backstop EWR at each alert base
+-- (guaranteed fallback — catches anything that slips through or survives after
+-- the EWR network is destroyed). The backstop always spawns; it is independent
+-- of GciRadius.
+--
+-- GciRadius (groundControlledInterceptionMaxRadius, default 100 NM) caps how
+-- far from a base a detected raid can trigger a scramble. The dispatcher only
+-- scrambles GCI once AirbaseDistance <= GciRadius. The IADS network provides
+-- the real detection range; GciRadius just prevents scrambling against very
+-- distant threats heading elsewhere.
+--
+-- The backstop EWR DCS type is supplied per record by the mission generator
+-- (rec.backstopEwrType) rather than hardcoded here. If the type is unknown to
+-- the running DCS build, mist.dynAdd silently spawns nothing; we therefore
+-- verify each backstop group exists before trusting it as a detection source
+-- and fall back to the EWR network for that base otherwise.
+--
+-- Build timing: backstop EWRs are spawned with mist.dynAdd up front, but the
+-- detection SET_GROUP (and the dispatcher) are assembled BUILD_DELAY seconds
+-- later. mist.dynAdd registers a group via a birth event on the next frame, so
+-- a SET_GROUP:FilterStart() built synchronously would not yet see the backstop.
+-- The short delay lets the groups register first.
+--
+-- AI_A2A_DISPATCHER:New() calls self:__Start(5) internally — no explicit
+-- dispatcher:Start() call is needed or valid (no such method exists).
+--
+-- Spawn path: NON-VISIBLE / fresh-spawn-on-scramble. We deliberately do NOT
+-- call SetSquadronVisible. That keeps Moose's AI_A2A_DISPATCHER:ResourceActivate
+-- in its else branch, which spawns a fresh group at scramble time honoring the
+-- configured takeoff method (SetDefaultTakeoffInAir below).
+--
+-- Takeoff method history (all validated in-DCS):
+--   1. Visible/ParkDefender pre-park: ParkDefender hardcodes SPAWN.Takeoff.Cold
+--      (ignores SetDefaultTakeoff*), so F-16s sat cold and never completed the
+--      cold-start→taxi sequence. SetSquadronVisible also clamps ResourceCount to
+--      free parking spots and forces Grouping=1. Abandoned.
+--   2. Non-visible ParkingHot (warm): F-16s DID scramble warm but still never
+--      taxied out of congested ramps (e.g. Tiyas, packed with OCA + ~30 rotary
+--      BARCAP — confirmed in-DCS), while
+--      the identical code launched fine from uncluttered bases like H3. Ground
+--      movement, not takeoff method, was the blocker.
+--   3. Runway: SetDefaultTakeoffFromRunway spawned fine at uncluttered H3 (jets on
+--      the runway, immediate takeoff) but at saturated Tiyas Moose could not place
+--      them on the runway and dumped them into hangars, where they sat. Every
+--      ground spawn (cold/hot/runway) fails on a fully-packed ramp.
+--   4. In-air (current): the only method that escapes the congested ground. It was
+--      blocked by a Moose bug (air-spawn's BASE:CreateEventTakeoff is mis-scheduled
+--      → self is a plain table → self:F() crash → defenders never activate). The
+--      BASE.CreateEventTakeoff monkeypatch above repairs that without touching the
+--      vendored Moose.lua, so in-air now works. Upstream fix filed as MOOSE PR
+--      #2595 (Core/Spawn.lua: pass the args as varargs, not a single table);
+--      drop the monkeypatch once that lands in the vendored Moose.lua.
+--
+-- The non-visible path keeps full reserve and real 2-ship grouping (the visible
+-- path lost both).
+--
+-- SetSquadronGci speed args are in km/h (WaypointAir divides by 3.6 to get m/s).
+-- 900/1200 km/h ≈ 485/648 kt — reasonable for jet interceptors.
+
+env.info("DCSRetribution|Intercept: configuring QRA dispatchers")
+
+intercept_survivors = intercept_survivors or {}
+
+-- Registry: maps squadronId -> { dispatcher, squadronName }. Populated by the
+-- deferred dispatcher build (BUILD_DELAY seconds in), then read by the refresh
+-- loop.
+local intercept_registry = {}
+
+-- QRA tuning (comms, GCI radius, engagement range) is sourced from the Campaign
+-- Doctrine settings and carried on each Intercept record by the mission generator
+-- (gciMaxRadiusNm/engagementRangeNm/commsEnabled). The values are global, so each
+-- record in a coalition carries the same trio; build_dispatcher reads them from
+-- records[1]. add_key_value serializes everything as a string, hence tonumber()
+-- for the numerics and a string compare ("false") for the boolean.
+local NM = 1852  -- metres per nautical mile
+local DETECTION_GROUPING_M = 30000  -- contact-clustering radius for DETECTION_AREAS
+local BUILD_DELAY = 5  -- seconds; let mist.dynAdd backstops register before SET_GROUP
+
+-- ---------------------------------------------------------------------------
+-- MOOSE BUG WORKAROUND — air-spawn takeoff event
+-- Upstream fix filed as MOOSE PR #2595
+-- (https://github.com/FlightControl-Master/MOOSE/pull/2595). REMOVE THIS WHOLE
+-- `do … end` BLOCK once that PR is released and pulled into Retribution's
+-- vendored resources/plugins/base/Moose.lua — check the SpawnAtAirbase call site
+-- there passes the args as varargs (no surrounding braces) before deleting.
+-- Core/Spawn.lua SpawnAtAirbase schedules the synthetic takeoff event as:
+--   self:ScheduleOnce(5, BASE.CreateEventTakeoff, {GroupSpawned, time, dcsObject})
+-- ScheduleOnce forwards its trailing args as VARARGS, so that single table becomes
+-- argument #1 — i.e. CreateEventTakeoff runs with the {group,time,dcs} table as
+-- `self`. A plain table has no :F(), so the first line (self:F(...)) errors, the
+-- takeoff event never fires, and air-spawned AI_A2A_DISPATCHER defenders never
+-- activate (observed: zero QRA flew on either side with takeoff=Air). A sibling
+-- call site uses SCHEDULER:New(nil, fn, {args}, 5) — which DOES treat the table as
+-- the arg list — and is correct; the SpawnAtAirbase one is the regression.
+--
+-- We don't touch the vendored Moose.lua: override BASE.CreateEventTakeoff to
+-- detect the mis-packed call (self is the args table, has no :F) and fire a proper
+-- takeoff event; all well-formed calls delegate to the original untouched. Remove
+-- once the upstream fix is vendored. Upstream fix = drop the braces at that line so
+-- the args pass as varargs.
+-- ---------------------------------------------------------------------------
+do
+    local _orig_create_event_takeoff = BASE.CreateEventTakeoff
+    function BASE:CreateEventTakeoff(EventTime, Initiator)
+        if type(self) == "table" and type(self.F) ~= "function" then
+            -- self is the mis-packed {GroupSpawned, time, dcsObject} table.
+            world.onEvent({
+                id = world.event.S_EVENT_TAKEOFF,
+                time = self[2],
+                initiator = self[3],
+            })
+            return
+        end
+        return _orig_create_event_takeoff(self, EventTime, Initiator)
+    end
+end
+
+-- Collect the EWR / SAM-as-EWR group names the IADS generator published for a
+-- coalition. SamAsEwr entries already carry the DCS GROUP name, but standalone
+-- Ewr entries carry the UNIT name (Skynet convention: dcs_name_for_group
+-- returns unit_name for EWR/CC roles). SET_GROUP filters by group name, so we
+-- resolve unit names to their parent group via UNIT:FindByName → GetGroup.
+local function ewr_group_names(coalition_name)
+    local names = {}
+    local seen = {}
+    local iads = dcsRetribution.IADS and dcsRetribution.IADS[coalition_name]
+    if iads then
+        for _, role in ipairs({ "Ewr", "SamAsEwr" }) do
+            local list = iads[role]
+            if list then
+                for _, node in pairs(list) do
+                    if node.dcsGroupName then
+                        local group_name = node.dcsGroupName
+                        local grp = GROUP:FindByName(group_name)
+                        if not grp then
+                            local unit = UNIT:FindByName(group_name)
+                            if unit then
+                                local parent = unit:GetGroup()
+                                if parent then
+                                    group_name = parent:GetName()
+                                end
+                            end
+                        end
+                        if not seen[group_name] then
+                            seen[group_name] = true
+                            names[#names + 1] = group_name
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return names
+end
+
+-- Make the backstop EWR invisible to enemy AI and immortal so the backstop
+-- cannot be shot out. Deferred a few seconds so Moose has registered the
+-- freshly spawned group.
+local function protect_group(group_name)
+    mist.scheduleFunction(function()
+        local grp = GROUP:FindByName(group_name)
+        if grp then
+            grp:SetCommandInvisible(true)
+            grp:SetCommandImmortal(true)
+        end
+    end, {}, timer.getTime() + 5)
+end
+
+-- Attempts to spawn a hidden backstop EWR. Returns true when a spawn was issued
+-- (a valid type and country were supplied); the caller still verifies the group
+-- actually exists before relying on it, since mist.dynAdd drops unknown types.
+local function spawn_backstop_ewr(group_name, vec2, ewr_type, country_id)
+    if not ewr_type or ewr_type == "" or not country_id then
+        return false
+    end
+    mist.dynAdd({
+        countryId = country_id,
+        category = "vehicle",
+        groupName = group_name,
+        hidden = true,
+        units = {
+            {
+                type = ewr_type,
+                x = vec2.x,
+                y = vec2.y,
+                heading = 0,
+                skill = "Excellent",
+                name = group_name .. " radar",
+            },
+        },
+    })
+    protect_group(group_name)
+    return true
+end
+
+local function build_dispatcher(coalition_name, records)
+    if #records == 0 then return end
+
+    -- Global QRA tuning, identical across this coalition's records (see header).
+    local comms_enabled = records[1].commsEnabled ~= "false"
+    local scramble_radius_nm = tonumber(records[1].gciMaxRadiusNm) or 100
+    local engagement_range_nm = tonumber(records[1].engagementRangeNm) or 60
+
+    -- Always spawn a hidden backstop EWR at each defended base so there is a
+    -- guaranteed detection source even when the IADS network is destroyed.
+    -- This is independent of GciRadius — the backstop ensures detection, while
+    -- GciRadius (set below) controls how far out a raid triggers a scramble.
+    local backstop_names = {}
+    do
+        local seen_bases = {}
+        for _, rec in ipairs(records) do
+            local base_name = rec.airbaseName
+            if not seen_bases[base_name] then
+                seen_bases[base_name] = true
+                local airbase = AIRBASE:FindByName(base_name)
+                if airbase then
+                    local vec2 = airbase:GetVec2()
+                    local ewr_name = "QRA_Backstop_" .. coalition_name .. "_" .. base_name
+                    if spawn_backstop_ewr(ewr_name, vec2, rec.backstopEwrType, tonumber(rec.countryId)) then
+                        backstop_names[#backstop_names + 1] = ewr_name
+                    end
+                end
+            end
+        end
+    end
+
+    -- Assemble the dispatcher once the backstop groups have registered.
+    mist.scheduleFunction(function()
+        local detection_prefixes = ewr_group_names(coalition_name)
+        for _, ewr_name in ipairs(backstop_names) do
+            if GROUP:FindByName(ewr_name) then
+                detection_prefixes[#detection_prefixes + 1] = ewr_name
+            else
+                env.info("DCSRetribution|Intercept: backstop EWR '"..ewr_name
+                         .."' did not spawn (unknown type?); base falls back to EWR network.")
+            end
+        end
+
+        if #detection_prefixes == 0 then
+            env.info("DCSRetribution|Intercept: no detection sources for "
+                     ..coalition_name.."; QRA will not scramble.")
+            return
+        end
+
+        local det_set = SET_GROUP:New()
+            :FilterCoalitions(string.lower(coalition_name))
+            :FilterPrefixes(detection_prefixes)
+            :FilterStart()
+
+        local detection = DETECTION_AREAS:New(det_set, DETECTION_GROUPING_M)
+
+        local dispatcher = AI_A2A_DISPATCHER:New(detection)
+        -- Spawn interceptors already airborne near the base. See header for the
+        -- full method history: every ground spawn (cold/hot/runway) leaves F-16s
+        -- stuck on congested ramps like Tiyas; only in-air escapes it. In-air is
+        -- viable here because the BASE.CreateEventTakeoff monkeypatch above fixes
+        -- the Moose air-spawn crash that previously killed it. Altitude is metres.
+        dispatcher:SetDefaultTakeoffInAir()
+        dispatcher:SetDefaultTakeoffInAirAltitude(2000)  -- ~6,500 ft
+        dispatcher:SetDefaultLandingAtEngineShutdown()
+        dispatcher:SetIntercept(0)
+        dispatcher:SetEngageRadius(engagement_range_nm * NM)
+        dispatcher:SetTacticalDisplay(false)  -- debug F10 overview; off in normal play
+        dispatcher:SetGciRadius(scramble_radius_nm * NM)
+        if comms_enabled then
+            dispatcher:SetSendMessages(true)
+        end
+
+        for _, rec in ipairs(records) do
+            -- Moose keys squadrons by name; the squadron display name is not
+            -- unique across bases (dr-wz6p), so append a short slice of the
+            -- unique squadron id to avoid one base's QRA overwriting another's.
+            local sq = rec.squadronName .. " #" .. string.sub(tostring(rec.squadronId), 1, 8)
+            dispatcher:SetSquadron(sq, rec.airbaseName, { rec.templatePrefix }, tonumber(rec.resourceCount))
+            dispatcher:SetSquadronGci(sq, 900, 1200)
+            dispatcher:SetSquadronGrouping(sq, 2)
+            -- NOTE: deliberately NOT SetSquadronVisible — see header. Visible mode
+            -- forces a cold pre-park (F-16 never taxis), clamps reserve to parking
+            -- spots, and forces Grouping=1. Non-visible = in-air fresh-spawn on scramble.
+            if comms_enabled then
+                dispatcher:SetSquadronLanguage(sq, "EN")
+            end
+            intercept_survivors[rec.squadronId] = tonumber(rec.resourceCount)
+
+            intercept_registry[rec.squadronId] = {
+                dispatcher    = dispatcher,
+                squadronName  = sq,
+            }
+        end
+    end, {}, timer.getTime() + BUILD_DELAY)
+end
+
+-- ---------------------------------------------------------------------------
+-- Survivor refresh
+-- Formula: survivors(squadron) = parked ResourceCount
+--                              + sum of GetSize() for each airborne Defender
+--                                whose SquadronName matches.
+--
+-- GetSquadron throws on unknown name — we pcall it.
+-- GetSize() returns nil when the GROUP has no DCS object; treat nil as 0.
+-- DefenderTasks is keyed by Defender GROUP object; we iterate pairs() and
+-- call GetDefenderTaskSquadronName(Defender) to match the squadron.
+-- ---------------------------------------------------------------------------
+local REFRESH_INTERVAL = 30  -- seconds between polls
+
+local function refresh_survivors()
+    for squadron_id, entry in pairs(intercept_registry) do
+        local ok, err = pcall(function()
+            local disp = entry.dispatcher
+            local sq_name = entry.squadronName
+
+            -- Parked count
+            local parked = 0
+            local sq_ok, sq_obj = pcall(function()
+                return disp:GetSquadron(sq_name)
+            end)
+            if sq_ok and sq_obj and sq_obj.ResourceCount then
+                parked = sq_obj.ResourceCount
+            else
+                -- GetSquadron threw or ResourceCount nil: keep last known value
+                return
+            end
+
+            -- Airborne count: sum GetSize() for alive Defender groups in this squadron
+            local airborne = 0
+            local tasks = disp:GetDefenderTasks()
+            for defender, _ in pairs(tasks) do
+                local task_sq_name = disp:GetDefenderTaskSquadronName(defender)
+                if task_sq_name == sq_name then
+                    local sz = defender:GetSize()
+                    if sz then
+                        airborne = airborne + sz
+                    end
+                end
+            end
+
+            local survivors = math.max(0, parked + airborne)
+            intercept_survivors[squadron_id] = survivors
+        end)
+        if not ok then
+            env.info("DCSRetribution|Intercept: survivor refresh error for squadron "
+                     ..tostring(squadron_id)..": "..tostring(err))
+            -- keep last known value; do not write nil
+        end
+    end
+
+    -- Self-reschedule (one-shot mist pattern, same as write_state_error_handling)
+    mist.scheduleFunction(refresh_survivors, {}, timer.getTime() + REFRESH_INTERVAL)
+end
+
+if dcsRetribution.Intercept then
+    local blue = dcsRetribution.Intercept.BLUE or {}
+    local red = dcsRetribution.Intercept.RED or {}
+    build_dispatcher("BLUE", blue)
+    build_dispatcher("RED", red)
+
+    -- The registry is populated by the deferred build (BUILD_DELAY in); start the
+    -- survivor poll well after that and after the dispatcher FSM auto-start.
+    if #blue > 0 or #red > 0 then
+        mist.scheduleFunction(refresh_survivors, {}, timer.getTime() + 15)
+    end
+end

--- a/resources/plugins/intercept/intercept-config.lua
+++ b/resources/plugins/intercept/intercept-config.lua
@@ -9,11 +9,12 @@
 -- matched almost nothing, because DCS EWR group names are suffix-form
 -- ("1L13 EWR", "55G6 EWR").
 --
--- Detection has two sources: the IADS EWR/SAM-as-EWR network (primary, wide
--- area) and a hidden/invisible/immortal backstop EWR at each alert base
--- (guaranteed fallback — catches anything that slips through or survives after
--- the EWR network is destroyed). The backstop always spawns; it is independent
--- of GciRadius.
+-- Detection source: the IADS EWR/SAM-as-EWR network published in
+-- dcsRetribution.IADS (the same source Skynet uses). A base only scrambles QRA
+-- against raids its radar network actually sees; if a coalition's EWR/SAM-as-EWR
+-- network is wiped out, its QRA loses GCI detection (by design — we no longer
+-- spawn a per-base backstop EWR, which DCS placed on runways/taxiways at the
+-- airbase reference point and broke AI taxi routing).
 --
 -- GciRadius (groundControlledInterceptionMaxRadius, default 100 NM) caps how
 -- far from a base a detected raid can trigger a scramble. The dispatcher only
@@ -21,17 +22,9 @@
 -- the real detection range; GciRadius just prevents scrambling against very
 -- distant threats heading elsewhere.
 --
--- The backstop EWR DCS type is supplied per record by the mission generator
--- (rec.backstopEwrType) rather than hardcoded here. If the type is unknown to
--- the running DCS build, mist.dynAdd silently spawns nothing; we therefore
--- verify each backstop group exists before trusting it as a detection source
--- and fall back to the EWR network for that base otherwise.
---
--- Build timing: backstop EWRs are spawned with mist.dynAdd up front, but the
--- detection SET_GROUP (and the dispatcher) are assembled BUILD_DELAY seconds
--- later. mist.dynAdd registers a group via a birth event on the next frame, so
--- a SET_GROUP:FilterStart() built synchronously would not yet see the backstop.
--- The short delay lets the groups register first.
+-- Build timing: the detection SET_GROUP and dispatcher are assembled BUILD_DELAY
+-- seconds in to give the mission's groups a frame to register before
+-- SET_GROUP:FilterStart() scans them.
 --
 -- AI_A2A_DISPATCHER:New() calls self:__Start(5) internally — no explicit
 -- dispatcher:Start() call is needed or valid (no such method exists).
@@ -86,7 +79,7 @@ local intercept_registry = {}
 -- for the numerics and a string compare ("false") for the boolean.
 local NM = 1852  -- metres per nautical mile
 local DETECTION_GROUPING_M = 30000  -- contact-clustering radius for DETECTION_AREAS
-local BUILD_DELAY = 5  -- seconds; let mist.dynAdd backstops register before SET_GROUP
+local BUILD_DELAY = 5  -- seconds; let mission groups register before SET_GROUP scan
 
 -- ---------------------------------------------------------------------------
 -- MOOSE BUG WORKAROUND — air-spawn takeoff event
@@ -165,46 +158,6 @@ local function ewr_group_names(coalition_name)
     return names
 end
 
--- Make the backstop EWR invisible to enemy AI and immortal so the backstop
--- cannot be shot out. Deferred a few seconds so Moose has registered the
--- freshly spawned group.
-local function protect_group(group_name)
-    mist.scheduleFunction(function()
-        local grp = GROUP:FindByName(group_name)
-        if grp then
-            grp:SetCommandInvisible(true)
-            grp:SetCommandImmortal(true)
-        end
-    end, {}, timer.getTime() + 5)
-end
-
--- Attempts to spawn a hidden backstop EWR. Returns true when a spawn was issued
--- (a valid type and country were supplied); the caller still verifies the group
--- actually exists before relying on it, since mist.dynAdd drops unknown types.
-local function spawn_backstop_ewr(group_name, vec2, ewr_type, country_id)
-    if not ewr_type or ewr_type == "" or not country_id then
-        return false
-    end
-    mist.dynAdd({
-        countryId = country_id,
-        category = "vehicle",
-        groupName = group_name,
-        hidden = true,
-        units = {
-            {
-                type = ewr_type,
-                x = vec2.x,
-                y = vec2.y,
-                heading = 0,
-                skill = "Excellent",
-                name = group_name .. " radar",
-            },
-        },
-    })
-    protect_group(group_name)
-    return true
-end
-
 local function build_dispatcher(coalition_name, records)
     if #records == 0 then return end
 
@@ -213,40 +166,9 @@ local function build_dispatcher(coalition_name, records)
     local scramble_radius_nm = tonumber(records[1].gciMaxRadiusNm) or 100
     local engagement_range_nm = tonumber(records[1].engagementRangeNm) or 60
 
-    -- Always spawn a hidden backstop EWR at each defended base so there is a
-    -- guaranteed detection source even when the IADS network is destroyed.
-    -- This is independent of GciRadius — the backstop ensures detection, while
-    -- GciRadius (set below) controls how far out a raid triggers a scramble.
-    local backstop_names = {}
-    do
-        local seen_bases = {}
-        for _, rec in ipairs(records) do
-            local base_name = rec.airbaseName
-            if not seen_bases[base_name] then
-                seen_bases[base_name] = true
-                local airbase = AIRBASE:FindByName(base_name)
-                if airbase then
-                    local vec2 = airbase:GetVec2()
-                    local ewr_name = "QRA_Backstop_" .. coalition_name .. "_" .. base_name
-                    if spawn_backstop_ewr(ewr_name, vec2, rec.backstopEwrType, tonumber(rec.countryId)) then
-                        backstop_names[#backstop_names + 1] = ewr_name
-                    end
-                end
-            end
-        end
-    end
-
-    -- Assemble the dispatcher once the backstop groups have registered.
+    -- Assemble the dispatcher once the mission's groups have registered.
     mist.scheduleFunction(function()
         local detection_prefixes = ewr_group_names(coalition_name)
-        for _, ewr_name in ipairs(backstop_names) do
-            if GROUP:FindByName(ewr_name) then
-                detection_prefixes[#detection_prefixes + 1] = ewr_name
-            else
-                env.info("DCSRetribution|Intercept: backstop EWR '"..ewr_name
-                         .."' did not spawn (unknown type?); base falls back to EWR network.")
-            end
-        end
 
         if #detection_prefixes == 0 then
             env.info("DCSRetribution|Intercept: no detection sources for "

--- a/resources/plugins/intercept/intercept-config.lua
+++ b/resources/plugins/intercept/intercept-config.lua
@@ -126,7 +126,8 @@ end
 -- task type is embedded in its DCS group name by namegen.next_aircraft_name as
 -- "{target} {flight_type}|{country}|{n}|{variant}|" (game/naming.py). We react
 -- only when a detected cluster contains a group whose type is in QRA_REACT_TASKS;
--- CAP/sweep/escort/intercept/SEAD/CAS/support are ignored. Non-ATO enemy air
+-- CAP/sweep/escort/intercept/SEAD/CAS/DEAD/Air Assault/support are ignored.
+-- Non-ATO enemy air
 -- (not named by namegen) has no matching suffix and is never reacted to.
 -- ---------------------------------------------------------------------------
 local QRA_REACT_TASKS = {
@@ -135,9 +136,7 @@ local QRA_REACT_TASKS = {
     ["OCA/Runway"] = true,
     ["OCA/Aircraft"] = true,
     ["Anti-ship"] = true,
-    ["DEAD"] = true,
     ["Armed Recon"] = true,
-    ["Air Assault"] = true,
 }
 
 local function ends_with(str, suffix)

--- a/resources/plugins/intercept/intercept-config.lua
+++ b/resources/plugins/intercept/intercept-config.lua
@@ -120,6 +120,68 @@ do
     end
 end
 
+-- ---------------------------------------------------------------------------
+-- Task-type reaction filter (dr-99hm)
+-- QRA only scrambles against air-to-ground raids. The enemy flight's Retribution
+-- task type is embedded in its DCS group name by namegen.next_aircraft_name as
+-- "{target} {flight_type}|{country}|{n}|{variant}|" (game/naming.py). We react
+-- only when a detected cluster contains a group whose type is in QRA_REACT_TASKS;
+-- CAP/sweep/escort/intercept/SEAD/CAS/support are ignored. Non-ATO enemy air
+-- (not named by namegen) has no matching suffix and is never reacted to.
+-- ---------------------------------------------------------------------------
+local QRA_REACT_TASKS = {
+    ["Strike"] = true,
+    ["BAI"] = true,
+    ["OCA/Runway"] = true,
+    ["OCA/Aircraft"] = true,
+    ["Anti-ship"] = true,
+    ["DEAD"] = true,
+    ["Armed Recon"] = true,
+    ["Air Assault"] = true,
+}
+
+local function ends_with(str, suffix)
+    return str:sub(-#suffix) == suffix
+end
+
+-- True if the group name's task-type suffix is a react-type. We require the
+-- namegen "{target} {flight_type}|..." format and match the first "|"-field:
+-- a name with no "|" is not a Retribution ATO flight, so we cannot classify it
+-- and never react (this enforces the documented non-ATO limitation and stops a
+-- mission-editor/Combined-Arms group coincidentally named e.g. "Eagle Strike"
+-- from false-matching). Within the field we suffix-match " " .. task so
+-- multi-word target names (e.g. "Al Dhafra Strike") and any multi-word react
+-- type both work; the leading space keeps a target name that merely ends in the
+-- task word (no separator) from matching.
+local function qra_group_reacts(group_name)
+    if type(group_name) ~= "string" then return false end
+    local field = group_name:match("^([^|]+)|")  -- "{target} {flight_type}" up to the first "|"
+    if not field then return false end
+    for task, _ in pairs(QRA_REACT_TASKS) do
+        if ends_with(field, " " .. task) then
+            return true
+        end
+    end
+    return false
+end
+
+-- True if any unit in the detected cluster belongs to a react-type group. A
+-- cluster reacts as soon as one react-type group is present (escorted strikes
+-- still trigger).
+local function qra_cluster_has_react(detected_item)
+    local set = detected_item and detected_item.Set
+    if not set then return false end
+    local found = false
+    set:ForEachUnit(function(unit)
+        if found then return end  -- short-circuit; ForEachUnit has no early break
+        local group = unit:GetGroup()
+        if group and qra_group_reacts(group:GetName()) then
+            found = true
+        end
+    end)
+    return found
+end
+
 -- Collect the EWR / SAM-as-EWR group names the IADS generator published for a
 -- coalition. SamAsEwr entries already carry the DCS GROUP name, but standalone
 -- Ewr entries carry the UNIT name (Skynet convention: dcs_name_for_group
@@ -184,6 +246,26 @@ local function build_dispatcher(coalition_name, records)
         local detection = DETECTION_AREAS:New(det_set, DETECTION_GROUPING_M)
 
         local dispatcher = AI_A2A_DISPATCHER:New(detection)
+        -- dr-99hm: only scramble against air-to-ground raids. Wrap this
+        -- instance's per-cluster evaluation so a detected cluster with no
+        -- react-type group is skipped; otherwise delegate to Moose's original.
+        -- Per-instance (not class-level) so it applies to this coalition's
+        -- dispatcher only. EvaluateGCI returns (DefendersMissing, Friendlies);
+        -- nil,nil means "no scramble". EvaluateENGAGE returns Friendlies or nil.
+        local orig_evaluate_gci = dispatcher.EvaluateGCI
+        function dispatcher:EvaluateGCI(detected_item)
+            if not qra_cluster_has_react(detected_item) then
+                return nil, nil
+            end
+            return orig_evaluate_gci(self, detected_item)
+        end
+        local orig_evaluate_engage = dispatcher.EvaluateENGAGE
+        function dispatcher:EvaluateENGAGE(detected_item)
+            if not qra_cluster_has_react(detected_item) then
+                return nil
+            end
+            return orig_evaluate_engage(self, detected_item)
+        end
         -- Spawn interceptors already airborne near the base. See header for the
         -- full method history: every ground spawn (cold/hot/runway) leaves F-16s
         -- stuck on congested ramps like Tiyas; only in-air escapes it. In-air is
@@ -294,3 +376,11 @@ if dcsRetribution.Intercept then
         mist.scheduleFunction(refresh_survivors, {}, timer.getTime() + 15)
     end
 end
+
+-- Test hook: expose the pure filter helpers for tests/missiongenerator/
+-- qra_filter_test.lua. The DCS plugin loader executes this chunk and discards
+-- its return value, so this is inert in-mission.
+return {
+    group_reacts = qra_group_reacts,
+    cluster_has_react = qra_cluster_has_react,
+}

--- a/resources/plugins/intercept/intercept-config.lua
+++ b/resources/plugins/intercept/intercept-config.lua
@@ -296,6 +296,13 @@ local function build_dispatcher(coalition_name, records)
         dispatcher:SetEngageRadius(engagement_range_nm * NM)
         dispatcher:SetTacticalDisplay(false)  -- debug F10 overview; off in normal play
         dispatcher:SetGciRadius(scramble_radius_nm * NM)
+        -- Moose's default DisengageRadius is 300 km (~162 NM): once a defender's
+        -- DistanceFromHomeBase exceeds it, Moose aborts the intercept mid-transit.
+        -- Our GCI radius is configurable up to 400 NM, so leaving the default would
+        -- launch a far-edge defender only to have it turn straight around. Size the
+        -- disengage radius to the furthest reachable point (scramble trigger + engage
+        -- chase) plus a maneuver margin so a valid intercept never self-aborts.
+        dispatcher:SetDisengageRadius((scramble_radius_nm + engagement_range_nm + 20) * NM)
         if comms_enabled then
             dispatcher:SetSendMessages(true)
         end

--- a/resources/plugins/intercept/intercept-config.lua
+++ b/resources/plugins/intercept/intercept-config.lua
@@ -326,7 +326,12 @@ local function build_dispatcher(coalition_name, records)
                     dispatcher:SetSquadronTakeoffInAirAltitude(sq, elev + 760)
                 end
             end
-            dispatcher:SetSquadronGrouping(sq, 2)
+            -- 75% single / 25% pair per scramble. QRA alert launches are mostly
+            -- singles; a fixed group of 2 means a reserve of 4 answers only 2 raids,
+            -- while mostly-singles lets the same reserve answer ~4. Rolled once per
+            -- squadron (record) so each base's launches are independent.
+            local grouping = (math.random() < 0.75) and 1 or 2
+            dispatcher:SetSquadronGrouping(sq, grouping)
             -- NOTE: deliberately NOT SetSquadronVisible — see header. Visible mode
             -- forces a cold pre-park (F-16 never taxis), clamps reserve to parking
             -- spots, and forces Grouping=1. Non-visible = in-air fresh-spawn on scramble.

--- a/resources/plugins/intercept/intercept-config.lua
+++ b/resources/plugins/intercept/intercept-config.lua
@@ -314,6 +314,18 @@ local function build_dispatcher(coalition_name, records)
             local sq = rec.squadronName .. " #" .. string.sub(tostring(rec.squadronId), 1, 8)
             dispatcher:SetSquadron(sq, rec.airbaseName, { rec.templatePrefix }, tonumber(rec.resourceCount))
             dispatcher:SetSquadronGci(sq, 900, 1200)
+            -- Terrain-relative in-air spawn altitude (~2,500 ft AGL over this
+            -- squadron's field). The global SetDefaultTakeoffInAirAltitude above
+            -- is absolute MSL, so high-elevation fields spawn low and low fields
+            -- spawn high with free energy; per-squadron we offset by the field's
+            -- land height. Falls back to the global 2000 m when the lookup misses.
+            local base = AIRBASE:FindByName(rec.airbaseName)
+            if base then
+                local ok_e, elev = pcall(function() return base:GetCoordinate():GetLandHeight() end)
+                if ok_e and elev then
+                    dispatcher:SetSquadronTakeoffInAirAltitude(sq, elev + 760)
+                end
+            end
             dispatcher:SetSquadronGrouping(sq, 2)
             -- NOTE: deliberately NOT SetSquadronVisible — see header. Visible mode
             -- forces a cold pre-park (F-16 never taxis), clamps reserve to parking

--- a/resources/plugins/intercept/intercept-config.lua
+++ b/resources/plugins/intercept/intercept-config.lua
@@ -144,6 +144,14 @@ local function ends_with(str, suffix)
     return str:sub(-#suffix) == suffix
 end
 
+-- Escape Lua pattern magic characters so a literal string can be used where
+-- Moose treats it as a pattern (SET_GROUP:FilterPrefixes matches via string.find
+-- with pattern semantics). We escape everything EXCEPT "-": Moose's FilterPrefixes
+-- already gsubs "-" -> "%-" itself, so escaping it here would double-escape.
+local function lua_pattern_escape(s)
+    return (s:gsub("[%(%)%.%%%+%*%?%[%]%^%$]", "%%%1"))
+end
+
 -- True if the group name's task-type suffix is a react-type. We require the
 -- namegen "{target} {flight_type}|..." format and match the first "|"-field:
 -- a name with no "|" is not a Retribution ATO flight, so we cannot classify it
@@ -238,9 +246,20 @@ local function build_dispatcher(coalition_name, records)
             return
         end
 
+        -- Moose SET_GROUP:FilterPrefixes matches names with Lua-pattern semantics
+        -- (string.find, only "-" pre-escaped). Retribution IADS group names contain
+        -- "(" / ")" (e.g. "0041 | LION (EWR)", "0114 | LORIKEET (S-300)"), which
+        -- would be read as pattern captures and never match, leaving the detection
+        -- set empty (no QRA scramble ever). Escape the magic chars so each prefix
+        -- matches its literal group name.
+        local detection_patterns = {}
+        for i, name in ipairs(detection_prefixes) do
+            detection_patterns[i] = lua_pattern_escape(name)
+        end
+
         local det_set = SET_GROUP:New()
             :FilterCoalitions(string.lower(coalition_name))
-            :FilterPrefixes(detection_prefixes)
+            :FilterPrefixes(detection_patterns)
             :FilterStart()
 
         local detection = DETECTION_AREAS:New(det_set, DETECTION_GROUPING_M)
@@ -383,4 +402,5 @@ end
 return {
     group_reacts = qra_group_reacts,
     cluster_has_react = qra_cluster_has_react,
+    pattern_escape = lua_pattern_escape,
 }

--- a/resources/plugins/intercept/plugin.json
+++ b/resources/plugins/intercept/plugin.json
@@ -1,0 +1,13 @@
+{
+    "skipUI": true,
+    "nameInUI": "Intercept (QRA)",
+    "defaultValue": true,
+    "specificOptions": [],
+    "scriptsWorkOrders": [],
+    "configurationWorkOrders": [
+        {
+            "file": "intercept-config.lua",
+            "mnemonic": "intercept-config"
+        }
+    ]
+}

--- a/resources/plugins/plugins.json
+++ b/resources/plugins/plugins.json
@@ -14,5 +14,6 @@
     "airboss",
     "MooseSoundhandler",    
     "MooseAutolase",
-    "MooseMarkerOps"
+    "MooseMarkerOps",
+    "intercept"
 ]

--- a/tests/missiongenerator/qra_filter_test.lua
+++ b/tests/missiongenerator/qra_filter_test.lua
@@ -104,6 +104,29 @@ check("cluster-escorted-strike",
 check("cluster-empty", M.cluster_has_react(fake_item({})), false)
 check("cluster-nil",   M.cluster_has_react({}),            false)
 
+-- pattern_escape: Retribution IADS group names contain "(" / ")" / "-" that
+-- break Moose's pattern-based FilterPrefixes. Replicate Moose's matcher
+-- (string.find with its own "-" -> "%-" gsub applied to the prefix) and assert
+-- an escaped prefix matches the literal name while the raw prefix does not.
+local function moose_matches(name, prefix)
+    -- Mirror Moose SET_GROUP:FilterPrefixes (Moose.lua): string.find(name,
+    -- gsub(prefix, "-", "%-"), 1) — NOT plain, so prefix is a Lua pattern.
+    return string.find(name, (prefix:gsub("%-", "%%-")), 1) ~= nil
+end
+
+local paren_names = {
+    "0041 | LION (EWR)",
+    "0035 | ELEPHANT (Naval Two Ship)",
+    "0114 | LORIKEET (S-300)",
+    "0178 | OPOSSUM (Patriot)",
+}
+for _, name in ipairs(paren_names) do
+    -- raw (unescaped) prefix fails to match because "(" / ")" are pattern captures
+    check("raw-nomatch:" .. name, moose_matches(name, name), false)
+    -- escaped prefix matches the literal name -> sensor lands in the SET_GROUP
+    check("escaped-match:" .. name, moose_matches(name, M.pattern_escape(name)), true)
+end
+
 if failures == 0 then
     print("OK: all QRA filter assertions passed")
     os.exit(0)

--- a/tests/missiongenerator/qra_filter_test.lua
+++ b/tests/missiongenerator/qra_filter_test.lua
@@ -1,0 +1,113 @@
+-- qra_filter_test.lua
+--
+-- Standalone unit test for the task-type reaction filter in
+-- resources/plugins/intercept/intercept-config.lua. QRA must react only to
+-- air-to-ground taskings (Strike/BAI/OCA-Runway/OCA-Aircraft/Anti-ship/DEAD)
+-- and ignore
+-- CAP/sweep/escort/intercept/SEAD/CAS/support, based on the DCS group name.
+--
+-- Not run by CI (CI has no Lua). Run locally with:
+--   lua    tests/missiongenerator/qra_filter_test.lua
+--   luajit tests/missiongenerator/qra_filter_test.lua
+
+local SCRIPT = "resources/plugins/intercept/intercept-config.lua"
+
+-- Minimal global stubs the script touches at load time. We deliberately do NOT
+-- set dcsRetribution.Intercept, so the module-level build block is skipped and
+-- no Moose/mist machinery runs — the load just defines the helpers and returns
+-- the test-export table.
+dcsRetribution = {}
+mist = { scheduleFunction = function() end }
+timer = { getTime = function() return 0 end }
+env = { info = function() end, warning = function() end }
+BASE = { CreateEventTakeoff = function() end }
+
+local M = assert(loadfile(SCRIPT))()
+assert(M, "intercept-config.lua did not return its test-export table")
+assert(type(M.group_reacts) == "function", "missing group_reacts export")
+assert(type(M.cluster_has_react) == "function", "missing cluster_has_react export")
+
+local failures = 0
+local function check(label, got, want)
+    if got ~= want then
+        failures = failures + 1
+        print(string.format("FAIL: %s -> got %s, want %s",
+            label, tostring(got), tostring(want)))
+    end
+end
+
+-- group_reacts: react-types => true
+check("Strike",       M.group_reacts("TIGER Strike|5|8|F-16C_50|"), true)
+check("BAI",          M.group_reacts("COLT BAI|5|3|0|"),            true)
+check("OCA/Runway",   M.group_reacts("HAWK OCA/Runway|5|1|0|"),     true)
+check("OCA/Aircraft", M.group_reacts("HAWK OCA/Aircraft|5|1|0|"),   true)
+check("Anti-ship",    M.group_reacts("VIPER Anti-ship|5|2|0|"),     true)
+check("DEAD",         M.group_reacts("WEASEL DEAD|5|4|0|"),         true)
+check("Armed Recon",  M.group_reacts("SCOUT Armed Recon|5|5|0|"),   true)
+check("Air Assault",  M.group_reacts("HERC Air Assault|5|6|0|"),    true)
+-- custom-named flight: naming.py appends the task type, so it still classifies
+check("custom-name-strike", M.group_reacts("Alpha Strike|5|8|0|"),  true)
+
+-- group_reacts: ignore-types => false
+check("TARCAP",        M.group_reacts("EAGLE TARCAP|5|7|0|"),        false)
+check("BARCAP",        M.group_reacts("EAGLE BARCAP|5|7|0|"),        false)
+check("SEAD",          M.group_reacts("WEASEL SEAD|5|4|0|"),         false)
+check("CAS",           M.group_reacts("HOG CAS|5|6|0|"),             false)
+check("Fighter sweep", M.group_reacts("EAGLE Fighter sweep|5|9|0|"), false)
+check("Escort",        M.group_reacts("EAGLE Escort|5|9|0|"),        false)
+check("Intercept",     M.group_reacts("Intercept|Tiyas|sq-abc|"),    false)
+check("AEW&C",         M.group_reacts("SENTRY AEW&C|5|1|0|"),        false)
+
+-- group_reacts: multi-word target name still parses the type suffix
+check("multiword-strike", M.group_reacts("Al Dhafra Strike|5|8|0|"), true)
+check("multiword-tarcap", M.group_reacts("Al Dhafra TARCAP|5|8|0|"), false)
+
+-- group_reacts: malformed / no match => false
+check("no-pipe",       M.group_reacts("garbage"),          false)
+check("empty",         M.group_reacts(""),                 false)
+check("nil",           M.group_reacts(nil),                false)
+check("no-type-match", M.group_reacts("SomeGroup|5|1|0|"), false)
+-- type word without the leading-space separator must NOT match
+check("no-separator",  M.group_reacts("BAI|5|1|0|"),       false)
+-- non-namegen name (no "|") that coincidentally ends in a react word must NOT
+-- match — only pipe-delimited namegen ATO flights are classifiable
+check("no-pipe-strike-suffix", M.group_reacts("Eagle Strike"),   false)
+check("no-pipe-bai-suffix",    M.group_reacts("Reserve BAI"),    false)
+check("leading-pipe",          M.group_reacts("|Strike|5|1|0|"), false)
+
+-- cluster_has_react: fake DetectedItem whose Set:ForEachUnit iterates units,
+-- each resolving to a group with GetName().
+local function fake_item(group_names)
+    local units = {}
+    for _, gname in ipairs(group_names) do
+        units[#units + 1] = {
+            GetGroup = function()
+                return { GetName = function() return gname end }
+            end,
+        }
+    end
+    return {
+        Set = {
+            ForEachUnit = function(_, fn)
+                for _, u in ipairs(units) do fn(u) end
+            end,
+        },
+    }
+end
+
+check("cluster-lone-cap",
+    M.cluster_has_react(fake_item({ "EAGLE TARCAP|5|7|0|", "EAGLE BARCAP|5|1|0|" })),
+    false)
+check("cluster-escorted-strike",
+    M.cluster_has_react(fake_item({ "EAGLE Escort|5|9|0|", "TIGER Strike|5|8|0|" })),
+    true)
+check("cluster-empty", M.cluster_has_react(fake_item({})), false)
+check("cluster-nil",   M.cluster_has_react({}),            false)
+
+if failures == 0 then
+    print("OK: all QRA filter assertions passed")
+    os.exit(0)
+else
+    print(string.format("%d assertion(s) failed", failures))
+    os.exit(1)
+end

--- a/tests/missiongenerator/qra_filter_test.lua
+++ b/tests/missiongenerator/qra_filter_test.lua
@@ -2,9 +2,10 @@
 --
 -- Standalone unit test for the task-type reaction filter in
 -- resources/plugins/intercept/intercept-config.lua. QRA must react only to
--- air-to-ground taskings (Strike/BAI/OCA-Runway/OCA-Aircraft/Anti-ship/DEAD)
--- and ignore
--- CAP/sweep/escort/intercept/SEAD/CAS/support, based on the DCS group name.
+-- air-to-ground taskings (Strike/BAI/OCA-Runway/OCA-Aircraft/Anti-ship/Armed
+-- Recon) and ignore
+-- CAP/sweep/escort/intercept/SEAD/CAS/DEAD/Air Assault/support, based on the
+-- DCS group name.
 --
 -- Not run by CI (CI has no Lua). Run locally with:
 --   lua    tests/missiongenerator/qra_filter_test.lua
@@ -42,9 +43,7 @@ check("BAI",          M.group_reacts("COLT BAI|5|3|0|"),            true)
 check("OCA/Runway",   M.group_reacts("HAWK OCA/Runway|5|1|0|"),     true)
 check("OCA/Aircraft", M.group_reacts("HAWK OCA/Aircraft|5|1|0|"),   true)
 check("Anti-ship",    M.group_reacts("VIPER Anti-ship|5|2|0|"),     true)
-check("DEAD",         M.group_reacts("WEASEL DEAD|5|4|0|"),         true)
 check("Armed Recon",  M.group_reacts("SCOUT Armed Recon|5|5|0|"),   true)
-check("Air Assault",  M.group_reacts("HERC Air Assault|5|6|0|"),    true)
 -- custom-named flight: naming.py appends the task type, so it still classifies
 check("custom-name-strike", M.group_reacts("Alpha Strike|5|8|0|"),  true)
 
@@ -57,6 +56,8 @@ check("Fighter sweep", M.group_reacts("EAGLE Fighter sweep|5|9|0|"), false)
 check("Escort",        M.group_reacts("EAGLE Escort|5|9|0|"),        false)
 check("Intercept",     M.group_reacts("Intercept|Tiyas|sq-abc|"),    false)
 check("AEW&C",         M.group_reacts("SENTRY AEW&C|5|1|0|"),        false)
+check("DEAD",          M.group_reacts("WEASEL DEAD|5|4|0|"),         false)
+check("Air Assault",   M.group_reacts("HERC Air Assault|5|6|0|"),    false)
 
 -- group_reacts: multi-word target name still parses the type suffix
 check("multiword-strike", M.group_reacts("Al Dhafra Strike|5|8|0|"), true)

--- a/tests/missiongenerator/test_interceptattrition.py
+++ b/tests/missiongenerator/test_interceptattrition.py
@@ -1,0 +1,35 @@
+from game.missiongenerator.interceptattrition import reconcile_intercept_losses
+
+
+def test_no_losses_when_all_survive() -> None:
+    losses = reconcile_intercept_losses({"a": 4}, {"a": 4})
+    assert losses == {"a": 0}
+
+
+def test_losses_are_reserve_minus_survivors() -> None:
+    losses = reconcile_intercept_losses({"a": 4}, {"a": 1})
+    assert losses == {"a": 3}
+
+
+def test_missing_squadron_takes_no_loss() -> None:
+    # Absent from the survivor map means the squadron never flew QRA this mission
+    # (carrier/no-EWR/plugin-disabled/no-parking) -> no loss, not a total loss.
+    losses = reconcile_intercept_losses({"a": 4}, {})
+    assert losses == {}
+
+
+def test_zero_survivors_is_a_real_total_loss() -> None:
+    # Present with zero survivors means the dispatcher reported everyone dead.
+    losses = reconcile_intercept_losses({"a": 4}, {"a": 0})
+    assert losses == {"a": 4}
+
+
+def test_survivors_never_produce_negative_losses() -> None:
+    # Defensive: a stale/over-count must not credit phantom airframes.
+    losses = reconcile_intercept_losses({"a": 2}, {"a": 5})
+    assert losses == {"a": 0}
+
+
+def test_unknown_squadron_in_state_is_ignored() -> None:
+    losses = reconcile_intercept_losses({"a": 2}, {"a": 2, "ghost": 9})
+    assert losses == {"a": 0}

--- a/tests/missiongenerator/test_interceptluadata.py
+++ b/tests/missiongenerator/test_interceptluadata.py
@@ -1,0 +1,79 @@
+from game.missiongenerator.interceptluadata import (
+    InterceptEntry,
+    populate_intercept_lua,
+)
+from game.missiongenerator.luagenerator import LuaData
+
+
+def _entry(**kw: object) -> InterceptEntry:
+    base = dict(
+        squadron_id="sq-1",
+        squadron_name="12th FS",
+        airbase_name="Batumi",
+        template_prefix="Intercept|Batumi|sq-1",
+        coalition="BLUE",
+        resource_count=4,
+        engagement_range_nm=60,
+        gci_max_radius_nm=100,
+        comms_enabled=True,
+        country_id=2,
+        backstop_ewr_type="FPS-117",
+    )
+    base.update(kw)
+    return InterceptEntry(**base)  # type: ignore[arg-type]
+
+
+def test_empty_entries_creates_blue_and_red_buckets() -> None:
+    root = LuaData("dcsRetribution")
+    populate_intercept_lua(root, [])
+    serialized = root.serialize()
+    assert "Intercept" in serialized
+    assert "BLUE" in serialized
+    assert "RED" in serialized
+
+
+def test_entry_is_grouped_under_its_coalition() -> None:
+    root = LuaData("dcsRetribution")
+    populate_intercept_lua(root, [_entry(coalition="RED")])
+
+    intercept = root.get_item("Intercept")
+    assert isinstance(intercept, LuaData)
+    red_bucket = intercept.get_item("RED")
+    blue_bucket = intercept.get_item("BLUE")
+    assert isinstance(red_bucket, LuaData)
+    assert isinstance(blue_bucket, LuaData)
+
+    # Entry must land in the RED bucket, not in BLUE.
+    assert len(red_bucket.objects) == 1
+    assert len(blue_bucket.objects) == 0
+
+    # Spot-check the record's content via the bucket's own serialization.
+    red_serialized = red_bucket.serialize()
+    assert "Intercept|Batumi|sq-1" in red_serialized
+    assert "12th FS" in red_serialized
+
+
+def test_resource_count_and_ranges_are_serialized() -> None:
+    root = LuaData("dcsRetribution")
+    populate_intercept_lua(root, [_entry(resource_count=4, engagement_range_nm=60)])
+    serialized = root.serialize()
+    assert "resourceCount" in serialized
+    assert "engagementRangeNm" in serialized
+    assert "gciMaxRadiusNm" in serialized
+    assert "commsEnabled" in serialized
+
+
+def test_country_id_is_serialized() -> None:
+    root = LuaData("dcsRetribution")
+    populate_intercept_lua(root, [_entry(country_id=82)])
+    serialized = root.serialize()
+    assert "countryId" in serialized
+    assert "82" in serialized
+
+
+def test_backstop_ewr_type_is_serialized() -> None:
+    root = LuaData("dcsRetribution")
+    populate_intercept_lua(root, [_entry(backstop_ewr_type="55G6 EWR")])
+    serialized = root.serialize()
+    assert "backstopEwrType" in serialized
+    assert "55G6 EWR" in serialized

--- a/tests/missiongenerator/test_interceptluadata.py
+++ b/tests/missiongenerator/test_interceptluadata.py
@@ -16,8 +16,6 @@ def _entry(**kw: object) -> InterceptEntry:
         engagement_range_nm=60,
         gci_max_radius_nm=100,
         comms_enabled=True,
-        country_id=2,
-        backstop_ewr_type="FPS-117",
     )
     base.update(kw)
     return InterceptEntry(**base)  # type: ignore[arg-type]
@@ -61,19 +59,3 @@ def test_resource_count_and_ranges_are_serialized() -> None:
     assert "engagementRangeNm" in serialized
     assert "gciMaxRadiusNm" in serialized
     assert "commsEnabled" in serialized
-
-
-def test_country_id_is_serialized() -> None:
-    root = LuaData("dcsRetribution")
-    populate_intercept_lua(root, [_entry(country_id=82)])
-    serialized = root.serialize()
-    assert "countryId" in serialized
-    assert "82" in serialized
-
-
-def test_backstop_ewr_type_is_serialized() -> None:
-    root = LuaData("dcsRetribution")
-    populate_intercept_lua(root, [_entry(backstop_ewr_type="55G6 EWR")])
-    serialized = root.serialize()
-    assert "backstopEwrType" in serialized
-    assert "55G6 EWR" in serialized

--- a/tests/squadrons/test_airwing_qra_propagation.py
+++ b/tests/squadrons/test_airwing_qra_propagation.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import cast
+
+from game.ato.flighttype import FlightType
+from game.dcs.aircrafttype import AircraftType
+from game.squadrons.airwing import AirWing
+from game.squadrons.squadron import Squadron
+
+
+class _FakeSquadron:
+    def __init__(self, reserve: int, max_size: int, barcap: bool) -> None:
+        self.intercept_reserve = reserve
+        self.max_size = max_size
+        self._barcap = barcap
+
+    def capable_of(self, task: FlightType) -> bool:
+        return self._barcap
+
+
+def _airwing(squadrons: list[_FakeSquadron]) -> AirWing:
+    wing = AirWing.__new__(AirWing)
+    wing.squadrons = cast("dict[AircraftType, list[Squadron]]", {0: list(squadrons)})
+    return wing
+
+
+def test_repropagate_bumps_only_tracking_barcap_squadrons() -> None:
+    tracking = _FakeSquadron(reserve=0, max_size=12, barcap=True)
+    user_set = _FakeSquadron(reserve=2, max_size=12, barcap=True)
+    non_barcap = _FakeSquadron(reserve=0, max_size=12, barcap=False)
+    wing = _airwing([tracking, user_set, non_barcap])
+
+    wing.repropagate_qra_reserve(0, 4)
+
+    assert tracking.intercept_reserve == 4
+    assert user_set.intercept_reserve == 2
+    assert non_barcap.intercept_reserve == 0
+
+
+def test_repropagate_is_a_no_op_when_default_unchanged() -> None:
+    squadron = _FakeSquadron(reserve=0, max_size=12, barcap=True)
+    wing = _airwing([squadron])
+
+    wing.repropagate_qra_reserve(0, 0)
+
+    assert squadron.intercept_reserve == 0

--- a/tests/squadrons/test_airwing_qra_propagation.py
+++ b/tests/squadrons/test_airwing_qra_propagation.py
@@ -13,9 +13,17 @@ class _FakeSquadron:
         self.intercept_reserve = reserve
         self.max_size = max_size
         self._barcap = barcap
+        # Attributes read by the real Squadron.set_intercept_reserve, which
+        # repropagate_qra_reserve now routes through.
+        self.owned_aircraft = max_size
+        self.untasked_aircraft = max(0, max_size - reserve)
 
     def capable_of(self, task: FlightType) -> bool:
         return self._barcap
+
+    def set_intercept_reserve(self, value: int) -> None:
+        # Exercise the real model logic (delta-adjust untasked + set reserve).
+        Squadron.set_intercept_reserve(cast(Squadron, self), value)
 
 
 def _airwing(squadrons: list[_FakeSquadron]) -> AirWing:

--- a/tests/squadrons/test_intercept_reserve.py
+++ b/tests/squadrons/test_intercept_reserve.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from game.squadrons.intercept_reserve import (
+    clamp_intercept_reserve,
+    qra_resource_count,
+    repropagated_intercept_reserve,
+    seeded_intercept_reserve,
+)
+
+
+def test_non_barcap_squadron_is_unchanged() -> None:
+    assert seeded_intercept_reserve(False, 0, 4, 12) == 0
+
+
+def test_explicit_non_zero_reserve_is_preserved() -> None:
+    assert seeded_intercept_reserve(True, 3, 4, 12) == 3
+
+
+def test_barcap_squadron_seeded_from_default() -> None:
+    assert seeded_intercept_reserve(True, 0, 4, 12) == 4
+
+
+def test_seed_is_clamped_to_max_size() -> None:
+    assert seeded_intercept_reserve(True, 0, 10, 4) == 4
+
+
+def test_zero_default_leaves_reserve_at_zero() -> None:
+    assert seeded_intercept_reserve(True, 0, 0, 12) == 0
+
+
+def test_clamp_within_bounds_is_unchanged() -> None:
+    assert clamp_intercept_reserve(3, 12) == 3
+
+
+def test_clamp_caps_at_max_size() -> None:
+    assert clamp_intercept_reserve(99, 12) == 12
+
+
+def test_clamp_floors_at_zero() -> None:
+    assert clamp_intercept_reserve(-5, 12) == 0
+
+
+def test_clamp_with_zero_max_size_returns_zero() -> None:
+    # An empty squadron (max_size 0) can hold no reserve, even from a YAML default.
+    assert clamp_intercept_reserve(5, 0) == 0
+
+
+def test_resource_count_is_reserve_when_owned_is_sufficient() -> None:
+    assert qra_resource_count(4, 10) == 4
+
+
+def test_resource_count_capped_at_owned_after_attrition() -> None:
+    # Squadron attrited below its reserve must not field more jets than it owns.
+    assert qra_resource_count(5, 3) == 3
+
+
+def test_resource_count_is_zero_when_nothing_owned() -> None:
+    assert qra_resource_count(4, 0) == 0
+
+
+def test_resource_count_capped_by_available_pilots() -> None:
+    assert qra_resource_count(4, 10, available_pilots=2) == 2
+
+
+def test_resource_count_airframes_win_when_fewer_than_pilots() -> None:
+    assert qra_resource_count(4, 1, available_pilots=10) == 1
+
+
+def test_resource_count_no_pilot_cap_when_pilots_none() -> None:
+    assert qra_resource_count(4, 10, available_pilots=None) == 4
+
+
+def test_resource_count_zero_with_no_available_pilots() -> None:
+    assert qra_resource_count(4, 10, available_pilots=0) == 0
+
+
+def test_repropagate_non_barcap_squadron_is_unchanged() -> None:
+    # A non-BARCAP squadron never carries QRA, even if its value equals the default.
+    assert repropagated_intercept_reserve(False, 0, 0, 4, 12) == 0
+
+
+def test_repropagate_tracking_squadron_moves_to_new_default() -> None:
+    # Opt-in on an existing campaign: 0 -> 4 bumps a squadron still at the old default.
+    assert repropagated_intercept_reserve(True, 0, 0, 4, 12) == 4
+
+
+def test_repropagate_user_set_value_is_left_alone() -> None:
+    # Reserve 3 != clamped old default 0, so the user's choice is preserved.
+    assert repropagated_intercept_reserve(True, 3, 0, 4, 12) == 3
+
+
+def test_repropagate_matches_clamped_old_default() -> None:
+    # max_size 4 clamped the old default 6 down to 4 at seed time; that squadron
+    # still tracks the default and follows it down to the new (clamped) value.
+    assert repropagated_intercept_reserve(True, 4, 6, 2, 4) == 2
+
+
+def test_repropagate_new_value_is_clamped_to_max_size() -> None:
+    assert repropagated_intercept_reserve(True, 0, 0, 10, 4) == 4
+
+
+def test_repropagate_no_op_when_old_equals_new() -> None:
+    assert repropagated_intercept_reserve(True, 2, 2, 2, 12) == 2

--- a/tests/squadrons/test_intercept_reserve.py
+++ b/tests/squadrons/test_intercept_reserve.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from game.squadrons.intercept_reserve import (
     clamp_intercept_reserve,
+    max_intercept_reserve,
     qra_resource_count,
     repropagated_intercept_reserve,
     seeded_intercept_reserve,
@@ -122,3 +123,35 @@ def test_untasked_floors_at_zero_when_reserve_exceeds_pool() -> None:
     # Only still-untasked jets can be benched; already-tasked flights are never
     # retroactively un-planned, so the pool floors at 0.
     assert untasked_after_reserve_change(0, 5, 2) == 0
+
+
+def test_max_reserve_capped_by_unplanned_airframes() -> None:
+    # 12/14 tasked -> untasked 2, reserve 0: QRA can rise to 2 (the unplanned jets).
+    assert (
+        max_intercept_reserve(untasked_aircraft=2, intercept_reserve=0, max_size=14)
+        == 2
+    )
+
+
+def test_max_reserve_is_zero_when_everything_tasked() -> None:
+    # 14/14 tasked -> untasked 0, reserve 0: no jets free for QRA.
+    assert (
+        max_intercept_reserve(untasked_aircraft=0, intercept_reserve=0, max_size=14)
+        == 0
+    )
+
+
+def test_max_reserve_includes_already_reserved_jets() -> None:
+    # untasked+reserve = owned - tasked is the invariant ceiling; already-reserved
+    # jets stay reservable.
+    assert (
+        max_intercept_reserve(untasked_aircraft=1, intercept_reserve=3, max_size=14)
+        == 4
+    )
+
+
+def test_max_reserve_bounded_by_max_size() -> None:
+    assert (
+        max_intercept_reserve(untasked_aircraft=20, intercept_reserve=0, max_size=12)
+        == 12
+    )

--- a/tests/squadrons/test_intercept_reserve.py
+++ b/tests/squadrons/test_intercept_reserve.py
@@ -5,6 +5,7 @@ from game.squadrons.intercept_reserve import (
     qra_resource_count,
     repropagated_intercept_reserve,
     seeded_intercept_reserve,
+    untasked_after_reserve_change,
 )
 
 
@@ -101,3 +102,23 @@ def test_repropagate_new_value_is_clamped_to_max_size() -> None:
 
 def test_repropagate_no_op_when_old_equals_new() -> None:
     assert repropagated_intercept_reserve(True, 2, 2, 2, 12) == 2
+
+
+def test_untasked_grows_when_reserve_freed() -> None:
+    # Reserve 4 -> 0 mid-turn releases the 4 benched jets into the plannable pool.
+    assert untasked_after_reserve_change(4, 0, 6) == 10
+
+
+def test_untasked_shrinks_when_reserve_raised() -> None:
+    # Reserve 0 -> 4 benches 4 jets that were plannable.
+    assert untasked_after_reserve_change(0, 4, 10) == 6
+
+
+def test_untasked_unchanged_when_reserve_unchanged() -> None:
+    assert untasked_after_reserve_change(3, 3, 5) == 5
+
+
+def test_untasked_floors_at_zero_when_reserve_exceeds_pool() -> None:
+    # Only still-untasked jets can be benched; already-tasked flights are never
+    # retroactively un-planned, so the pool floors at 0.
+    assert untasked_after_reserve_change(0, 5, 2) == 0

--- a/tests/squadrons/test_intercept_reserve.py
+++ b/tests/squadrons/test_intercept_reserve.py
@@ -107,22 +107,30 @@ def test_repropagate_no_op_when_old_equals_new() -> None:
 
 def test_untasked_grows_when_reserve_freed() -> None:
     # Reserve 4 -> 0 mid-turn releases the 4 benched jets into the plannable pool.
-    assert untasked_after_reserve_change(4, 0, 6) == 10
+    # owned 10: 6 untasked + 4 reserve.
+    assert untasked_after_reserve_change(4, 0, 6, 10) == 10
 
 
 def test_untasked_shrinks_when_reserve_raised() -> None:
-    # Reserve 0 -> 4 benches 4 jets that were plannable.
-    assert untasked_after_reserve_change(0, 4, 10) == 6
+    # Reserve 0 -> 4 benches 4 jets that were plannable. owned 10.
+    assert untasked_after_reserve_change(0, 4, 10, 10) == 6
 
 
 def test_untasked_unchanged_when_reserve_unchanged() -> None:
-    assert untasked_after_reserve_change(3, 3, 5) == 5
+    assert untasked_after_reserve_change(3, 3, 5, 8) == 5
 
 
 def test_untasked_floors_at_zero_when_reserve_exceeds_pool() -> None:
     # Only still-untasked jets can be benched; already-tasked flights are never
-    # retroactively un-planned, so the pool floors at 0.
-    assert untasked_after_reserve_change(0, 5, 2) == 0
+    # retroactively un-planned, so the pool floors at 0. owned 10, 8 tasked.
+    assert untasked_after_reserve_change(0, 5, 2, 10) == 0
+
+
+def test_untasked_capped_at_owned_after_attrition() -> None:
+    # Attrition left owned 2 below reserve 4; return_all floored untasked to 0.
+    # Lowering reserve to 1 must free only the 1 jet that exists beyond the new
+    # reserve (max 2-1), NOT the delta of 3.
+    assert untasked_after_reserve_change(4, 1, 0, 2) == 1
 
 
 def test_max_reserve_capped_by_unplanned_airframes() -> None:

--- a/tests/squadrons/test_squadron_inventory.py
+++ b/tests/squadrons/test_squadron_inventory.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+from game.settings import Settings
+from game.squadrons.squadron import Squadron
+
+
+def _bare_squadron(
+    owned: int, reserve: int, intercept_enabled: bool = True
+) -> Squadron:
+    squadron = Squadron.__new__(Squadron)
+    squadron.current_roster = []
+    squadron.owned_aircraft = owned
+    squadron.intercept_reserve = reserve
+    squadron.settings = cast(
+        Settings, SimpleNamespace(plugins={"intercept": intercept_enabled})
+    )
+    return squadron
+
+
+def test_reset_holds_back_qra_reserve_from_plannable_inventory() -> None:
+    squadron = _bare_squadron(owned=10, reserve=4)
+    squadron.return_all_pilots_and_aircraft()
+    assert squadron.untasked_aircraft == 6
+
+
+def test_reset_with_zero_reserve_leaves_all_aircraft_plannable() -> None:
+    squadron = _bare_squadron(owned=10, reserve=0)
+    squadron.return_all_pilots_and_aircraft()
+    assert squadron.untasked_aircraft == 10
+
+
+def test_reset_clamps_plannable_inventory_at_zero() -> None:
+    squadron = _bare_squadron(owned=3, reserve=5)
+    squadron.return_all_pilots_and_aircraft()
+    assert squadron.untasked_aircraft == 0
+
+
+def test_reset_benches_reserve_regardless_of_plugin_flag() -> None:
+    # The reserve (intercept_reserve > 0) is the single on/off switch for QRA:
+    # emission and loss commit gate on it alone, so benching must too. The plugin
+    # flag must NOT change benching, otherwise a reserve could be both
+    # ATO-plannable and fielded as QRA.
+    squadron = _bare_squadron(owned=10, reserve=4, intercept_enabled=False)
+    squadron.return_all_pilots_and_aircraft()
+    assert squadron.untasked_aircraft == 6

--- a/tests/squadrons/test_squadron_inventory.py
+++ b/tests/squadrons/test_squadron_inventory.py
@@ -46,3 +46,25 @@ def test_reset_benches_reserve_regardless_of_plugin_flag() -> None:
     squadron = _bare_squadron(owned=10, reserve=4, intercept_enabled=False)
     squadron.return_all_pilots_and_aircraft()
     assert squadron.untasked_aircraft == 6
+
+
+def test_set_intercept_reserve_releases_jets_into_pool_immediately() -> None:
+    # Editing the reserve mid-turn must update the plannable pool at once, without
+    # a full return_all_pilots_and_aircraft() (which would return tasked flights).
+    squadron = _bare_squadron(owned=10, reserve=4)
+    squadron.return_all_pilots_and_aircraft()
+    assert squadron.untasked_aircraft == 6
+
+    squadron.set_intercept_reserve(0)
+    assert squadron.intercept_reserve == 0
+    assert squadron.untasked_aircraft == 10
+
+
+def test_set_intercept_reserve_benches_jets_immediately() -> None:
+    squadron = _bare_squadron(owned=10, reserve=0)
+    squadron.return_all_pilots_and_aircraft()
+    assert squadron.untasked_aircraft == 10
+
+    squadron.set_intercept_reserve(4)
+    assert squadron.intercept_reserve == 4
+    assert squadron.untasked_aircraft == 6

--- a/tests/squadrons/test_squadron_pilots.py
+++ b/tests/squadrons/test_squadron_pilots.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+from game.settings import Settings
+from game.squadrons.pilot import Pilot, PilotStatus
+from game.squadrons.squadron import Squadron
+
+
+def _squadron(available: list[Pilot], invulnerable_players: bool = False) -> Squadron:
+    squadron = Squadron.__new__(Squadron)
+    squadron.available_pilots = available
+    squadron.settings = cast(
+        Settings, SimpleNamespace(invulnerable_player_pilots=invulnerable_players)
+    )
+    return squadron
+
+
+def _dead(pilots: list[Pilot]) -> int:
+    return sum(p.status is PilotStatus.Dead for p in pilots)
+
+
+def test_lose_pilots_kills_the_requested_count() -> None:
+    pilots = [Pilot(f"AI {i}") for i in range(4)]
+    _squadron(list(pilots)).lose_pilots(2)
+    assert _dead(pilots) == 2
+
+
+def test_lose_pilots_only_touches_untasked_pilots() -> None:
+    # A pilot tasked to another flight has been claimed (removed from
+    # available_pilots) and must not be killed by a QRA loss.
+    tasked = Pilot("Tasked")
+    idle = Pilot("Idle")
+    _squadron([idle]).lose_pilots(2)
+    assert idle.status is PilotStatus.Dead
+    assert tasked.status is PilotStatus.Active
+
+
+def test_lose_pilots_prefers_ai_over_players() -> None:
+    player = Pilot("Ace", player=True)
+    ai = Pilot("Wingman", player=False)
+    _squadron([player, ai]).lose_pilots(1)
+    assert ai.status is PilotStatus.Dead
+    assert player.status is PilotStatus.Active
+
+
+def test_lose_pilots_spares_players_when_invulnerable() -> None:
+    player = Pilot("Ace", player=True)
+    _squadron([player], invulnerable_players=True).lose_pilots(1)
+    assert player.status is PilotStatus.Active
+
+
+def test_lose_pilots_kills_players_when_no_ai_and_vulnerable() -> None:
+    player = Pilot("Ace", player=True)
+    _squadron([player]).lose_pilots(1)
+    assert player.status is PilotStatus.Dead
+
+
+def test_lose_pilots_removes_dead_pilots_from_available() -> None:
+    pilots = [Pilot("AI 1"), Pilot("AI 2")]
+    squadron = _squadron(pilots)
+    squadron.lose_pilots(1)
+    assert len(squadron.available_pilots) == 1
+    assert squadron.available_pilots[0].name == "AI 2"
+
+
+def test_lose_pilots_caps_at_available_pilots() -> None:
+    pilots = [Pilot("AI 1"), Pilot("AI 2")]
+    _squadron(list(pilots)).lose_pilots(5)
+    assert _dead(pilots) == 2

--- a/tests/squadrons/test_squadron_setstate.py
+++ b/tests/squadrons/test_squadron_setstate.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from game.squadrons.squadron import Squadron
+
+
+def test_setstate_defaults_intercept_reserve_for_old_saves() -> None:
+    # Old saves pickled before this field existed must load with the default.
+    squadron = Squadron.__new__(Squadron)
+    squadron.__setstate__({"name": "Test", "livery_set": []})
+    assert squadron.intercept_reserve == 0
+
+
+def test_setstate_preserves_saved_intercept_reserve() -> None:
+    squadron = Squadron.__new__(Squadron)
+    squadron.__setstate__({"name": "Test", "livery_set": [], "intercept_reserve": 3})
+    assert squadron.intercept_reserve == 3

--- a/tests/test_debriefing.py
+++ b/tests/test_debriefing.py
@@ -207,3 +207,9 @@ def test_state_data_intercept_survivors_defaults_to_empty() -> None:
     """StateData.from_json defaults intercept_survivors to {} when key absent."""
     state = StateData.from_json({}, _minimal_unit_map())
     assert state.intercept_survivors == {}
+
+
+def test_state_data_intercept_survivors_tolerates_empty_lua_array() -> None:
+    """An empty Lua table serializes to [] in JSON; from_json must not crash."""
+    state = StateData.from_json({"intercept_survivors": []}, _minimal_unit_map())
+    assert state.intercept_survivors == {}

--- a/tests/test_debriefing.py
+++ b/tests/test_debriefing.py
@@ -8,6 +8,7 @@ from game.debriefing import (
     Debriefing,
     GroundLosses,
     SideLossCounts,
+    StateData,
 )
 from game.theater import ControlPoint, Player
 
@@ -58,7 +59,49 @@ def _sample_debriefing() -> Debriefing:
     debriefing.air_losses = air
     debriefing.ground_losses = ground
     debriefing.base_captures = captures
+    # loss_counts now also folds in survivor-based QRA losses; default to none.
+    debriefing.state_data = cast(StateData, SimpleNamespace(intercept_survivors={}))
+    debriefing.game = MagicMock()
+    debriefing.game.blue.air_wing.iter_squadrons.return_value = []
+    debriefing.game.red.air_wing.iter_squadrons.return_value = []
     return debriefing
+
+
+def _qra_squadron(
+    squadron_id: str, reserve: int, owned: int, aircraft: Any
+) -> MagicMock:
+    squadron = MagicMock()
+    squadron.id = squadron_id
+    squadron.intercept_reserve = reserve
+    squadron.owned_aircraft = owned
+    squadron.pilot_limits_enabled = False
+    squadron.aircraft = aircraft
+    return squadron
+
+
+def test_qra_losses_folded_into_aircraft_counts() -> None:
+    """QRA interceptors are Moose-spawned (not ATO flights), so their losses come
+    from survivor counts, not air_losses. They must still show in the debrief."""
+    debriefing = _sample_debriefing()  # ATO air losses: blue 1, red 2
+    mig19 = MagicMock(name="MiG-19P")
+    # Blue QRA squadron fielded 2, 0 survivors -> 2 lost. Red enrolled but all
+    # survived -> 0 lost.
+    blue_sq = _qra_squadron("blue-qra", reserve=2, owned=4, aircraft=mig19)
+    red_sq = _qra_squadron("red-qra", reserve=2, owned=4, aircraft=MagicMock())
+    debriefing.state_data = cast(
+        StateData,
+        SimpleNamespace(intercept_survivors={"blue-qra": 0, "red-qra": 2}),
+    )
+    game: Any = debriefing.game
+    game.blue.air_wing.iter_squadrons.return_value = [blue_sq]
+    game.red.air_wing.iter_squadrons.return_value = [red_sq]
+
+    assert debriefing.qra_losses_by_type(Player.BLUE) == {mig19: 2}
+    assert debriefing.qra_losses_by_type(Player.RED) == {}
+    # ATO (1) + QRA (2) for blue; red unchanged (ATO 2 + QRA 0).
+    assert debriefing.loss_counts(Player.BLUE).aircraft == 3
+    assert debriefing.loss_counts(Player.RED).aircraft == 2
+    assert debriefing.aircraft_losses_by_type(Player.BLUE)[mig19] == 2
 
 
 def test_loss_counts_blue_side() -> None:
@@ -136,3 +179,31 @@ def test_motorpool_losses_by_type_counts_per_side() -> None:
 
     assert debriefing.motorpool_losses_by_type(Player.BLUE) == {t90: 2, bmp: 1}
     assert debriefing.motorpool_losses_by_type(Player.RED) == {bmp: 1}
+
+
+def _minimal_unit_map() -> MagicMock:
+    """A UnitMap mock where every unit lookup returns None (no aircraft/ground units)."""
+    unit_map = MagicMock()
+    unit_map.flight.return_value = None
+    return unit_map
+
+
+def test_state_data_parses_intercept_survivors() -> None:
+    """StateData.from_json reads intercept_survivors from the JSON payload."""
+    data = {
+        "intercept_survivors": {
+            "aaaaaaaa-0000-0000-0000-000000000001": 2,
+            "aaaaaaaa-0000-0000-0000-000000000002": 0,
+        }
+    }
+    state = StateData.from_json(data, _minimal_unit_map())
+    assert state.intercept_survivors == {
+        "aaaaaaaa-0000-0000-0000-000000000001": 2,
+        "aaaaaaaa-0000-0000-0000-000000000002": 0,
+    }
+
+
+def test_state_data_intercept_survivors_defaults_to_empty() -> None:
+    """StateData.from_json defaults intercept_survivors to {} when key absent."""
+    state = StateData.from_json({}, _minimal_unit_map())
+    assert state.intercept_survivors == {}

--- a/tests/test_game_qra_propagation.py
+++ b/tests/test_game_qra_propagation.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+from game.coalition import Coalition
+from game.game import Game
+from game.settings import Settings
+
+
+def test_coordinator_maps_ownfor_to_blue_and_opfor_to_red() -> None:
+    recorded: list[tuple[str, int, int]] = []
+
+    def _wing(tag: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            repropagate_qra_reserve=(
+                lambda old, new, _tag=tag: recorded.append((_tag, old, new))
+            )
+        )
+
+    game = Game.__new__(Game)
+    game.blue = cast(Coalition, SimpleNamespace(air_wing=_wing("blue")))
+    game.red = cast(Coalition, SimpleNamespace(air_wing=_wing("red")))
+    game.settings = cast(
+        Settings,
+        SimpleNamespace(ownfor_default_qra_reserve=4, opfor_default_qra_reserve=3),
+    )
+
+    game.repropagate_qra_reserves(old_ownfor=0, old_opfor=1)
+
+    # New values come from settings; blue<-OWNFOR, red<-OPFOR, not swapped.
+    assert recorded == [("blue", 0, 4), ("red", 1, 3)]

--- a/tests/test_intercept_loss_commit.py
+++ b/tests/test_intercept_loss_commit.py
@@ -1,0 +1,154 @@
+"""Regression tests for QRA attrition reconciliation in
+``MissionResultsProcessor.commit_intercept_losses``.
+
+The dispatcher is only seeded with the *fielded* count
+(``qra_resource_count`` = reserve capped by owned airframes and untasked
+pilots), and the Lua bounds reported survivors by that fielded count. The loss
+baseline must therefore be the fielded count, not the raw ``intercept_reserve``
+-- otherwise an under-strength squadron loses airframes (and pilots) that never
+flew, and does so every turn, spiralling to zero with no combat.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from uuid import uuid4
+
+from game.debriefing import Debriefing
+from game.settings import Settings
+from game.sim.missionresultsprocessor import MissionResultsProcessor
+from game.squadrons.pilot import Pilot
+from game.squadrons.squadron import Squadron
+
+
+def _squadron(*, reserve: int, owned: int, pilots: int, pilot_limits: bool) -> Squadron:
+    squadron = Squadron.__new__(Squadron)
+    squadron.id = uuid4()
+    squadron.name = "Test Squadron"
+    squadron.nickname = None
+    squadron.intercept_reserve = reserve
+    squadron.owned_aircraft = owned
+    squadron.available_pilots = [Pilot(f"AI {i}") for i in range(pilots)]
+    squadron.settings = cast(
+        Settings,
+        SimpleNamespace(
+            invulnerable_player_pilots=False,
+            enable_squadron_pilot_limits=pilot_limits,
+        ),
+    )
+    return squadron
+
+
+def _processor(squadrons: list[Squadron]) -> MissionResultsProcessor:
+    return _processor_split(squadrons, [])
+
+
+def _processor_split(
+    blue: list[Squadron], red: list[Squadron]
+) -> MissionResultsProcessor:
+    game = SimpleNamespace(
+        blue=SimpleNamespace(air_wing=SimpleNamespace(iter_squadrons=lambda: blue)),
+        red=SimpleNamespace(air_wing=SimpleNamespace(iter_squadrons=lambda: red)),
+    )
+    return MissionResultsProcessor(cast(Any, game))
+
+
+def _debrief(survivors: dict[str, int]) -> Debriefing:
+    return cast(
+        Debriefing,
+        SimpleNamespace(state_data=SimpleNamespace(intercept_survivors=survivors)),
+    )
+
+
+def test_understrength_squadron_takes_no_phantom_loss() -> None:
+    # reserve 6 but only 4 owned -> fields 4; all 4 survive -> zero real losses.
+    squadron = _squadron(reserve=6, owned=4, pilots=4, pilot_limits=False)
+    processor = _processor([squadron])
+    processor.commit_intercept_losses(_debrief({str(squadron.id): 4}))
+    assert squadron.owned_aircraft == 4
+    assert len(squadron.available_pilots) == 4
+
+
+def test_pilot_capped_squadron_takes_no_phantom_loss() -> None:
+    # reserve 6, 10 owned, but only 3 untasked pilots -> fields 3; all survive.
+    squadron = _squadron(reserve=6, owned=10, pilots=3, pilot_limits=True)
+    processor = _processor([squadron])
+    processor.commit_intercept_losses(_debrief({str(squadron.id): 3}))
+    assert squadron.owned_aircraft == 10
+    assert len(squadron.available_pilots) == 3
+
+
+def test_genuine_losses_still_applied() -> None:
+    # reserve 6, 10 owned, pilots ample -> fields 6; only 2 survive -> 4 lost.
+    squadron = _squadron(reserve=6, owned=10, pilots=8, pilot_limits=False)
+    processor = _processor([squadron])
+    processor.commit_intercept_losses(_debrief({str(squadron.id): 2}))
+    assert squadron.owned_aircraft == 6
+    assert len(squadron.available_pilots) == 4
+
+
+def test_pilot_limits_enabled_owned_is_binding_no_phantom_loss() -> None:
+    # pilot limits on, but owned (2) binds below both reserve (6) and pilots (10)
+    # -> fields 2; both survive -> no loss, no pilot deaths.
+    squadron = _squadron(reserve=6, owned=2, pilots=10, pilot_limits=True)
+    processor = _processor([squadron])
+    processor.commit_intercept_losses(_debrief({str(squadron.id): 2}))
+    assert squadron.owned_aircraft == 2
+    assert len(squadron.available_pilots) == 10
+
+
+def test_pilot_limited_squadron_genuine_losses() -> None:
+    # pilot limits on, pilots (4) bind -> fields 4; 1 survives -> 3 lost, 3 pilots
+    # killed (AI), owned drops 10 -> 7.
+    squadron = _squadron(reserve=6, owned=10, pilots=4, pilot_limits=True)
+    processor = _processor([squadron])
+    processor.commit_intercept_losses(_debrief({str(squadron.id): 1}))
+    assert squadron.owned_aircraft == 7
+    assert len(squadron.available_pilots) == 1
+
+
+def test_red_coalition_losses_committed() -> None:
+    # A squadron in only the red wing is processed identically; guards against a
+    # refactor silently dropping red from the iteration.
+    squadron = _squadron(reserve=4, owned=10, pilots=8, pilot_limits=False)
+    processor = _processor_split([], [squadron])
+    processor.commit_intercept_losses(_debrief({str(squadron.id): 1}))
+    assert squadron.owned_aircraft == 7
+    assert len(squadron.available_pilots) == 5
+
+
+def test_multiple_squadrons_mixed_outcomes() -> None:
+    # One taking losses, one absent from the survivor map (no participation, no
+    # loss), one fully surviving -- all in one commit.
+    losing = _squadron(reserve=4, owned=10, pilots=8, pilot_limits=False)
+    absent = _squadron(reserve=4, owned=10, pilots=8, pilot_limits=False)
+    survived = _squadron(reserve=4, owned=10, pilots=8, pilot_limits=False)
+    processor = _processor([losing, absent, survived])
+    processor.commit_intercept_losses(
+        _debrief({str(losing.id): 1, str(survived.id): 4})
+    )
+    assert losing.owned_aircraft == 7
+    assert len(losing.available_pilots) == 5
+    assert absent.owned_aircraft == 10
+    assert len(absent.available_pilots) == 8
+    assert survived.owned_aircraft == 10
+    assert len(survived.available_pilots) == 8
+
+
+def test_zero_reserve_squadron_skipped_even_if_in_survivors() -> None:
+    # reserve 0 -> never fielded; a stale survivor entry must not touch it.
+    squadron = _squadron(reserve=0, owned=10, pilots=8, pilot_limits=False)
+    processor = _processor([squadron])
+    processor.commit_intercept_losses(_debrief({str(squadron.id): 0}))
+    assert squadron.owned_aircraft == 10
+    assert len(squadron.available_pilots) == 8
+
+
+def test_owned_zero_squadron_not_charged_even_if_in_survivors() -> None:
+    # reserve 4 but nothing owned -> fields 0; a survivor entry is a no-op.
+    squadron = _squadron(reserve=4, owned=0, pilots=8, pilot_limits=False)
+    processor = _processor([squadron])
+    processor.commit_intercept_losses(_debrief({str(squadron.id): 0}))
+    assert squadron.owned_aircraft == 0
+    assert len(squadron.available_pilots) == 8

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -1,0 +1,77 @@
+"""Regression tests for save-game migration (game.migrator.Migrator)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from game.migrator import Migrator
+from game.squadrons.squadron import Squadron
+
+
+def _qra_squadron(owned: int, reserve: int) -> Squadron:
+    """A minimal squadron holding a QRA reserve, with no pilot roster.
+
+    Built without __init__ -- the migrator path under test only touches
+    inventory counts, the (empty) roster, and claim_available_pilot (mocked).
+    """
+    squadron = Squadron.__new__(Squadron)
+    squadron.id = uuid4()
+    squadron.name = "010"
+    squadron.owned_aircraft = owned
+    squadron.intercept_reserve = reserve
+    squadron.current_roster = []
+    squadron.available_pilots = []
+    return squadron
+
+
+def test_release_untasked_flights_respects_qra_reserve() -> None:
+    """An old save whose flights were planned against the full owned count must
+    still load once the squadron holds a QRA reserve.
+
+    return_all_pilots_and_aircraft() benches the reserve (untasked = owned -
+    intercept_reserve), so _release_untasked_flights must claim against
+    untasked_aircraft, not owned_aircraft -- otherwise claim_inventory raises
+    "Cannot remove 14 from Squadron 010. Only have 10." and the app reports the
+    save as incompatible.
+    """
+    squadron = _qra_squadron(owned=14, reserve=4)  # untasked == 10
+    # Flights task all 14 airframes -- more than the 10 untasked after reserve.
+    flights = [SimpleNamespace(squadron=squadron, count=7) for _ in range(2)]
+    squadron.flight_db = cast(
+        Any, SimpleNamespace(objects={i: f for i, f in enumerate(flights)})
+    )
+    squadron.claim_available_pilot = MagicMock()  # type: ignore[method-assign]
+
+    cp = SimpleNamespace(squadrons=[squadron])
+    game = cast(Any, SimpleNamespace(theater=SimpleNamespace(controlpoints=[cp])))
+
+    migrator = Migrator.__new__(Migrator)
+    migrator.game = game
+
+    migrator._release_untasked_flights()  # must not raise
+
+    assert squadron.untasked_aircraft == 0  # all 10 untasked claimed by flights
+    assert squadron.owned_aircraft == 14  # owned unchanged; 4 still on reserve
+    assert squadron.claim_available_pilot.call_count == 10
+
+
+def test_release_untasked_flights_zero_reserve_unchanged() -> None:
+    """With no QRA reserve, untasked == owned, so behaviour is the pre-fix one:
+    flights claim min(count, owned)."""
+    squadron = _qra_squadron(owned=10, reserve=0)
+    flights = [SimpleNamespace(squadron=squadron, count=3)]
+    squadron.flight_db = cast(Any, SimpleNamespace(objects={0: flights[0]}))
+    squadron.claim_available_pilot = MagicMock()  # type: ignore[method-assign]
+
+    cp = SimpleNamespace(squadrons=[squadron])
+    game = cast(Any, SimpleNamespace(theater=SimpleNamespace(controlpoints=[cp])))
+
+    migrator = Migrator.__new__(Migrator)
+    migrator.game = game
+    migrator._release_untasked_flights()
+
+    assert squadron.untasked_aircraft == 7  # 10 owned - 3 claimed
+    assert squadron.claim_available_pilot.call_count == 3

--- a/tests/test_missionresultsprocessor.py
+++ b/tests/test_missionresultsprocessor.py
@@ -25,6 +25,7 @@ from game.theater import ControlPoint
 #: this list fails ``test_battle_impact_scored_before_captures_flip_ownership``.
 COMMIT_STEPS = [
     "commit_air_losses",
+    "commit_intercept_losses",
     "commit_pilot_experience",
     "commit_front_line_losses",
     "commit_motorpool_losses",

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Optional, cast
+from unittest.mock import MagicMock
+
+from dcs.country import Country
+
+from game.ato.flight import Flight
+from game.ato.flighttype import FlightType
+from game.naming import NameGenerator
+
+
+def _fake_flight(
+    flight_type: FlightType, custom_name: Optional[str], target_name: str
+) -> Flight:
+    flight = MagicMock()
+    flight.custom_name = custom_name
+    flight.flight_type = flight_type
+    flight.unit_type.variant_id = "F-16C_50"
+    flight.package.target.name = target_name
+    return cast(Flight, flight)
+
+
+def _fake_country(country_id: int) -> Country:
+    country = MagicMock()
+    country.id = country_id
+    return cast(Country, country)
+
+
+def test_next_aircraft_name_uses_target_and_task() -> None:
+    NameGenerator.reset_numbers()
+    name = NameGenerator.next_aircraft_name(
+        _fake_country(5), _fake_flight(FlightType.STRIKE, None, "Tiyas")
+    )
+    assert name.startswith("Tiyas Strike|5|")
+
+
+def test_next_aircraft_name_custom_name_keeps_task() -> None:
+    # dr-99hm: a custom name must still carry the task type so the Moose QRA
+    # filter (and debrief attribution) can classify the flight from its group
+    # name. Before the fix, a custom name dropped the task entirely.
+    NameGenerator.reset_numbers()
+    name = NameGenerator.next_aircraft_name(
+        _fake_country(6), _fake_flight(FlightType.BAI, "Alpha", "Tiyas")
+    )
+    assert name.startswith("Alpha BAI|6|")

--- a/tests/test_qra_reserve_settings.py
+++ b/tests/test_qra_reserve_settings.py
@@ -1,0 +1,38 @@
+from game.settings.settings import Settings
+
+
+def test_ownfor_default_qra_reserve_defaults_to_zero() -> None:
+    assert Settings().ownfor_default_qra_reserve == 0
+
+
+def test_opfor_default_qra_reserve_defaults_to_zero() -> None:
+    assert Settings().opfor_default_qra_reserve == 0
+
+
+def test_qra_gci_max_radius_defaults_to_hundred() -> None:
+    assert Settings().qra_gci_max_radius_nm == 100
+
+
+def test_qra_engagement_range_defaults_to_sixty() -> None:
+    assert Settings().qra_engagement_range_nm == 60
+
+
+def test_qra_comms_enabled_defaults_to_true() -> None:
+    assert Settings().qra_comms_enabled is True
+
+
+def test_qra_settings_are_user_visible() -> None:
+    # Settings.fields() walks dataclass fields whose metadata carries the
+    # option-description key; all new settings must be discoverable so the
+    # settings window renders them.
+    names = {
+        name
+        for page in Settings.pages()
+        for section in Settings.sections(page)
+        for name, _description in Settings.fields(page, section)
+    }
+    assert "ownfor_default_qra_reserve" in names
+    assert "opfor_default_qra_reserve" in names
+    assert "qra_gci_max_radius_nm" in names
+    assert "qra_engagement_range_nm" in names
+    assert "qra_comms_enabled" in names

--- a/tests/test_qra_reserve_settings.py
+++ b/tests/test_qra_reserve_settings.py
@@ -9,12 +9,12 @@ def test_opfor_default_qra_reserve_defaults_to_zero() -> None:
     assert Settings().opfor_default_qra_reserve == 0
 
 
-def test_qra_gci_max_radius_defaults_to_hundred() -> None:
-    assert Settings().qra_gci_max_radius_nm == 100
+def test_qra_gci_max_radius_defaults_to_sixty() -> None:
+    assert Settings().qra_gci_max_radius_nm == 60
 
 
-def test_qra_engagement_range_defaults_to_sixty() -> None:
-    assert Settings().qra_engagement_range_nm == 60
+def test_qra_engagement_range_defaults_to_thirty_eight() -> None:
+    assert Settings().qra_engagement_range_nm == 38
 
 
 def test_qra_comms_enabled_defaults_to_true() -> None:


### PR DESCRIPTION
## Intercept (QRA): hot-alert interceptors that scramble on EWR detection

Adds a Quick Reaction Alert system: per-squadron reserve aircraft that sit hot on alert and scramble to intercept inbound raids when the enemy is detected by the radar network — driven by Moose's `AI_A2A_DISPATCHER`, for both coalitions.

### What it does

- **Per-squadron QRA reserve.** A first-class `intercept_reserve` on each BARCAP-capable squadron, **carved out of the plannable inventory** so reserved airframes/pilots aren't double-booked by the ATO. Editable in three places (Air Wing config, Squadron dialog, recruitment menu), propagated wing-wide, and saved with the campaign.
- **Real GCI via Moose EWR integration.** Detection comes from the **same IADS EWR / SAM-as-EWR network Skynet uses** (`dcsRetribution.IADS`), feeding a per-coalition `AI_A2A_DISPATCHER`.
- **Attrition + debrief accounting.** QRA losses are reconciled from in-mission survivors and folded into the debrief loss report, so reserve aircraft shot down on alert are counted like any other loss.

### Why in-air spawns

Cold/hot/runway ground spawns repeatedly left interceptors stuck and unable to taxi on some fields, even when there was no congestion on the taxiways (e.g. Tiyas). In-air spawning (`SetDefaultTakeoffInAir`) is the only method that reliably escapes a congested ground and gets the QRA airborne in time to matter while not affecting any previously planned flights trying to taxi or use the runway.

There was a latent Moose bug that was breaking the in-air spawns, so monkeypatched that to avoid modifying the vendored MOOSE copy. Filed the permanetfix as **[MOOSE #2595](https://github.com/FlightControl-Master/MOOSE/pull/2595)** — the monkeypatch can be dropped once that lands in retribution's copy of Moose.

### Configuration (Campaign Doctrine)

| Setting | Default | Range |
|---|---|---|
| Default QRA reserve per OWNFOR interceptor squadron | 0 | 0–12 |
| Default QRA reserve per OPFOR interceptor squadron | 0 | 0–12 |
| QRA GCI max scramble radius (NM) — gates how close a raid must be before a base scrambles | 100 | 1–400 |
| QRA interceptor engagement range (NM) — how far a scrambled interceptor chases before disengaging (`SetEngageRadius`) | 60 | 1–200 |
| QRA radio scramble callouts (scramble / wheels-up / engaging / RTB) | on | toggle |

Defaults are 0 reserve, so the feature is **off until a player opts in** — existing campaigns are unaffected. Per-squadron values can be tuned after new-game start.

Fixes #682 