### PR TITLE
Mirror COMM1 radio presets onto COMM2 on aircraft with a second radio

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@
 * **[Map]** Hovering a SAM threat or detection ring highlights its emitter — and hovering an emitter highlights its ring — making it easy to tell which site a ring belongs to. Can be disabled from the map's layer control.
 
 ## Fixes
+* **[Comms]** Fix COMM1/COMM2 being swapped in the kneeboard for the Super Hornet family (EA-18G, F/A-18E/F and their tanker variants): align their radio indices to the F/A-18C so intra-flight is COMM2 and ATC/package are on COMM1.
+* **[Kneeboard]** Stop the Support Info FREQ column being clipped now that it lists both COMM1 and COMM2 (the single-digit aircraft-count column no longer pads the row past the page edge).
 * **[Mission]** Reliably auto-detect end of mission, even when DCS wrote the final state.json before the wait dialog started watching
 * **[Performance]** Faster post-mission turn processing
 * **[AirWing]** Track per-squadron campaign aircraft stats (initial/destroyed/purchased, save-compatible) and expose pilot experience level and living/dead pilot views for the UI

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[Comms]** Preset radio channels (ATC, AWACS, tanker, package, JTAC) are also mirrored onto COMM2 on aircraft with a second radio (e.g. F/A-18C, F-16), so you can monitor two nets at once; the kneeboard shows both channels.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.
 * **[UX]** Avoid having escorts from wondering off too far while chasing a target.

--- a/game/missiongenerator/aircraft/flightdata.py
+++ b/game/missiongenerator/aircraft/flightdata.py
@@ -74,8 +74,10 @@ class FlightData:
 
     callsign: str = field(init=False)
 
-    #: Map of radio frequencies to their assigned radio and channel, if any.
-    frequency_to_channel_map: dict[RadioFrequency, ChannelAssignment] = field(
+    #: Map of radio frequencies to the radio/channel presets they were assigned
+    #: to. A frequency can land on more than one channel -- e.g. on both COMM1
+    #: and COMM2 -- so each maps to a list, ordered by assignment (COMM1 first).
+    frequency_to_channel_map: dict[RadioFrequency, list[ChannelAssignment]] = field(
         init=False, default_factory=dict
     )
 
@@ -93,8 +95,13 @@ class FlightData:
         return self.client_units[0].num_radio_channels(radio_id)
 
     def channel_for(self, frequency: RadioFrequency) -> Optional[ChannelAssignment]:
-        """Returns the radio and channel number for the given frequency."""
-        return self.frequency_to_channel_map.get(frequency, None)
+        """Returns the first (lowest) channel a frequency was assigned to."""
+        channels = self.frequency_to_channel_map.get(frequency)
+        return channels[0] if channels else None
+
+    def channels_for(self, frequency: RadioFrequency) -> list[ChannelAssignment]:
+        """Returns every channel a frequency was assigned to (COMM1 first)."""
+        return self.frequency_to_channel_map.get(frequency, [])
 
     def assign_channel(
         self, radio_id: int, channel_id: int, frequency: RadioFrequency
@@ -103,10 +110,8 @@ class FlightData:
         for unit in self.client_units:
             unit.set_radio_channel_preset(radio_id, channel_id, frequency.mhz)
 
-        # One frequency could be bound to multiple channels. Prefer the first,
-        # since with the current implementation it will be the lowest numbered
-        # channel.
-        if frequency not in self.frequency_to_channel_map:
-            self.frequency_to_channel_map[frequency] = ChannelAssignment(
-                radio_id, channel_id
-            )
+        # A frequency can be bound to several channels (e.g. mirrored onto both
+        # COMM1 and COMM2). Record them all, in assignment order.
+        self.frequency_to_channel_map.setdefault(frequency, []).append(
+            ChannelAssignment(radio_id, channel_id)
+        )

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -607,7 +607,9 @@ class SupportPage(KneeboardPage):
                 ]
             )
 
