### PR TITLE
Fix kneeboard waypoint numbering for in-air-start flights

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 * **[UI]** Avoid a crash dialog ("'QWidgetItem' object has no attribute 'width'") when a list using the two-column row delegate relayouts with a malformed style option under PySide6 6.4.x.
 
 ## Fixes
+* **[Kneeboard]** Flight-plan kneeboard now matches the in-game waypoint numbering for flights that start in the air
 * **[AirWing]** Squadron transfer-destination parking now accounts for already-ordered incoming transfers, matching the Airfield Command hangar count
 * **[Mission Generation]** Anti-Ship flights now attack the carrier group the flight plan routes to instead of the control point's first ground object, so strikes against carrier groups no longer leave the AI without a target (it would fly to the ingress point and turn back without engaging).
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.

--- a/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
+++ b/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
@@ -129,7 +129,14 @@ class WaypointGenerator:
         # plan construction, but for now it's only used by the kneeboard so is generated
         # late.
         self._estimate_min_fuel_for(waypoints)
-        return mission_start_time, waypoints
+
+        # In-air starts spawn at the current waypoint, so DCS omits the
+        # already-passed waypoints; slice from the spawn waypoint so the kneeboard
+        # numbering matches the cockpit.
+        kneeboard_waypoints = waypoints
+        if isinstance(self.flight.state, InFlight):
+            kneeboard_waypoints = waypoints[self.flight.state.waypoint_index :]
+        return mission_start_time, kneeboard_waypoints
 
     def builder_for_waypoint(self, waypoint: FlightWaypoint) -> PydcsWaypointBuilder:
         builders = {


### PR DESCRIPTION
**Problem:** For flights that start in the air, DCS spawns the group at its current waypoint (group point 0) and omits the already-passed takeoff/join/ingress waypoints, so the in-game waypoint numbers start later in the plan. The kneeboard was built from the full flight plan starting at takeoff, so its numbering and labels were offset from the cockpit (e.g. kneeboard "1: Hold" while DCS showed "1: Escort Hold").

**Fix:** `create_waypoints()` now returns the plan from the spawn waypoint onward for `InFlight` states, so the kneeboard flight-plan page and strike-task page match the generated mission. Ground/runway starts are unchanged.
