### PR TITLE
Spread multiple AWACS/tanker orbits laterally instead of stacking

### DIFF
--- a/game/ato/flightplans/aewc.py
+++ b/game/ato/flightplans/aewc.py
@@ -5,7 +5,9 @@ from typing import Type
 
 from game.ato.flightplans.ibuilder import IBuilder
 from game.ato.flightplans.patrolling import PatrollingFlightPlan, PatrollingLayout
+from game.ato.flightplans.patrolspacing import deconflicted_racetrack_center
 from game.ato.flightplans.waypointbuilder import WaypointBuilder
+from game.ato.flighttype import FlightType
 from game.utils import Distance, Heading, Speed, knots, meters, nautical_miles
 
 
@@ -56,8 +58,19 @@ class Builder(IBuilder[AewcFlightPlan, PatrollingLayout]):
         else:
             orbit_distance = distance_to_threat - threat_buffer
 
-        racetrack_center = location.position.point_from_heading(
+        base_center = location.position.point_from_heading(
             orbit_heading.degrees, orbit_distance.meters
+        )
+
+        # When multiple AWACS are planned, spread their orbits laterally along the
+        # front so each covers a different section instead of stacking on one orbit.
+        racetrack_center = deconflicted_racetrack_center(
+            base_center,
+            orbit_heading,
+            meters(racetrack_half_distance * 2),
+            self.flight,
+            self.coalition,
+            FlightType.AEWC,
         )
 
         racetrack_start = racetrack_center.point_from_heading(

--- a/game/ato/flightplans/patrolspacing.py
+++ b/game/ato/flightplans/patrolspacing.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dcs import Point
+
+    from game.coalition import Coalition
+    from game.utils import Distance, Heading
+    from ..flight import Flight
+    from ..flighttype import FlightType
+
+
+def deconflicted_racetrack_center(
+    base_center: Point,
+    orbit_heading: Heading,
+    spacing: Distance,
+    flight: Flight,
+    coalition: Coalition,
+    flight_type: FlightType,
+) -> Point:
+    """Offset a patrol's racetrack center laterally so multiple same-type patrols
+    (AWACS, tankers) spread out along the front instead of stacking on one orbit.
+
+    All flights of ``flight_type`` planned for ``coalition`` are ordered
+    deterministically and assigned evenly spaced offsets centered on
+    ``base_center``. With a single such flight the offset is zero, preserving the
+    original placement.
+    """
+    same_type = sorted(
+        (
+            f
+            for package in coalition.ato.packages
+            for f in package.flights
+            if f.flight_type is flight_type
+        ),
+        key=lambda f: str(f.id),
+    )
+    count = len(same_type)
+    try:
+        index = next(i for i, f in enumerate(same_type) if f is flight)
+    except StopIteration:
+        index = 0
+
+    lateral = (index - (count - 1) / 2) * spacing.meters
+    if lateral >= 0:
+        return base_center.point_from_heading(orbit_heading.right.degrees, lateral)
+    return base_center.point_from_heading(orbit_heading.left.degrees, -lateral)

--- a/game/ato/flightplans/theaterrefueling.py
+++ b/game/ato/flightplans/theaterrefueling.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from typing import Type
 
+from game.ato.flighttype import FlightType
 from game.utils import Heading, meters, nautical_miles
 from .ibuilder import IBuilder
 from .patrolling import PatrollingLayout
+from .patrolspacing import deconflicted_racetrack_center
 from .refuelingflightplan import RefuelingFlightPlan
 from .waypointbuilder import WaypointBuilder
 
@@ -39,8 +41,19 @@ class Builder(IBuilder[TheaterRefuelingFlightPlan, PatrollingLayout]):
         else:
             orbit_distance = distance_to_threat - threat_buffer
 
-        racetrack_center = location.position.point_from_heading(
+        base_center = location.position.point_from_heading(
             orbit_heading.degrees, orbit_distance.meters
+        )
+
+        # When multiple tankers are planned, spread their orbits laterally along
+        # the front so each serves a different slice instead of stacking together.
+        racetrack_center = deconflicted_racetrack_center(
+            base_center,
+            orbit_heading,
+            meters(racetrack_half_distance * 2),
+            self.flight,
+            self.coalition,
+            FlightType.REFUELING,
         )
 
         racetrack_start = racetrack_center.point_from_heading(

--- a/tests/test_patrolspacing.py
+++ b/tests/test_patrolspacing.py
@@ -1,0 +1,81 @@
+"""deconflicted_racetrack_center spreads same-type patrols laterally.
+
+Multiple AWACS (or tankers) used to be placed on the exact same racetrack center,
+stacking their orbits. The helper offsets each one along the front so a single
+flight is unchanged (offset 0) and multiple flights fan out symmetrically.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from game.ato.flightplans.patrolspacing import deconflicted_racetrack_center
+from game.ato.flighttype import FlightType
+
+
+class _Point:
+    """Records the (heading_degrees, distance_m) it was offset by."""
+
+    def point_from_heading(
+        self, heading: float, distance: float
+    ) -> tuple[float, float]:
+        return (heading, distance)
+
+
+def _heading() -> Any:
+    return SimpleNamespace(
+        right=SimpleNamespace(degrees=90.0),
+        left=SimpleNamespace(degrees=270.0),
+    )
+
+
+def _coalition(*flights: Any) -> Any:
+    return SimpleNamespace(
+        ato=SimpleNamespace(packages=[SimpleNamespace(flights=list(flights))])
+    )
+
+
+def _flight(flight_id: str, flight_type: FlightType = FlightType.AEWC) -> Any:
+    return SimpleNamespace(id=flight_id, flight_type=flight_type)
+
+
+def _spacing(meters: float) -> Any:
+    return SimpleNamespace(meters=meters)
+
+
+def _center(base: Any, heading: Any, spacing: Any, flight: Any, coalition: Any) -> Any:
+    return deconflicted_racetrack_center(
+        cast(Any, base),
+        cast(Any, heading),
+        cast(Any, spacing),
+        cast(Any, flight),
+        cast(Any, coalition),
+        FlightType.AEWC,
+    )
+
+
+def test_single_flight_is_not_offset() -> None:
+    flight = _flight("a")
+    result = _center(_Point(), _heading(), _spacing(1000.0), flight, _coalition(flight))
+    # right.degrees with zero distance == no lateral shift.
+    assert result == (90.0, 0.0)
+
+
+def test_two_flights_fan_out_symmetrically() -> None:
+    a, b = _flight("a"), _flight("b")
+    coalition = _coalition(a, b)
+    first = _center(_Point(), _heading(), _spacing(1000.0), a, coalition)
+    second = _center(_Point(), _heading(), _spacing(1000.0), b, coalition)
+    # Half a spacing each, in opposite directions (left for the first, right second).
+    assert first == (270.0, 500.0)
+    assert second == (90.0, 500.0)
+
+
+def test_other_flight_types_are_ignored() -> None:
+    awacs = _flight("a")
+    tanker = _flight("b", FlightType.REFUELING)
+    coalition = _coalition(awacs, tanker)
+    # Only the single AWACS counts, so it is not offset by the tanker's presence.
+    result = _center(_Point(), _heading(), _spacing(1000.0), awacs, coalition)
+    assert result == (90.0, 0.0)


### PR DESCRIPTION
## Problem

`AewcFlightPlan` and `TheaterRefuelingFlightPlan` place their racetrack center at a single point derived from the threat boundary. When more than one AWACS (or more than one tanker) is planned for a coalition, they all get the **same** center and stack their orbits on top of each other, covering identical airspace instead of spreading coverage along the front.

## Fix

Adds a shared `deconflicted_racetrack_center()` helper (`game/ato/flightplans/patrolspacing.py`) that:
- orders the same-type flights deterministically,
- offsets each one sideways by a full racetrack width, centered on the original point.

With a single flight the offset is **zero**, so existing single-AWACS / single-tanker behavior is unchanged (no regression). Both builders now share this helper rather than duplicating the placement logic.

## Tests

Adds `tests/test_patrolspacing.py` (single flight = no offset, two flights fan out symmetrically, other flight types ignored). Black- and mypy-clean; no import cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)