### PR TITLE
Fix app process lingering in the background after the window is closed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 * **[UI]** Avoid a crash dialog ("'QWidgetItem' object has no attribute 'width'") when a list using the two-column row delegate relayouts with a malformed style option under PySide6 6.4.x.
 
 ## Fixes
+* **[App]** Fix Retribution sometimes staying alive in the background after the window is closed.
 * **[AirWing]** Squadron transfer-destination parking now accounts for already-ordered incoming transfers, matching the Airfield Command hangar count
 * **[Mission Generation]** Anti-Ship flights now attack the carrier group the flight plan routes to instead of the control point's first ground object, so strikes against carrier groups no longer leave the AI without a target (it would fly to the ingress point and turn back without engaging).
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.

--- a/game/server/server.py
+++ b/game/server/server.py
@@ -12,6 +12,10 @@ from game.server.app import app
 from game.server.settings import ServerSettings
 from game.sim import GameUpdateEvents
 
+# Upper bound (seconds) on uvicorn's graceful shutdown; without it, it can wait
+# forever for the long-lived /eventstream websocket task to drain on exit.
+GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = 3
+
 
 class Server(uvicorn.Server):
     def __init__(self, port: Optional[int]) -> None:
@@ -23,6 +27,7 @@ class Server(uvicorn.Server):
                 port=settings.server_port,
                 # Configured explicitly with default_logging.yaml or logging.yaml.
                 log_config=None,
+                timeout_graceful_shutdown=GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS,
             )
         )
 
@@ -39,4 +44,9 @@ class Server(uvicorn.Server):
         finally:
             self.should_exit = True
             EventStream.put_nowait(GameUpdateEvents().shut_down())
-            thread.join()
+            thread.join(timeout=GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS + 2)
+            if thread.is_alive():
+                # Graceful shutdown stalled anyway; force uvicorn to stop waiting
+                # so the process can exit instead of hanging on join() forever.
+                self.force_exit = True
+                thread.join(timeout=GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS)


### PR DESCRIPTION
**Problem:** Closing Retribution sometimes left `retribution_main.exe` running in the background (~800 MB, sometimes I've seen 1500MB!).

The API server (uvicorn) runs in a background thread; on shutdown `Server.run_in_thread()` joins it. But `timeout_graceful_shutdown` was never configured, so uvicorn waited forever for the long-lived `/eventstream` websocket task to drain — it never does when the web view is torn down on close — and the join hung.

**Fix:** Set `timeout_graceful_shutdown=3` on the uvicorn config, plus a `force_exit` + bounded-join backstop, so the server thread always stops and the process exits.