-        writer.table(comm_ladder, headers=["Callsign", "Task", "Type", "#A/C", "FREQ"])
+        # "#" not "#A/C": the count is a single digit, so the wider header padded the
+        # column and pushed the FREQ column off the right edge of the page.
+        writer.table(comm_ladder, headers=["Callsign", "Task", "Type", "#", "FREQ"])
 
         # AEW&C
         writer.heading("AEW&C")

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -645,7 +645,6 @@ class SupportPage(KneeboardPage):
             comm_ladder.append(
                 [
                     tanker.callsign,
-                    "Tanker",
                     KneeboardPageWriter.wrap_line(tanker.variant, 21),
                     str(tanker.tacan) if tanker.tacan else "N/A",
                     self.format_frequency(tanker.freq),
@@ -655,7 +654,10 @@ class SupportPage(KneeboardPage):
 
         writer.table(
             comm_ladder,
-            headers=["Callsign", "Task", "Type", "TACAN", "FREQ", "TOT / TOS"],
+            # Drop the "Task" column (always "Tanker" in this table) and shorten
+            # TACAN to TCN (3-char code), so the wider FREQ column (now COMM1 +
+            # COMM2) and TOT/TOS no longer run off the page edge.
+            headers=["Callsign", "Type", "TCN", "FREQ", "TOT / TOS"],
         )
 
         writer.heading("JTAC")
@@ -672,7 +674,9 @@ class SupportPage(KneeboardPage):
                     self.format_frequency(jtac.freq),
                 ]
             )
-        writer.table(jtacs, headers=["Callsign", "Region", "Laser Code", "FREQ"])
+        # "Laser" instead of "Laser Code": the code is 4 digits, so the longer
+        # header padded the column and pushed the FREQ column off the page.
+        writer.table(jtacs, headers=["Callsign", "Region", "Laser", "FREQ"])
 
         writer.write(path)
 

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -528,14 +528,15 @@ class BriefingPage(KneeboardPage):
         ]
 
     def format_frequency(self, frequency: RadioFrequency) -> str:
-        channel = self.flight.channel_for(frequency)
-        if channel is None:
+        channels = self.flight.channels_for(frequency)
+        if not channels:
             return str(frequency)
 
