### PR TITLE
Create new scramble logic for dormant aircraft

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[Mission]** Add reactive GCI scramble support. RED untasked, uncontrolled, air-to-air-capable aircraft can sit cold on the ramp as dormant interceptors; when a Blue aircraft is detected by the RED radar network, `reactive_scramble.lua` wakes the nearest available group and tasks it to intercept.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.
 * **[UX]** Avoid having escorts from wondering off too far while chasing a target.

--- a/game/missiongenerator/aircraft/aircraftgenerator.py
+++ b/game/missiongenerator/aircraft/aircraftgenerator.py
@@ -48,6 +48,9 @@ if TYPE_CHECKING:
     from game.squadrons import Squadron
 
 
+MAX_SCRAMBLE_GROUPS_PER_AIRFIELD = 4
+
+
 class AircraftGenerator:
     def __init__(
         self,
@@ -79,6 +82,7 @@ class AircraftGenerator:
         self.ground_spawns_roadbase = ground_spawns_roadbase
         self.ground_spawns_large = ground_spawns_large
         self.ground_spawns = ground_spawns
+        self.scramble_groups_by_control_point: dict[ControlPoint, int] = {}
 
         self.ewrj_package_dict: Dict[int, List[FlyingGroup[Any]]] = {}
         self.ewrj = settings.plugins.get("ewrj")
@@ -247,10 +251,33 @@ class AircraftGenerator:
         ):
             return
 
+        is_scramble_eligible_squadron = (
+            squadron.coalition.player.is_red
+            and (
+                squadron.aircraft.capable_of(FlightType.BARCAP)
+                or squadron.aircraft.capable_of(FlightType.SWEEP)
+            )
+            and not (
+                squadron.aircraft.flyable
+                and (
+                    self.game.settings.enable_squadron_pilot_limits
+                    or squadron.number_of_available_pilots > 0
+                )
+                and self.game.settings.untasked_opfor_client_slots
+            )
+        )
+
         for _ in range(squadron.untasked_aircraft):
+            scramble_group_count = self.scramble_groups_by_control_point.get(
+                squadron.location, 0
+            )
+            can_be_scramble = (
+                is_scramble_eligible_squadron
+                and scramble_group_count < MAX_SCRAMBLE_GROUPS_PER_AIRFIELD
+            )
             # Creating a flight even those this isn't a fragged mission lets us
-            # reuse the existing debriefing code.
-            # TODO: Special flight type?
+            # reuse the existing debriefing code. Use BARCAP for A/A loadout
+            # selection, but name idle RED fighters as Scramble/QRA assets.
             flight = Flight(
                 Package(squadron.location, self.game.db.flights),
                 squadron,
@@ -258,6 +285,9 @@ class AircraftGenerator:
                 FlightType.BARCAP,
                 StartType.COLD,
                 divert=None,
+                custom_name=(
+                    f"{squadron.location.name} Scramble" if can_be_scramble else None
+                ),
                 claim_inv=False,
             )
             flight.state = Completed(flight, self.game.settings)
@@ -287,6 +317,15 @@ class AircraftGenerator:
                     )
                     group.uncontrolled = False
                     group.units[0].skill = Skill.Client
+                # Reactive GCI scramble pool: a RED group left uncontrolled (cold
+                # on the ramp) that can fly air-to-air becomes a dormant
+                # interceptor. reactive_scramble.lua wakes the nearest one when a
+                # Blue threat is detected by the RED radar network.
+                if group.uncontrolled and can_be_scramble:
+                    self.mission_data.scramble_pool.append(group.name)
+                    self.scramble_groups_by_control_point[squadron.location] = (
+                        scramble_group_count + 1
+                    )
                 AircraftPainter(flight, group).apply_livery()
                 self.unit_map.add_aircraft(group, flight)
 

--- a/game/missiongenerator/luagenerator.py
+++ b/game/missiongenerator/luagenerator.py
@@ -41,10 +41,31 @@ class LuaGenerator:
             x for x in self.mission.triggerrules.triggers if isinstance(x, TriggerStart)
         ]
         self.generate_plugin_data()
+        # reactive_scramble.lua is injected below only when a scramble pool
+        # exists, so skip any plugin script work order to avoid double-loading.
+        self.bypass_plugin_script("scramble")
         self.inject_plugins()
+        self._inject_scramble_script()
         for t in ewrj_triggers:
             self.mission.triggerrules.triggers.remove(t)
             self.mission.triggerrules.triggers.append(t)
+
+    def _inject_scramble_script(self) -> None:
+        """Inject reactive_scramble.lua as a core mission script."""
+        if not self.mission_data.scramble_pool:
+            return
+        script_path = Path("./resources/plugins/scramble/reactive_scramble.lua")
+        if not script_path.exists():
+            logging.error(
+                "reactive_scramble.lua not found at %s - RED scramble pool will "
+                "stay dormant",
+                script_path.resolve(),
+            )
+            return
+        trigger = TriggerStart(comment="Load reactive_scramble (core GCI)")
+        fileref = self.mission.map_resource.add_resource_file(script_path.resolve())
+        trigger.add_action(DoScriptFile(fileref))
+        self.mission.triggerrules.triggers.append(trigger)
 
     def generate_plugin_data(self) -> None:
         lua_data = LuaData("dcsRetribution")
