### PR TITLE
Colour enemy IADS network links by kind and state, and ease the tooltip hover

### DIFF
--- a/client/src/components/iadsnetwork/IadsNetwork.tsx
+++ b/client/src/components/iadsnetwork/IadsNetwork.tsx
@@ -3,37 +3,67 @@ import { Polyline as LPolyline } from "leaflet";
 import { useRef } from "react";
 import { Polyline, Tooltip } from "react-leaflet";
 
+// Colour each IADS link by both kind and state, with tones picked to stay
+// distinct from the other map layers:
+//   Communication: green = active, red  = inactive
+//   Power:         cyan  = active, gold = inactive
+// Power's cyan avoids the routes / threat-zone blue (#0084ff), and its gold
+// avoids the SAM detection-range yellow (#eee17b) and the highlight (#ffff00).
+const COMMS_ACTIVE = "#2ecc40";
+const COMMS_INACTIVE = "#ff4136";
+const POWER_ACTIVE = "#00bcd4";
+const POWER_INACTIVE = "#f1c40f";
+
 interface IadsConnectionProps {
   iads_connection: IadsConnectionModel;
 }
 
+function linkColor(isPower: boolean, active: boolean): string {
+  if (isPower) {
+    return active ? POWER_ACTIVE : POWER_INACTIVE;
+  }
+  return active ? COMMS_ACTIVE : COMMS_INACTIVE;
+}
+
 function IadsConnectionTooltip(props: IadsConnectionProps) {
-  var status = props.iads_connection.active ? "Active" : "Inactive"; 
+  const status = props.iads_connection.active ? "Active" : "Inactive";
   if (props.iads_connection.is_power) {
-    return <Tooltip>Power Connection ({status})</Tooltip>;
+    return <Tooltip sticky>Power Connection ({status})</Tooltip>;
   } else {
-    return <Tooltip>Communication Connection ({status})</Tooltip>;
+    return <Tooltip sticky>Communication Connection ({status})</Tooltip>;
   }
 }
 
-
 export default function IadsConnection(props: IadsConnectionProps) {
-  const color = props.iads_connection.is_power ? "#FFD580" : "#87CEEB";
+  const { active, is_power } = props.iads_connection;
+  const color = linkColor(is_power, active);
   const path = useRef<LPolyline | null>();
-  const weight = 1
-  var opacity = props.iads_connection.active ? 1.0 : 0.5
-  var dashArray = props.iads_connection.active ? "" : "20"
+  const opacity = active ? 1.0 : 0.8;
+  const dashArray = active ? "" : "20";
 
   return (
-    <Polyline
-      positions={props.iads_connection.points}
-      color={color}
-      weight={weight}
-      opacity={opacity}
-      dashArray={dashArray}
-      ref={(ref) => (path.current = ref)}
-    >
-      <IadsConnectionTooltip {...props} />
-    </Polyline>
+    <>
+      {/* Visible, state- and kind-coloured line. */}
+      <Polyline
+        positions={props.iads_connection.points}
+        color={color}
+        weight={2}
+        opacity={opacity}
+        dashArray={dashArray}
+        interactive={false}
+        ref={(ref) => (path.current = ref)}
+      />
+      {/* Invisible, much wider line carrying the tooltip, so hovering has a
+          comfortable margin instead of needing a pixel-perfect hit on the thin
+          line. Leaflet interactive paths use pointer-events: auto, so a zero-
+          opacity line still captures the mouse. */}
+      <Polyline
+        positions={props.iads_connection.points}
+        weight={16}
+        opacity={0}
+      >
+        <IadsConnectionTooltip {...props} />
+      </Polyline>
+    </>
   );
 }


### PR DESCRIPTION
## What

When the **Enemy IADS Network** overlay is enabled, every connection line was drawn in a single washed-out colour, so you couldn't tell a live link from a dead one, and the line was a pixel-thin hit target that made the status tooltip hard to hover.

This colours each link by both **kind** and **state**, and gives the tooltip a comfortable hover margin:

| Link | Active | Inactive |
| --- | --- | --- |
| Communication | green | red |
| Power | cyan | gold |

Inactive links are also drawn dashed (and slightly more transparent) so the state reads at a glance even for the colour-blind.

The two power tones are deliberately picked to stay distinct from the existing map layers: the cyan avoids the routes / threat-zone blue (`#0084ff`), and the gold avoids the SAM detection-range yellow (`#eee17b`) and the selection highlight (`#ffff00`).

## Hover margin

The visible line is still thin (`weight=2`). Hovering is handled by a second, invisible (`opacity=0`) `weight=16` polyline laid over the same points that carries the sticky tooltip — Leaflet interactive paths use `pointer-events: auto`, so the zero-opacity line still captures the mouse. You no longer need a pixel-perfect hit on the thin line to read the **Active/Inactive** status.

## Scope

Client-only — a single file, `client/src/components/iadsnetwork/IadsNetwork.tsx`. No API, backend, or schema changes.