-        channel_name = self.flight.aircraft_type.channel_name(
-            channel.radio_id, channel.channel
+        names = " / ".join(
+            self.flight.aircraft_type.channel_name(c.radio_id, c.channel)
+            for c in channels
         )
-        return f"{channel_name}\n{frequency}"
+        return f"{names}\n{frequency}"
 
 
 class SupportPage(KneeboardPage):
@@ -678,14 +679,15 @@ class SupportPage(KneeboardPage):
     def format_frequency(self, frequency: Optional[RadioFrequency]) -> str:
         if frequency is None:
             return ""
-        channel = self.flight.channel_for(frequency)
-        if channel is None:
+        channels = self.flight.channels_for(frequency)
+        if not channels:
             return str(frequency)
 
-        channel_name = self.flight.aircraft_type.channel_name(
-            channel.radio_id, channel.channel
+        names = " / ".join(
+            self.flight.aircraft_type.channel_name(c.radio_id, c.channel)
+            for c in channels
         )
-        return f"{channel_name}\n{frequency}"
+        return f"{names}\n{frequency}"
 
     @staticmethod
     def _format_time(time: datetime.datetime | None) -> str:

--- a/game/radio/channels.py
+++ b/game/radio/channels.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from game.missiongenerator.aircraft.flightdata import FlightData
     from game.missiongenerator.missiondata import MissionData
+    from game.radio.radios import RadioFrequency
 
 
 class RadioChannelAllocator:
@@ -57,45 +58,64 @@ class CommonRadioChannelAllocator(RadioChannelAllocator):
         if self.inter_flight_radio_index is None:
             return
 
+        # The ordered set of inter-flight preset frequencies (departure ATC,
+        # AWACS, JTAC, package, arrival ATC, tankers, divert ATC).
+        frequencies = self._inter_flight_frequencies(flight, mission_data)
+
         # For cases where the inter-flight and intra-flight radios share presets
         # (the JF-17 only has one set of channels, even though it can use two
         # channels simultaneously), start assigning inter-flight channels at 2.
         radio_id = self.inter_flight_radio_index
-        if self.intra_flight_radio_index == radio_id:
-            first_channel = 2
-        else:
-            first_channel = 1
+        first_channel = 2 if self.intra_flight_radio_index == radio_id else 1
+        self._assign_sequential(flight, radio_id, first_channel, frequencies)
 
-        last_channel = flight.num_radio_channels(radio_id)
-        channel_alloc = iter(range(first_channel, last_channel + 1))
+        # Mirror the same presets onto the second radio (COMM2) when the
+        # aircraft has a distinct one, so a pilot can monitor two nets at once
+        # (e.g. the package on COMM1 and AWACS on COMM2). Channel 1 there holds
+        # the intra-flight frequency (which DCS also clobbers), so start at 2.
+        comm2_id = self.intra_flight_radio_index
+        if (
+            comm2_id is not None
+            and comm2_id != radio_id
+            and flight.num_radio_channels(comm2_id) > 1
+        ):
+            self._assign_sequential(flight, comm2_id, 2, frequencies)
 
+    @staticmethod
+    def _inter_flight_frequencies(
+        flight: FlightData, mission_data: MissionData
+    ) -> list[RadioFrequency]:
+        frequencies: list[RadioFrequency] = []
         if flight.departure.atc is not None:
-            flight.assign_channel(radio_id, next(channel_alloc), flight.departure.atc)
-
+            frequencies.append(flight.departure.atc)
         # TODO: If there ever are multiple AWACS, limit to mission relevant.
-        for awacs in mission_data.awacs:
-            flight.assign_channel(radio_id, next(channel_alloc), awacs.freq)
-
-        for jtac in mission_data.jtacs:
-            flight.assign_channel(radio_id, next(channel_alloc), jtac.freq)
-
+        frequencies.extend(awacs.freq for awacs in mission_data.awacs)
+        frequencies.extend(jtac.freq for jtac in mission_data.jtacs)
         if (freq := flight.package.frequency) is not None:
-            flight.assign_channel(radio_id, next(channel_alloc), freq)
-
+            frequencies.append(freq)
         if flight.arrival != flight.departure and flight.arrival.atc is not None:
-            flight.assign_channel(radio_id, next(channel_alloc), flight.arrival.atc)
+            frequencies.append(flight.arrival.atc)
+        # TODO: Skip incompatible tankers.
+        frequencies.extend(tanker.freq for tanker in mission_data.tankers)
+        if flight.divert is not None and flight.divert.atc is not None:
+            frequencies.append(flight.divert.atc)
+        return frequencies
 
-        try:
-            # TODO: Skip incompatible tankers.
-            for tanker in mission_data.tankers:
-                flight.assign_channel(radio_id, next(channel_alloc), tanker.freq)
-
-            if flight.divert is not None and flight.divert.atc is not None:
-                flight.assign_channel(radio_id, next(channel_alloc), flight.divert.atc)
-        except StopIteration:
-            # Any remaining channels are nice-to-haves, but not necessary for
-            # the few aircraft with a small number of channels available.
-            pass
+    @staticmethod
+    def _assign_sequential(
+        flight: FlightData,
+        radio_id: int,
+        first_channel: int,
+        frequencies: list[RadioFrequency],
+    ) -> None:
+        channels = iter(range(first_channel, flight.num_radio_channels(radio_id) + 1))
+        for frequency in frequencies:
+            try:
+                flight.assign_channel(radio_id, next(channels), frequency)
+            except StopIteration:
+                # Any remaining channels are nice-to-haves, but not necessary
+                # for the few aircraft with a small number of channels.
+                break
 
     @classmethod
     def from_cfg(cls, cfg: dict[str, Any]) -> CommonRadioChannelAllocator:

--- a/resources/units/aircraft/EA-18G.yaml
+++ b/resources/units/aircraft/EA-18G.yaml
@@ -25,12 +25,10 @@ radios:
   inter_flight: AN/ARC-210
   channels:
     type: common
-    # DCS will clobber channel 1 of the first radio compatible with the flight's
-    # assigned frequency. Since the F/A-18's two radios are both AN/ARC-210s,
-    # radio 1 will be compatible regardless of which frequency is assigned, so
-    # we must use radio 1 for the intra-flight radio.
-    intra_flight_radio_index: 1
-    inter_flight_radio_index: 2
+    # Two AN/ARC-210s. Inter-flight (ATC/package/AWACS) on radio 1 = COMM1, intra-flight
+    # on radio 2 = COMM2, matching the stock F/A-18C (upstream #608 swapped these indices).
+    intra_flight_radio_index: 2
+    inter_flight_radio_index: 1
 utc_kneeboard: true
 # default_overrides:
 #   HelmetMountedDevice: 1

--- a/resources/units/aircraft/FA-18E.yaml
+++ b/resources/units/aircraft/FA-18E.yaml
@@ -36,12 +36,10 @@ radios:
   inter_flight: AN/ARC-210
   channels:
     type: common
-    # DCS will clobber channel 1 of the first radio compatible with the flight's
-    # assigned frequency. Since the F/A-18's two radios are both AN/ARC-210s,
-    # radio 1 will be compatible regardless of which frequency is assigned, so
-    # we must use radio 1 for the intra-flight radio.
-    intra_flight_radio_index: 1
-    inter_flight_radio_index: 2
+    # Two AN/ARC-210s. Inter-flight (ATC/package/AWACS) on radio 1 = COMM1, intra-flight
+    # on radio 2 = COMM2, matching the stock F/A-18C (upstream #608 swapped these indices).
+    intra_flight_radio_index: 2
+    inter_flight_radio_index: 1
 utc_kneeboard: true
 # default_overrides:
 #   HelmetMountedDevice: 1

--- a/resources/units/aircraft/FA-18ET.yaml
+++ b/resources/units/aircraft/FA-18ET.yaml
@@ -45,12 +45,10 @@ radios:
   inter_flight: AN/ARC-210
   channels:
     type: common
-    # DCS will clobber channel 1 of the first radio compatible with the flight's
-    # assigned frequency. Since the F/A-18's two radios are both AN/ARC-210s,
-    # radio 1 will be compatible regardless of which frequency is assigned, so
-    # we must use radio 1 for the intra-flight radio.
-    intra_flight_radio_index: 1
-    inter_flight_radio_index: 2
+    # Two AN/ARC-210s. Inter-flight (ATC/package/AWACS) on radio 1 = COMM1, intra-flight
+    # on radio 2 = COMM2, matching the stock F/A-18C (upstream #608 swapped these indices).
+    intra_flight_radio_index: 2
+    inter_flight_radio_index: 1
 utc_kneeboard: true
 # default_overrides:
 #   HelmetMountedDevice: 1

--- a/resources/units/aircraft/FA-18F.yaml
+++ b/resources/units/aircraft/FA-18F.yaml
@@ -36,12 +36,10 @@ radios:
   inter_flight: AN/ARC-210
   channels:
     type: common
-    # DCS will clobber channel 1 of the first radio compatible with the flight's
-    # assigned frequency. Since the F/A-18's two radios are both AN/ARC-210s,
-    # radio 1 will be compatible regardless of which frequency is assigned, so
-    # we must use radio 1 for the intra-flight radio.
-    intra_flight_radio_index: 1
-    inter_flight_radio_index: 2
+    # Two AN/ARC-210s. Inter-flight (ATC/package/AWACS) on radio 1 = COMM1, intra-flight
+    # on radio 2 = COMM2, matching the stock F/A-18C (upstream #608 swapped these indices).
+    intra_flight_radio_index: 2
+    inter_flight_radio_index: 1
 utc_kneeboard: true
 # default_overrides:
 #   HelmetMountedDevice: 1

--- a/resources/units/aircraft/FA-18FT.yaml
+++ b/resources/units/aircraft/FA-18FT.yaml
@@ -45,12 +45,10 @@ radios:
   inter_flight: AN/ARC-210
   channels:
     type: common
-    # DCS will clobber channel 1 of the first radio compatible with the flight's
-    # assigned frequency. Since the F/A-18's two radios are both AN/ARC-210s,
-    # radio 1 will be compatible regardless of which frequency is assigned, so
-    # we must use radio 1 for the intra-flight radio.
-    intra_flight_radio_index: 1
-    inter_flight_radio_index: 2
+    # Two AN/ARC-210s. Inter-flight (ATC/package/AWACS) on radio 1 = COMM1, intra-flight
+    # on radio 2 = COMM2, matching the stock F/A-18C (upstream #608 swapped these indices).
+    intra_flight_radio_index: 2
+    inter_flight_radio_index: 1
 utc_kneeboard: true
 # default_overrides:
 #   HelmetMountedDevice: 1


### PR DESCRIPTION
Retribution assigns every preset radio channel (departure/arrival ATC, AWACS, JTAC, package, tankers, divert) to the inter-flight radio only. On a two-radio aircraft like the F/A-18C or F-16 you therefore can't keep, for example, your package on COMM1 and AWACS on COMM2 at the same time -- which is how manual campaign missions are usually set up.

This mirrors the same preset set onto the second radio (the intra-flight radio, which is COMM2 on the Hornet/Viper), starting at channel 2 since channel 1 carries the intra-flight frequency. It is driven by each aircraft's actual radio layout, so single-radio types and JF-17-style shared-preset radios are skipped automatically. The kneeboard now shows every channel a frequency maps to (e.g. `COMM1 Ch 3 / COMM2 Ch 4`).

The Tankers/JTAC kneeboard tables were also tightened so the wider FREQ column still fits (drop the always-"Tanker" Task column, `TACAN`->`TCN`, `Laser Code`->`Laser`).

![Support page kneeboard](https://raw.githubusercontent.com/juanjux/dcs-retribution/pr-assets-comm2/comm2_support_info.png)

![Mission info kneeboard](https://raw.githubusercontent.com/juanjux/dcs-retribution/pr-assets-comm2/comm2_mission_info.png)