@@ -294,6 +315,19 @@ class LuaGenerator:
         trigger = TriggerStart(comment="Set DCS Retribution data")
         trigger.add_action(DoScript(String(lua_data.create_operations_lua())))
         self.mission.triggerrules.triggers.append(trigger)
+
+        # Emit the RED reactive-GCI scramble pool: names of uncontrolled untasked
+        # A/A groups collected in AircraftGenerator._spawn_unused_for.
+        if self.mission_data.scramble_pool:
+            lines = ["dcsRetribution.scramble_pool = {}"]
+            for name in self.mission_data.scramble_pool:
+                lines.append(
+                    "dcsRetribution.scramble_pool[#dcsRetribution.scramble_pool + 1]"
+                    f' = "{escape_string_for_lua(name)}"'
+                )
+            pool_trigger = TriggerStart(comment="Set DCS Retribution scramble pool")
+            pool_trigger.add_action(DoScript(String("\n".join(lines))))
+            self.mission.triggerrules.triggers.append(pool_trigger)
 
     def inject_lua_trigger(self, contents: str, comment: str) -> None:
         trigger = TriggerStart(comment=comment)

--- a/game/missiongenerator/missiondata.py
+++ b/game/missiongenerator/missiondata.py
@@ -125,3 +125,7 @@ class MissionData:
     cp_stack: dict[UUID, Distance] = field(default_factory=dict)
     player_frontline_groups: list[FrontlineUnitGroupsInfo] = field(default_factory=list)
     enemy_frontline_groups: list[FrontlineUnitGroupsInfo] = field(default_factory=list)
+    # Names of RED uncontrolled untasked A/A groups eligible for reactive GCI
+    # scramble. Emitted to the mission as dcsRetribution.scramble_pool and read
+    # by reactive_scramble.lua.
+    scramble_pool: list[str] = field(default_factory=list)

--- a/resources/plugins/plugins.json
+++ b/resources/plugins/plugins.json
@@ -6,13 +6,14 @@
     "bigeye",
     "dismounts",
     "ewrj",
+    "scramble",
     "ewrs",
     "herculescargo",
     "lotatc",
     "skynetiads",
     "splashdamage3",
     "airboss",
-    "MooseSoundhandler",    
+    "MooseSoundhandler",
     "MooseAutolase",
     "MooseMarkerOps"
 ]

--- a/resources/plugins/scramble/plugin.json
+++ b/resources/plugins/scramble/plugin.json
@@ -1,0 +1,23 @@
+{
+    "skipUI": false,
+    "nameInUI": "GCI Scramble",
+    "defaultValue": true,
+    "specificOptions": [
+        {
+            "nameInUI": "Intercept radius (NM)",
+            "mnemonic": "engageRadius",
+            "defaultValue": 51,
+            "minimumValue": 10,
+            "maximumValue": 160
+        },
+        {
+            "nameInUI": "Re-engage cooldown (seconds)",
+            "mnemonic": "reengageDelay",
+            "defaultValue": 180,
+            "minimumValue": 30,
+            "maximumValue": 600
+        }
+    ],
+    "scriptsWorkOrders": [],
+    "configurationWorkOrders": []
+}

