### PR TITLE
Fix DCS rejecting missions with a locked-speed waypoint between TOT-locked waypoints

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 * **[UI]** Avoid a crash dialog ("'QWidgetItem' object has no attribute 'width'") when a list using the two-column row delegate relayouts with a malformed style option under PySide6 6.4.x.
 
 ## Fixes
+* **[Mission Generation]** Fix the generated mission being rejected by DCS with "locked speed ... surrounded by waypoints ... with locked time" (e.g. carrier escorts).
 * **[AirWing]** Squadron transfer-destination parking now accounts for already-ordered incoming transfers, matching the Airfield Command hangar count
 * **[Mission Generation]** Anti-Ship flights now attack the carrier group the flight plan routes to instead of the control point's first ground object, so strikes against carrier groups no longer leave the AI without a target (it would fly to the ingress point and turn back without engaging).
 * **[Performance]** Improved robustness w.r.t. state.json handling to avoid corruption and thus save loss.

--- a/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
+++ b/game/missiongenerator/aircraft/waypoints/waypointgenerator.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import random
 from collections.abc import Iterator
 from datetime import datetime, timedelta
@@ -123,6 +124,8 @@ class WaypointGenerator:
         for idx, point in enumerate(filtered_points):
             self.builder_for_waypoint(point).build()
 
+        self._resolve_locked_speed_time_conflicts()
+
         # Set here rather than when the FlightData is created so they waypoints
         # have their TOTs and fuel minimums set. Once we're more confident in our fuel
         # estimation ability the minimum fuel amounts will be calculated during flight
@@ -130,6 +133,46 @@ class WaypointGenerator:
         # late.
         self._estimate_min_fuel_for(waypoints)
         return mission_start_time, waypoints
