### PR TITLE
Write loadout payload files atomically (avoid half-written files)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,7 +24,7 @@
 * **[UI]** Avoid a crash dialog ("'QWidgetItem' object has no attribute 'width'") when a list using the two-column row delegate relayouts with a malformed style option under PySide6 6.4.x.
 
 ## Fixes
-* **[Mission Generation]** Fix a crash ("could not convert string to float") when adding a flight or starting a mission.
+* **[Mission Generation]** Loadout payloads are saved atomically (write to a temp file, then rename), so mission generation or the payload editor never reads a half-written payload file.
 * **[AirWing]** Squadron transfer-destination parking now accounts for already-ordered incoming transfers, matching the Airfield Command hangar count
 * **[Mission Generation]** Anti-Ship flights now attack the carrier group the flight plan routes to instead of the control point's first ground object, so strikes against carrier groups no longer leave the AI without a target (it would fly to the ingress point and turn back without engaging).
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 * **[UI]** Avoid a crash dialog ("'QWidgetItem' object has no attribute 'width'") when a list using the two-column row delegate relayouts with a malformed style option under PySide6 6.4.x.
 
 ## Fixes
+* **[Mission Generation]** Fix a crash ("could not convert string to float") when adding a flight or starting a mission.
 * **[AirWing]** Squadron transfer-destination parking now accounts for already-ordered incoming transfers, matching the Airfield Command hangar count
 * **[Mission Generation]** Anti-Ship flights now attack the carrier group the flight plan routes to instead of the control point's first ground object, so strikes against carrier groups no longer leave the AI without a target (it would fly to the ingress point and turn back without engaging).
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -61,6 +61,56 @@ def inject_custom_payloads(user_path: Path) -> None:
     PayloadDirectories.set_preferred(user_path / "MissionEditor" / "UnitPayloads")
 
 
+def _harden_payload_loading() -> None:
+    """Make pydcs' payload loading tolerant of malformed / mid-write payload files.
+
+    FlyingType.load_payloads() reads every payload .lua for an aircraft type and,
+    on the full parse, only catches SyntaxError. A bad payload file -- or one
+    caught mid-write, whose truncated number raises ValueError ("could not convert
+    string to float: ''") -- therefore crashes whatever first triggered the load
+    for that type: the Add-Flight loadout selector, mission generation, the payload
+    editor, etc. Wrap load_payloads so any parse error is tolerated: retry a couple
+    of times (clearing the partial cache so the files are re-read, which recovers a
+    transient torn read), then fall back to an empty payload set with a logged
+    error. Installed once, this covers every call site. Idempotent.
+    """
+    from time import sleep
+    from dcs.unittype import FlyingType
+
+    if getattr(FlyingType, "_retribution_payload_hardening", False):
+        return
+    original = FlyingType.load_payloads.__func__
+
+    def load_payloads(cls):
+        last_error = None
+        for attempt in range(3):
+            try:
+                return original(cls)
+            except (ValueError, SyntaxError) as e:
+                last_error = e
+                # Drop the partial cache so the next attempt re-reads from disk
+                # (recovers a payload file that was briefly mid-write).
+                cls.payloads = None
+                logging.warning(
+                    "Failed to parse payloads for %s (attempt %d/3): %s",
+                    getattr(cls, "id", cls.__name__),
+                    attempt + 1,
+                    e,
+                )
+                sleep(0.25)
+        logging.error(
+            "Could not parse payloads for %s after 3 attempts; using an empty "
+            "payload set so the app does not crash. Last error: %s",
+            getattr(cls, "id", cls.__name__),
+            last_error,
+        )
+        cls.payloads = {}
+        return cls.payloads
+
+    FlyingType.load_payloads = classmethod(load_payloads)
+    FlyingType._retribution_payload_hardening = True
+
+
 def on_game_load(game: Optional[Game]) -> None:
     EventStream.drain()
     EventStream.put_nowait(GameUpdateEvents().game_loaded(game))
@@ -412,6 +462,10 @@ def dump_task_priorities() -> None:
 
 def main():
     logging_config.init_logging(VERSION)
+
+    # Tolerate malformed / mid-write payload .lua files instead of crashing
+    # (see _harden_payload_loading). Installed before anything loads payloads.
+    _harden_payload_loading()
 
     logging.debug("Python version %s", sys.version)
 

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -61,56 +61,6 @@ def inject_custom_payloads(user_path: Path) -> None:
     PayloadDirectories.set_preferred(user_path / "MissionEditor" / "UnitPayloads")
 
 
