### PR TITLE
Don't show "Missing Recon Picture" placeholder on building cards

### DIFF
--- a/qt_ui/windows/groundobject/QBuildingInfo.py
+++ b/qt_ui/windows/groundobject/QBuildingInfo.py
@@ -1,7 +1,8 @@
 import os
 
+from PySide6.QtCore import Qt
 from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QGroupBox, QHBoxLayout, QLabel, QVBoxLayout
+from PySide6.QtWidgets import QGroupBox, QLabel, QVBoxLayout
 
 from game.config import REWARDS
 from game.theater import TheaterUnit
@@ -15,31 +16,32 @@ class QBuildingInfo(QGroupBox):
         self.init_ui()
 
     def init_ui(self):
-        self.header = QLabel()
-        path = os.path.join(
+        icon_path = os.path.join(
             "./resources/ui/units/buildings/" + self.building.icon + ".png"
         )
-        if not self.building.alive:
-            pixmap = QPixmap("./resources/ui/units/buildings/dead.png")
-        elif os.path.isfile(path):
-            pixmap = QPixmap(path)
-        else:
-            pixmap = QPixmap("./resources/ui/units/buildings/missing.png")
-        self.header.setPixmap(pixmap)
-        self.name = QLabel(self.building.short_name)
-        self.name.setProperty("style", "small")
+        has_real_icon = self.building.icon != "missing" and os.path.isfile(icon_path)
+
         layout = QVBoxLayout()
-        layout.addWidget(self.header)
-        layout.addWidget(self.name)
+        layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+
+        if not self.building.alive:
+            header = QLabel()
+            header.setPixmap(QPixmap("./resources/ui/units/buildings/dead.png"))
+            layout.addWidget(header)
+        elif has_real_icon:
+            header = QLabel()
+            header.setPixmap(QPixmap(icon_path))
+            layout.addWidget(header)
+
+        name_label = QLabel(self.building.short_name)
+        name_label.setProperty("style", "small")
+        name_label.setWordWrap(True)
+        layout.addWidget(name_label)
 
         if self.ground_object.category in REWARDS:
-            income_label_text = (
-                "Value: " + str(REWARDS[self.ground_object.category]) + "M"
-            )
+            income_text = "Value: " + str(REWARDS[self.ground_object.category]) + "M"
             if not self.building.alive:
-                income_label_text = "<s>" + income_label_text + "</s>"
-            self.reward = QLabel(income_label_text)
-            layout.addWidget(self.reward)
+                income_text = "<s>" + income_text + "</s>"
+            layout.addWidget(QLabel(income_text))
 
-        footer = QHBoxLayout()
         self.setLayout(layout)


### PR DESCRIPTION
## Problem

`SceneryUnit.icon` always returns `"missing"` (`game/theater/theatergroup.py`), so every scenery-building card in the ground-object menu loads `resources/ui/units/buildings/missing.png` as its header image — and that PNG contains the literal text **"Missing Recon Picture"**. The result is a large cyan placeholder block on every building card where no real icon exists.

## Fix

`QBuildingInfo.init_ui()` now skips the image widget entirely when there is no real icon (icon is `"missing"` or the file is absent) and the building is alive, leaving a compact, top-aligned **name + value** card. Dead buildings still show `dead.png`, and buildings that *do* have a real icon still show it.

Also: word-wrap the name label and remove a leftover unused `QHBoxLayout` footer.

## Notes

UI-only, no behavioral change to mission/economy logic. Black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)