--- a/resources/plugins/scramble/reactive_scramble.lua
+++ b/resources/plugins/scramble/reactive_scramble.lua
@@ -1,0 +1,224 @@
+-- ============================================================================
+-- REACTIVE SCRAMBLE v2.0 (Retribution GCI Scramble Plugin)
+-- Bundled automatically into every Retribution-generated .miz that has a
+-- non-empty RED untasked-aircraft scramble pool.
+-- ============================================================================
+--
+-- Retribution spawns each RED squadron's leftover untasked aircraft cold on the
+-- ramp as uncontrolled groups. The mission generator records the air-to-air
+-- capable groups in dcsRetribution.scramble_pool.
+--
+-- This script holds those groups dormant until a Blue aircraft is detected by
+-- the RED radar network within CFG_engageRadius, then wakes the nearest
+-- available one with StartUncontrolled and tasks it to intercept.
+--
+-- Cold-ramp behavior is intentional: an idle group starts cold, taxis, takes
+-- off, and hunts. Nothing flies until a threat appears.
+-- ============================================================================
+
+local CFG_scanInterval  = 15      -- seconds between threat scans
+local CFG_engageRadius  = 95000   -- metres, about 51 nm
+local CFG_reengageDelay = 180     -- seconds before a busy group re-qualifies
+local CFG_spawnDelay    = 1.0     -- seconds between Start command and setTask
+
+-- Retribution plugin config override. The config table is written by the
+-- mission-start data trigger, so read it on the next tick.
+timer.scheduleFunction(function()
+    if not (dcsRetribution and dcsRetribution.plugins and dcsRetribution.plugins.scramble) then return end
+    local c = dcsRetribution.plugins.scramble
+    if c.engageRadius ~= nil then CFG_engageRadius = c.engageRadius * 1852 end
+    if c.reengageDelay ~= nil then CFG_reengageDelay = c.reengageDelay end
+end, nil, timer.getTime() + 0)
+
+local _groups = {} -- name -> record
+
+local function log(msg)
+    BASE:E("=== SCRAMBLE: " .. tostring(msg))
+end
+
+local function dist3D(p1, p2)
+    local dx = p1.x - p2.x
+    local dy = (p1.y or 0) - (p2.y or 0)
+    local dz = p1.z - p2.z
+    return math.sqrt(dx * dx + dy * dy + dz * dz)
+end
+
+local function taskIntercept(rec)
+    local mg = GROUP:FindByName(rec.name)
+    if not mg or not mg:IsAlive() then return end
+
+    rec.group = mg
+    mg:OptionROEWeaponFree()
+    mg:OptionROTEvadeFire()
+
+    local ctrl = mg:GetController()
+    if ctrl then
+        ctrl:setTask({
+            id = "EngageTargets",
+            params = {
+                targetTypes = { "Air" },
+                maxDist = CFG_engageRadius,
+                priority = 0,
+            },
+        })
+    end
+end
+
+-- Wake a dormant uncontrolled group, then task it after a short delay so DCS
+-- finishes processing the Start command before setTask fires.
+local function spawnAndIntercept(rec)
+    local mg = GROUP:FindByName(rec.name)
+    if not mg then
+        log("ERROR: cannot find pool group: " .. rec.name)
+        return
+    end
+
+    rec.group = mg
+    rec.spawned = true
+    mg:StartUncontrolled()
+    log("Waking dormant group: " .. rec.name)
+
+    timer.scheduleFunction(function()
+        taskIntercept(rec)
+    end, nil, timer.getTime() + CFG_spawnDelay)
+end
+
+-- The pool table is written by a TriggerStart DoScript. Read it on the next
+-- tick so it is populated before registration.
+timer.scheduleFunction(function()
+    local pool = dcsRetribution and dcsRetribution.scramble_pool
+    if not pool then
+        log("WARNING: dcsRetribution.scramble_pool not available - no interceptors registered")
+        return
+    end
+
+    for _, name in ipairs(pool) do
+        if not _groups[name] then
+            local mg = GROUP:FindByName(name)
+            _groups[name] = {
+                name = name,
+                group = mg,
+                busy = false,
+                lastTasked = 0,
+                spawned = false,
+            }
+            log("Registered dormant interceptor: " .. name)
+        end
+    end
+end, nil, timer.getTime() + 0.1)
+
+local function getRedRadarPositions()
+    local pts = {}
+    for _, cat in ipairs({ Group.Category.GROUND, Group.Category.SHIP }) do
+        for _, g in ipairs(coalition.getGroups(coalition.side.RED, cat) or {}) do
+            if g and g:isExist() then
+                for _, u in ipairs(g:getUnits() or {}) do
+                    if u and u:isExist() then
+                        local d = u:getDesc()
+                        if d and d.sensor and d.sensor.radar then
+                            pts[#pts + 1] = u:getPoint()
+                            break
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return pts
+end
+
+local function detectBlueThreats(radarPts)
+    local threats = {}
+    local seen = {}
+
+    for _, g in ipairs(coalition.getGroups(coalition.side.BLUE, Group.Category.AIRPLANE) or {}) do
+        if g and g:isExist() and not seen[g:getName()] then
+            local units = g:getUnits()
+            local u = units and units[1]
+            if u and u:isExist() then
+                local pos = u:getPoint()
+                for _, rp in ipairs(radarPts) do
+                    if dist3D(pos, rp) <= CFG_engageRadius then
+                        threats[#threats + 1] = { group = g, pos = pos }
+                        seen[g:getName()] = true
+                        break
+                    end
+                end
+            end
+        end
+    end
+
+    return threats
+end
+
+-- Pick the nearest available pool group to the threat. Dormant groups report
+-- their parked position, so distance ranking works before they wake.
+local function selectGroup(threatPos)
+    local now = timer.getTime()
+    local best = nil
+    local bestDist = math.huge
+
+    for _, rec in pairs(_groups) do
+        local available = not rec.busy or (now - rec.lastTasked) > CFG_reengageDelay
+        local mg = rec.group or GROUP:FindByName(rec.name)
+        if available and mg and mg:IsAlive() then
+            rec.group = mg
+            local u1 = mg:GetUnit(1)
+            if u1 and u1:IsAlive() then
+                local d = dist3D(u1:GetVec3(), threatPos)
+                if d < bestDist then
+                    best = rec
+                    bestDist = d
+                end
+            end
+        end
+    end
+
+    return best
+end
+
+SCHEDULER:New(nil, function()
+    local radars = getRedRadarPositions()
+    if #radars == 0 then return end
+
+    local threats = detectBlueThreats(radars)
+
+    if #threats == 0 then
+        local now = timer.getTime()
+        for _, rec in pairs(_groups) do
+            if rec.busy and (now - rec.lastTasked) > CFG_reengageDelay then
+                rec.busy = false
+                log("Released: " .. rec.name)
+            end
+        end
+        return
+    end
+
+    for _, threat in ipairs(threats) do
+        local rec = selectGroup(threat.pos)
+        if rec then
+            local now = timer.getTime()
+            if not rec.busy or (now - rec.lastTasked) > CFG_reengageDelay then
+                rec.busy = true
+                rec.lastTasked = now
+
+                if rec.spawned then
+                    taskIntercept(rec)
+                else
+                    spawnAndIntercept(rec)
+                end
+
+                log("Scramble: " .. rec.name .. " -> " .. threat.group:getName())
+                MESSAGE:New("SCRAMBLE: interceptors launching!", 12):ToAll()
+            end
+        end
+    end
+end, {}, 10, CFG_scanInterval)
+
+timer.scheduleFunction(function()
+    local n = 0
+    for _ in pairs(_groups) do n = n + 1 end
+    log(string.format("ONLINE - %d dormant interceptor group(s)", n))
+    MESSAGE:New(string.format(
+        "REACTIVE SCRAMBLE ONLINE: %d dormant interceptor group(s)", n), 12):ToAll()
+end, nil, timer.getTime() + 2)

--- a/resources/plugins/scramble/reactive_scramble.lua
+++ b/resources/plugins/scramble/reactive_scramble.lua
@@ -1,111 +1,251 @@
 -- ============================================================================
--- REACTIVE SCRAMBLE v2.0 (Retribution GCI Scramble Plugin)
+-- REACTIVE SCRAMBLE v2.3  (Retribution GCI Scramble Plugin)
 -- Bundled automatically into every Retribution-generated .miz that has a
 -- non-empty RED untasked-aircraft scramble pool.
 -- ============================================================================
 --
--- Retribution spawns each RED squadron's leftover untasked aircraft cold on the
--- ramp as uncontrolled groups. The mission generator records the air-to-air
--- capable groups in dcsRetribution.scramble_pool.
+-- Retribution spawns each RED squadron's leftover ("untasked") aircraft cold on
+-- the ramp as UNCONTROLLED groups — parked, engines off, no route. The mission
+-- generator records the air-to-air-capable ones in dcsRetribution.scramble_pool.
 --
--- This script holds those groups dormant until a Blue aircraft is detected by
--- the RED radar network within CFG_engageRadius, then wakes the nearest
--- available one with StartUncontrolled and tasks it to intercept.
+-- This script holds those groups dormant until a Blue aircraft penetrates RED
+-- airspace (the dcsRetribution.scramble_border polygon), then wakes the nearest
+-- available one (StartUncontrolled) and tasks it to intercept with a MOOSE-built
+-- route plus attack tasking.
+-- When no border polygon is supplied it falls back to the legacy behaviour:
+-- a Blue aircraft detected by the RED radar network within CFG_engageRadius.
 --
--- Cold-ramp behavior is intentional: an idle group starts cold, taxis, takes
--- off, and hunts. Nothing flies until a threat appears.
+-- Cold-ramp behaviour is intentional: an idle group does a full cold start,
+-- taxis, takes off, and hunts. Nothing flies until a threat appears.
+--
+-- ── API NOTES ───────────────────────────────────────────────────────────────
+--  GROUP:StartUncontrolled() — issues the {id='Start'} command to a parked
+--                              uncontrolled group (cold start + taxi + takeoff)
+--  GROUP:Route()             — applies a MOOSE-built waypoint route to the group
+--  TaskAttackUnit            — MOOSE attack task applied at the intercept point
 -- ============================================================================
 
-local CFG_scanInterval  = 15      -- seconds between threat scans
-local CFG_engageRadius  = 95000   -- metres, about 51 nm
-local CFG_reengageDelay = 180     -- seconds before a busy group re-qualifies
-local CFG_spawnDelay    = 1.0     -- seconds between Start command and setTask
+local CFG_scanInterval   = 15     -- seconds between threat scans
+local CFG_engageRadius   = 95000  -- metres (~51 nm); radar-range detection fallback
+local CFG_interceptRange = 185000 -- metres (~100 nm); how far a scrambled QRA pursues
+local CFG_responseRadius = 138900 -- metres (~75 nm); max distance from threat to launch
+local CFG_interceptAlt   = 7000   -- metres (~23000 ft) intercept routing altitude
+local CFG_interceptSpeed = 900    -- km/h transit speed for MOOSE route building
+local CFG_reengageDelay  = 180    -- seconds before a busy group re-qualifies
+local CFG_spawnDelay     = 5.0    -- seconds after Start before tasking the intercept
+local CFG_vectorRefresh  = 45     -- seconds between re-vectors for an active intercept
+local CFG_debug          = true   -- periodic status line in dcs.log (radars/border)
 
--- Retribution plugin config override. The config table is written by the
--- mission-start data trigger, so read it on the next tick.
+-- ── Retribution plugin config override ────────────────────────────────────
+-- If a dcsRetribution.plugins.scramble block exists, apply it on the next tick
+-- after mission-start data triggers have fired.
+-- CFG_scanInterval is intentionally excluded — the SCHEDULER interval is
+-- captured at creation time and cannot be changed after the fact.
 timer.scheduleFunction(function()
     if not (dcsRetribution and dcsRetribution.plugins and dcsRetribution.plugins.scramble) then return end
     local c = dcsRetribution.plugins.scramble
-    if c.engageRadius ~= nil then CFG_engageRadius = c.engageRadius * 1852 end
-    if c.reengageDelay ~= nil then CFG_reengageDelay = c.reengageDelay end
+    if c.engageRadius   ~= nil then CFG_engageRadius   = c.engageRadius * 1852 end  -- NM → metres
+    if c.interceptRange ~= nil then CFG_interceptRange = c.interceptRange * 1852 end -- NM → metres
+    if c.responseRadius ~= nil then
+        CFG_responseRadius = c.responseRadius * 1852
+    elseif c.interceptRange ~= nil then
+        CFG_responseRadius = CFG_interceptRange
+    end
+    if c.reengageDelay  ~= nil then CFG_reengageDelay  = c.reengageDelay end
 end, nil, timer.getTime() + 0)
 
-local _groups = {} -- name -> record
+local _groups = {}            -- name -> record
+local _border = nil           -- list of { x=, z= } points (RED airspace polygon) or nil
+local _borderZone = nil       -- MOOSE polygon zone built from _border
+local _supportGroups = {}     -- blue support groups that should not trigger QRA
+local _targetAssignments = {} -- threat group name -> interceptor group name
 
-local function log(msg)
-    BASE:E("=== SCRAMBLE: " .. tostring(msg))
-end
+-- ── UTILITIES ────────────────────────────────────────────────────────────────
+
+local function log(msg) BASE:E("=== SCRAMBLE: " .. tostring(msg)) end
 
 local function dist3D(p1, p2)
-    local dx = p1.x - p2.x
-    local dy = (p1.y or 0) - (p2.y or 0)
-    local dz = p1.z - p2.z
-    return math.sqrt(dx * dx + dy * dy + dz * dz)
+    local dx, dy, dz = p1.x-p2.x, (p1.y or 0)-(p2.y or 0), p1.z-p2.z
+    return math.sqrt(dx*dx + dy*dy + dz*dz)
 end
+
+local function addSupportGroup(name)
+    if name and name ~= "" then
+        _supportGroups[name] = true
+    end
+end
+
+local function indexSupportGroups()
+    if not dcsRetribution then return end
+
+    for _, jtac in ipairs(dcsRetribution.JTACs or {}) do
+        addSupportGroup(jtac.dcsGroupName)
+    end
+    for _, awacs in ipairs(dcsRetribution.AWACs or {}) do
+        addSupportGroup(awacs.dcsGroupName)
+    end
+    for _, tanker in ipairs(dcsRetribution.Tankers or {}) do
+        addSupportGroup(tanker.dcsGroupName)
+    end
+end
+
+local function clearAssignment(rec, reason)
+    if not rec then return end
+    if reason and rec.targetName then
+        log(reason .. ": " .. rec.name .. " from " .. rec.targetName)
+    end
+    if rec.targetName then
+        _targetAssignments[rec.targetName] = nil
+        rec.targetName = nil
+    end
+    rec.busy = false
+end
+
+-- A Blue contact is a threat once it crosses into RED airspace. Border crossing
+-- is the primary trigger; raw radar range is the fallback when no border exists.
+local function threatActive(pos, radarPts)
+    if _borderZone then
+        return _borderZone:IsVec3InZone(pos)
+    end
+    for _, rp in ipairs(radarPts) do
+        if dist3D(pos, rp) <= CFG_engageRadius then return true end
+    end
+    return false
+end
+
+-- ── TASK APPLICATION ─────────────────────────────────────────────────────────
 
 local function taskIntercept(rec)
     local mg = GROUP:FindByName(rec.name)
     if not mg or not mg:IsAlive() then return end
-
     rec.group = mg
+    rec.lastVectorTime = timer.getTime()
     mg:OptionROEWeaponFree()
     mg:OptionROTEvadeFire()
+    mg:OptionKeepWeaponsOnThreat()
 
-    local ctrl = mg:GetController()
-    if ctrl then
-        ctrl:setTask({
-            id = "EngageTargets",
-            params = {
-                targetTypes = { "Air" },
-                maxDist = CFG_engageRadius,
-                priority = 0,
-            },
-        })
+    local targetGroup = rec.targetName and Group.getByName(rec.targetName) or nil
+    local targetUnits = targetGroup and targetGroup:getUnits() or nil
+    local targetUnit = targetUnits and targetUnits[1] or nil
+    if not targetUnit or not targetUnit:isExist() then
+        log("ERROR: no live target unit for " .. rec.name)
+        return
     end
+
+    local defenderCoord = mg:GetCoordinate()
+    defenderCoord:SetAltitude(CFG_interceptAlt)
+    local targetCoord = COORDINATE:NewFromVec3(targetUnit:getPoint())
+    targetCoord:SetAltitude(CFG_interceptAlt)
+
+    local attackTasks = {}
+    for _, dcsUnit in ipairs(targetUnits or {}) do
+        if dcsUnit and dcsUnit:isExist() then
+            local mooseUnit = UNIT:FindByName(dcsUnit:getName())
+            if mooseUnit and mooseUnit:IsAlive() and mooseUnit:IsAir() then
+                attackTasks[#attackTasks + 1] = mg:TaskAttackUnit(mooseUnit)
+            end
+        end
+    end
+    if #attackTasks == 0 then
+        log("ERROR: no valid attack tasks for " .. rec.name .. " -> " .. rec.targetName)
+        return
+    end
+
+    local targetDistance = defenderCoord:Get2DDistance(targetCoord)
+    local angle = defenderCoord:GetAngleDegrees(defenderCoord:GetDirectionVec3(targetCoord))
+    local climbDistance = math.min(25000, math.max(8000, targetDistance * 0.15))
+    local commitDistance = math.min(CFG_interceptRange, math.max(25000, targetDistance * 0.7))
+    if commitDistance >= targetDistance then
+        commitDistance = math.max(10000, targetDistance * 0.8)
+    end
+
+    local climbCoord = defenderCoord:Translate(climbDistance, angle, true)
+    climbCoord:SetAltitude(CFG_interceptAlt)
+    local commitCoord = defenderCoord:Translate(commitDistance, angle, true)
+    commitCoord:SetAltitude(CFG_interceptAlt)
+
+    local route = {
+        defenderCoord:WaypointAirTurningPoint("BARO", CFG_interceptSpeed, {}, "Current"),
+        climbCoord:WaypointAirTurningPoint("BARO", CFG_interceptSpeed, {}, "Climb"),
+        commitCoord:WaypointAirTurningPoint("BARO", CFG_interceptSpeed, { mg:TaskCombo(attackTasks) }, "Commit"),
+    }
+    mg:Route(route, 0.1)
 end
 
--- Wake a dormant uncontrolled group, then task it after a short delay so DCS
--- finishes processing the Start command before setTask fires.
+-- Wake a dormant uncontrolled group and send it to intercept.
+--
+-- The pool groups are generated with a single TakeOffParking point and no onward
+-- route, so StartUncontrolled() alone only spins up engines — it will NOT take
+-- off. The follow-on intercept route/task is what makes the cold-started AI
+-- taxi, take off and hunt. So: Start first, then (after a short delay so the
+-- Start command is processed) push the intercept task, which drives the takeoff.
 local function spawnAndIntercept(rec)
     local mg = GROUP:FindByName(rec.name)
     if not mg then
         log("ERROR: cannot find pool group: " .. rec.name)
         return
     end
-
-    rec.group = mg
+    rec.group   = mg
     rec.spawned = true
     mg:StartUncontrolled()
-    log("Waking dormant group: " .. rec.name)
-
+    log("Waking dormant group (cold start): " .. rec.name)
     timer.scheduleFunction(function()
         taskIntercept(rec)
+        log("Tasked intercept (takeoff + hunt): " .. rec.name)
     end, nil, timer.getTime() + CFG_spawnDelay)
 end
 
--- The pool table is written by a TriggerStart DoScript. Read it on the next
--- tick so it is populated before registration.
+-- ── REGISTRATION: read dcsRetribution.scramble_pool ──────────────────────────
+-- The pool table is written by a TriggerStart DoScript that runs at mission
+-- start; we read it on the next tick so it is guaranteed populated.
+
 timer.scheduleFunction(function()
-    local pool = dcsRetribution and dcsRetribution.scramble_pool
-    if not pool then
-        log("WARNING: dcsRetribution.scramble_pool not available - no interceptors registered")
-        return
+    local border = dcsRetribution and dcsRetribution.scramble_border
+    if border and #border >= 3 then
+        _border = border
+        if ZONE_POLYGON and ZONE_POLYGON.NewFromPointsArray then
+            local points = {}
+            for _, pt in ipairs(border) do
+                points[#points + 1] = { x = pt.x, y = pt.z }
+            end
+            if #points >= 4 then
+                local first, last = points[1], points[#points]
+                if first.x == last.x and first.y == last.y then
+                    table.remove(points, #points)
+                end
+            end
+            if #points >= 3 then
+                _borderZone = ZONE_POLYGON:NewFromPointsArray("Retribution Scramble Border", points)
+            end
+        end
+        log(string.format("RED airspace border loaded (%d vertices)", #border))
+    else
+        log("No scramble border supplied — falling back to radar-range detection")
     end
 
+    indexSupportGroups()
+
+    local pool = dcsRetribution and dcsRetribution.scramble_pool
+    if not pool then
+        log("WARNING: dcsRetribution.scramble_pool not available — no interceptors registered")
+        return
+    end
     for _, name in ipairs(pool) do
         if not _groups[name] then
             local mg = GROUP:FindByName(name)
             _groups[name] = {
-                name = name,
-                group = mg,
-                busy = false,
+                name       = name,
+                group      = mg,      -- uncontrolled groups exist at T=0
+                busy       = false,
                 lastTasked = 0,
-                spawned = false,
+                spawned    = false,
             }
             log("Registered dormant interceptor: " .. name)
         end
     end
 end, nil, timer.getTime() + 0.1)
+
+-- ── THREAT SCAN ──────────────────────────────────────────────────────────────
 
 local function getRedRadarPositions()
     local pts = {}
@@ -128,36 +268,50 @@ local function getRedRadarPositions()
 end
 
 local function detectBlueThreats(radarPts)
-    local threats = {}
-    local seen = {}
+    local threats, seen = {}, {}
+    local function considerGroup(g)
+        if not g or not g:isExist() then return end
+        local name = g:getName()
+        if seen[name] or _supportGroups[name] then return end
 
-    for _, g in ipairs(coalition.getGroups(coalition.side.BLUE, Group.Category.AIRPLANE) or {}) do
-        if g and g:isExist() and not seen[g:getName()] then
-            local units = g:getUnits()
-            local u = units and units[1]
-            if u and u:isExist() then
-                local pos = u:getPoint()
-                for _, rp in ipairs(radarPts) do
-                    if dist3D(pos, rp) <= CFG_engageRadius then
-                        threats[#threats + 1] = { group = g, pos = pos }
-                        seen[g:getName()] = true
-                        break
-                    end
-                end
-            end
+        local units = g:getUnits()
+        local u = units and units[1]
+        if not u or not u:isExist() or not u:inAir() then return end
+
+        local pos = u:getPoint()
+        if threatActive(pos, radarPts) then
+            threats[#threats + 1] = { name = name, group = g, pos = pos }
+            seen[name] = true
         end
     end
 
+    if _borderZone then
+        local blueSet = SET_GROUP:New()
+        blueSet:FilterCoalitions("blue")
+        blueSet:FilterCategoryAirplane()
+        blueSet:FilterActive(true)
+        blueSet:FilterZones({ _borderZone })
+        blueSet:FilterOnce()
+        blueSet:ForEachGroup(function(mooseGroup)
+            local dcsGroup = Group.getByName(mooseGroup:GetName())
+            considerGroup(dcsGroup)
+        end)
+    else
+        for _, g in ipairs(coalition.getGroups(coalition.side.BLUE, Group.Category.AIRPLANE) or {}) do
+            if g and g:isExist() then
+                considerGroup(g)
+            end
+        end
+    end
     return threats
 end
 
--- Pick the nearest available pool group to the threat. Dormant groups report
--- their parked position, so distance ranking works before they wake.
+-- Nearest available pool group to the threat, constrained by
+-- CFG_responseRadius. Dormant groups report their parked position fine, so
+-- distance ranking works before they spawn.
 local function selectGroup(threatPos)
     local now = timer.getTime()
-    local best = nil
-    local bestDist = math.huge
-
+    local best, bestDist = nil, math.huge
     for _, rec in pairs(_groups) do
         local available = not rec.busy or (now - rec.lastTasked) > CFG_reengageDelay
         local mg = rec.group or GROUP:FindByName(rec.name)
@@ -166,59 +320,95 @@ local function selectGroup(threatPos)
             local u1 = mg:GetUnit(1)
             if u1 and u1:IsAlive() then
                 local d = dist3D(u1:GetVec3(), threatPos)
-                if d < bestDist then
-                    best = rec
-                    bestDist = d
+                if d <= CFG_responseRadius and d < bestDist then
+                    best, bestDist = rec, d
                 end
             end
         end
     end
-
     return best
 end
 
 SCHEDULER:New(nil, function()
     local radars = getRedRadarPositions()
-    if #radars == 0 then return end
+    -- With a border polygon we trigger on penetration and don't need radars;
+    -- without one we rely on radar detection, so nothing to do with no radars.
+    if #radars == 0 and not _borderZone then return end
 
     local threats = detectBlueThreats(radars)
+    local activeThreats = {}
+    for _, threat in ipairs(threats) do
+        activeThreats[threat.name] = true
+    end
+
+    for _, rec in pairs(_groups) do
+        if rec.targetName and not activeThreats[rec.targetName] then
+            clearAssignment(rec, "Released")
+        end
+    end
 
     if #threats == 0 then
-        local now = timer.getTime()
-        for _, rec in pairs(_groups) do
-            if rec.busy and (now - rec.lastTasked) > CFG_reengageDelay then
-                rec.busy = false
-                log("Released: " .. rec.name)
-            end
-        end
         return
     end
 
     for _, threat in ipairs(threats) do
-        local rec = selectGroup(threat.pos)
-        if rec then
-            local now = timer.getTime()
-            if not rec.busy or (now - rec.lastTasked) > CFG_reengageDelay then
-                rec.busy = true
-                rec.lastTasked = now
+        local now = timer.getTime()
+        local assignedName = _targetAssignments[threat.name]
+        local assignedRec = assignedName and _groups[assignedName] or nil
+        if assignedRec then
+            local mg = assignedRec.group or GROUP:FindByName(assignedRec.name)
+            if not mg or not mg:IsAlive() then
+                clearAssignment(assignedRec, "Releasing dead interceptor")
+                assignedRec = nil
+            elseif assignedRec.spawned and (now - (assignedRec.lastVectorTime or 0)) >= CFG_vectorRefresh then
+                taskIntercept(assignedRec)
+            end
+        end
 
-                if rec.spawned then
-                    taskIntercept(rec)
-                else
-                    spawnAndIntercept(rec)
+        if not assignedRec then
+            local rec = selectGroup(threat.pos)
+            if rec then
+                if not rec.busy or (now - rec.lastTasked) > CFG_reengageDelay then
+                    rec.busy       = true
+                    rec.lastTasked = now
+                    rec.targetName = threat.name
+                    _targetAssignments[threat.name] = rec.name
+                    if rec.spawned then
+                        taskIntercept(rec)
+                    else
+                        spawnAndIntercept(rec)
+                    end
+                    log("Scramble: " .. rec.name .. " -> " .. threat.group:getName())
+                    MESSAGE:New("SCRAMBLE: interceptors launching!", 12):ToAll()
                 end
-
-                log("Scramble: " .. rec.name .. " -> " .. threat.group:getName())
-                MESSAGE:New("SCRAMBLE: interceptors launching!", 12):ToAll()
             end
         end
     end
 end, {}, 10, CFG_scanInterval)
 
+-- ── STARTUP REPORT ───────────────────────────────────────────────────────────
+
 timer.scheduleFunction(function()
     local n = 0
     for _ in pairs(_groups) do n = n + 1 end
-    log(string.format("ONLINE - %d dormant interceptor group(s)", n))
+    log(string.format("ONLINE — %d dormant interceptor group(s)", n))
     MESSAGE:New(string.format(
         "REACTIVE SCRAMBLE ONLINE: %d dormant interceptor group(s)", n), 12):ToAll()
 end, nil, timer.getTime() + 2)
+
+-- ── DEBUG STATUS ─────────────────────────────────────────────────────────────
+-- Periodic one-liner so a test run can confirm from dcs.log that detection is
+-- wired up (radar count, whether a border loaded, live threats). Set
+-- CFG_debug = false to silence.
+if CFG_debug then
+    timer.scheduleFunction(function()
+        local radars = getRedRadarPositions()
+        local n = 0
+        for _ in pairs(_groups) do n = n + 1 end
+        local threats = detectBlueThreats(radars)
+        log(string.format(
+            "status: groups=%d radars=%d border=%s threats=%d",
+            n, #radars, _borderZone and "yes" or "no", #threats))
+        return timer.getTime() + 60
+    end, nil, timer.getTime() + 25)
+end


### PR DESCRIPTION
## Summary

This PR adds a new reactive scramble plugin for Retribution that creates a border-defense/QRA system for RED untasked interceptors. It keeps designated aircraft cold and dormant at mission start, then launches nearby responders only after a real blue air incursion is detected.

## What this adds

- a new reactive scramble plugin for Retribution
- mission-generation support for a RED scramble pool
- mission-generation support for a RED border trigger polygon
- runtime scramble logic that wakes dormant interceptors only when needed

## What changed during testing

In-game testing and `dcs.log` review led to several refinements to make the new scramble behavior stable and usable:

- exclude Retribution support flights from scramble triggers
  - JTACs
  - AWACS
  - tankers
- use the generated RED border polygon as the primary trigger area
- track one interceptor assignment per live threat group
- release assignments cleanly when the threat leaves or dies
- replace the earlier raw intercept tasking with MOOSE-built intercept routing
- periodically re-vector active interceptors while the threat remains live
- limit eligible scramble launches to groups within a max response radius of the threat
  - current default: 75 NM

## Why

Retribution did not previously have a reactive scramble/QRA system for untasked RED interceptors.

This plugin was added to fill that gap, and then iterated through in-game testing to fix several observed issues:

- support aircraft could trigger scrambles unintentionally
- multiple scramble groups could launch against the same persistent contact
- rear-base fighters far from the incursion could launch on first border penetration
- some interceptors would take off, turn around, or fail to commit forward correctly

## Validation

Validated with in-game DCS mission tests and `dcs.log` review.

Expected behavior after this change:

- designated RED untasked interceptors remain cold and dormant at mission start
- scramble launches occur only on real blue air incursions
- support aircraft do not trigger QRA
- only nearby scramble bases respond
- interceptors continue committing forward instead of immediately recovering or stalling near base