-def _harden_payload_loading() -> None:
-    """Make pydcs' payload loading tolerant of malformed / mid-write payload files.
-
-    FlyingType.load_payloads() reads every payload .lua for an aircraft type and,
-    on the full parse, only catches SyntaxError. A bad payload file -- or one
-    caught mid-write, whose truncated number raises ValueError ("could not convert
-    string to float: ''") -- therefore crashes whatever first triggered the load
-    for that type: the Add-Flight loadout selector, mission generation, the payload
-    editor, etc. Wrap load_payloads so any parse error is tolerated: retry a couple
-    of times (clearing the partial cache so the files are re-read, which recovers a
-    transient torn read), then fall back to an empty payload set with a logged
-    error. Installed once, this covers every call site. Idempotent.
-    """
-    from time import sleep
-    from dcs.unittype import FlyingType
-
-    if getattr(FlyingType, "_retribution_payload_hardening", False):
-        return
-    original = FlyingType.load_payloads.__func__
-
-    def load_payloads(cls):
-        last_error = None
-        for attempt in range(3):
-            try:
-                return original(cls)
-            except (ValueError, SyntaxError) as e:
-                last_error = e
-                # Drop the partial cache so the next attempt re-reads from disk
-                # (recovers a payload file that was briefly mid-write).
-                cls.payloads = None
-                logging.warning(
-                    "Failed to parse payloads for %s (attempt %d/3): %s",
-                    getattr(cls, "id", cls.__name__),
-                    attempt + 1,
-                    e,
-                )
-                sleep(0.25)
-        logging.error(
-            "Could not parse payloads for %s after 3 attempts; using an empty "
-            "payload set so the app does not crash. Last error: %s",
-            getattr(cls, "id", cls.__name__),
-            last_error,
-        )
-        cls.payloads = {}
-        return cls.payloads
-
-    FlyingType.load_payloads = classmethod(load_payloads)
-    FlyingType._retribution_payload_hardening = True
-
-
 def on_game_load(game: Optional[Game]) -> None:
     EventStream.drain()
     EventStream.put_nowait(GameUpdateEvents().game_loaded(game))
@@ -462,10 +412,6 @@ def dump_task_priorities() -> None:
 
 def main():
     logging_config.init_logging(VERSION)
-
-    # Tolerate malformed / mid-write payload .lua files instead of crashing
-    # (see _harden_payload_loading). Installed before anything loads payloads.
-    _harden_payload_loading()
 
     logging.debug("Python version %s", sys.version)
 

--- a/qt_ui/windows/mission/flight/payload/QLoadoutEditor.py
+++ b/qt_ui/windows/mission/flight/payload/QLoadoutEditor.py
@@ -1,5 +1,8 @@
+import os
+import tempfile
 from collections.abc import Iterator
 from dataclasses import dataclass
+from pathlib import Path
 from shutil import copyfile
 from typing import Dict, Union, Any
 
@@ -24,6 +27,31 @@ from game.data.weapons import Pylon
 from game.persistency import payloads_dir
 from qt_ui.blocksignals import block_signals
 from qt_ui.windows.mission.flight.payload.QPylonEditor import QPylonEditor
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write text to path atomically.
+
+    A payload .lua is read by pydcs (during mission generation) at the same time
+    the user can save one here. Writing in place leaves a window where the file
+    is truncated, which makes the reader choke on a half-written number. Write to
+    a temp file in the same directory and os.replace() it into place so a reader
+    only ever sees the old or the new file, never a partial one.
+    """
+    directory = path.parent
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=f"{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 class QLoadoutEditor(QGroupBox):
@@ -119,24 +147,28 @@ class QLoadoutEditor(QGroupBox):
                 pdict[next_key] = DcsPayload.from_flight_member(
                     self.flight_member, payload_name
                 ).to_dict()
-                with payload_file.open("w", encoding="utf-8") as f:
-                    f.write("local unitPayloads = ")
-                    f.write(lua.dumps(payloads["unitPayloads"], indent=1))
-                    f.write("\nreturn unitPayloads")
+                _atomic_write_text(
+                    payload_file,
+                    "local unitPayloads = "
+                    + lua.dumps(payloads["unitPayloads"], indent=1)
+                    + "\nreturn unitPayloads",
+                )
         else:
-            with payload_file.open("w", encoding="utf-8") as f:
-                payloads = {
-                    "name": f"{self.flight.unit_type.dcs_unit_type.id}",
-                    "payloads": {
-                        1: DcsPayload.from_flight_member(
-                            self.flight_member, payload_name
-                        ).to_dict(),
-                    },
-                    "unitType": f"{self.flight.unit_type.dcs_unit_type.id}",
-                }
-                f.write("local unitPayloads = ")
-                f.write(lua.dumps(payloads, indent=1))
-                f.write("\nreturn unitPayloads")
+            payloads = {
+                "name": f"{self.flight.unit_type.dcs_unit_type.id}",
+                "payloads": {
+                    1: DcsPayload.from_flight_member(
+                        self.flight_member, payload_name
+                    ).to_dict(),
+                },
+                "unitType": f"{self.flight.unit_type.dcs_unit_type.id}",
+            }
+            _atomic_write_text(
+                payload_file,
+                "local unitPayloads = "
+                + lua.dumps(payloads, indent=1)
+                + "\nreturn unitPayloads",
+            )
             self.flight.unit_type.dcs_unit_type.add_to_payload_cache(payload_file)
         self.saved.emit(payload_name)
         QMessageBox.information(


### PR DESCRIPTION
Saving a loadout in the payload editor wrote the `.lua` in place, leaving a window where a concurrent reader (mission generation, the loadout editor) could read a truncated, half-written file. This writes to a temp file in the same directory and `os.replace()`s it into place, so a reader only ever sees the old or the new file — never a partial one.

(The parse-error handling that previously lived here is superseded by #751, which keeps the payloads it can read instead of dropping the whole airframe.)