+
+    def _resolve_locked_speed_time_conflicts(self) -> None:
+        """Unlock the speed on any waypoint that has a locked speed while sitting
+        between time-locked (TOT) waypoints.
+
+        DCS rejects that combination at mission start ("All waypoints (N-M) have
+        locked speed and surrounded by waypoints ... with locked time"): the
+        bounding TOTs already determine the segment's speed, so a locked speed in
+        between is contradictory. It happens e.g. on a carrier escort whose JOIN
+        TOT clamps to the mission start -- the waypoint then gets a locked speed
+        (because ETA == 0) and is trapped between TOT-locked neighbours. Keep the
+        times (needed to sync with the escorted package) and drop the speed lock
+        so DCS can honour them. Split/RTB legs keep their locked speed since no
+        TOT-locked waypoint follows them.
+        """
+        points = self.group.points
+        n = len(points)
+        eta_locked_before = [False] * n
+        seen = False
+        for i in range(n):
+            eta_locked_before[i] = seen
+            if getattr(points[i], "ETA_locked", False):
+                seen = True
+        eta_locked_after = False
+        for i in range(n - 1, -1, -1):
+            if (
+                getattr(points[i], "speed_locked", False)
+                and eta_locked_before[i]
+                and eta_locked_after
+            ):
+                points[i].speed_locked = False
+                logging.debug(
+                    "%s: unlocked speed on waypoint %d (%s); a locked speed "
+                    "between TOT-locked waypoints is rejected by DCS.",
+                    self.flight,
+                    i,
+                    getattr(points[i], "name", ""),
+                )
+            if getattr(points[i], "ETA_locked", False):
+                eta_locked_after = True
 
     def builder_for_waypoint(self, waypoint: FlightWaypoint) -> PydcsWaypointBuilder:
         builders = {

--- a/tests/missiongenerator/aircraft/test_waypointgenerator.py
+++ b/tests/missiongenerator/aircraft/test_waypointgenerator.py
@@ -1,0 +1,79 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+from game.missiongenerator.aircraft.waypoints.waypointgenerator import (
+    WaypointGenerator,
+)
+
+
+def _wp(eta_locked: bool, speed_locked: bool, name: str = "") -> Any:
+    wp = MagicMock()
+    wp.ETA_locked = eta_locked
+    wp.speed_locked = speed_locked
+    wp.name = name
+    return wp
+
+
+def _generator(points: list[Any]) -> WaypointGenerator:
+    # Bypass __init__ (it needs a full flight/mission); only group.points and
+    # flight are consulted by the method under test.
+    gen: Any = object.__new__(WaypointGenerator)
+    gen.group = MagicMock()
+    gen.group.points = points
+    gen.flight = MagicMock()
+    return gen
+
+
+def test_unlocks_speed_locked_waypoint_trapped_between_tots() -> None:
+    """A carrier escort's JOIN waypoint gets a locked speed (its TOT clamps to
+    the mission start, ETA == 0) while trapped between TOT-locked waypoints,
+    which DCS rejects. The speed lock must be dropped while the times stay."""
+    # spawn, JOIN (trapped), ESCORT HOLD, SPLIT, REFUEL, LANDING
+    points = [
+        _wp(eta_locked=True, speed_locked=True, name="spawn"),
+        _wp(eta_locked=True, speed_locked=True, name="JOIN"),
+        _wp(eta_locked=True, speed_locked=False, name="ESCORT HOLD"),
+        _wp(eta_locked=False, speed_locked=True, name="SPLIT"),
+        _wp(eta_locked=False, speed_locked=True, name="REFUEL"),
+        _wp(eta_locked=False, speed_locked=True, name="LANDING"),
+    ]
+
+    _generator(points)._resolve_locked_speed_time_conflicts()
+
+    # Only JOIN is unlocked; the spawn (nothing before it) and the SPLIT/RTB legs
+    # (no TOT-locked waypoint after them) keep their locked speed.
+    assert [p.speed_locked for p in points] == [True, False, False, True, True, True]
+    # Times are untouched.
+    assert all(p.ETA_locked for p in points[:3])
+
+
+def test_leaves_untrapped_speed_locks_alone() -> None:
+    """A normal escort (JOIN has a real TOT, so no speed lock there) is unchanged:
+    the split/RTB legs are not trapped (no TOT-locked waypoint follows them)."""
+    points = [
+        _wp(eta_locked=True, speed_locked=True, name="spawn"),
+        _wp(eta_locked=True, speed_locked=False, name="JOIN"),
+        _wp(eta_locked=True, speed_locked=False, name="ESCORT HOLD"),
+        _wp(eta_locked=False, speed_locked=True, name="SPLIT"),
+        _wp(eta_locked=False, speed_locked=True, name="REFUEL"),
+        _wp(eta_locked=False, speed_locked=True, name="LANDING"),
+    ]
+
+    _generator(points)._resolve_locked_speed_time_conflicts()
+
+    assert [p.speed_locked for p in points] == [True, False, False, True, True, True]
+
+
+def test_unlocks_a_run_of_trapped_speed_locked_waypoints() -> None:
+    """Every locked-speed waypoint in a run bounded by TOT-locked waypoints on
+    both sides is unlocked."""
+    points = [
+        _wp(eta_locked=True, speed_locked=False, name="A"),
+        _wp(eta_locked=False, speed_locked=True, name="B"),
+        _wp(eta_locked=False, speed_locked=True, name="C"),
+        _wp(eta_locked=True, speed_locked=False, name="D"),
+    ]
+
+    _generator(points)._resolve_locked_speed_time_conflicts()
+
+    assert [p.speed_locked for p in points] == [False, False, False, False]


### PR DESCRIPTION
**Problem:** Some generated missions are rejected by DCS at load with *"All waypoints (N-M) have locked speed and surrounded by waypoints ... with locked time"*. Seen on carrier escorts: the JOIN waypoint's TOT clamps to the mission start (`ETA == 0`), which locks its speed (`set_waypoint_tot` sets `speed_locked = ETA == 0`), leaving a locked speed trapped between TOT-locked neighbours.

**Fix:** After a flight's waypoints are built, unlock the speed on any waypoint that has a TOT-locked waypoint both before and after it — keeping the times (needed to sync with the escorted package) and letting DCS derive the speed. Split/RTB legs keep their locked speed since no TOT-locked waypoint follows them. Adds unit tests.
