### PR TITLE
Anubis C-130 Hercules: suppress_ballute crash + air-assault zig-zag route (C-130 & helos)

### DIFF
--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -125,18 +125,15 @@ class Builder(FormationAttackBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
             pickup.alt = altitude
             pickup_position = pickup.position
 
-        ingress = (
-            builder.ingress(
-                FlightWaypointType.INGRESS_AIR_ASSAULT,
-                self.package.waypoints.ingress,
-                self.package.target,
-            )
-            if not self.flight.is_hercules
-            else builder.ingress(
-                FlightWaypointType.INGRESS_AIR_ASSAULT,
-                self.package.waypoints.initial,
-                self.package.target,
-            )
+        # Use the package ingress point for the ingress waypoint -- the same point
+        # the join uses below. The Hercules previously ingressed via
+        # package.waypoints.initial while the join stayed at .ingress, so its route
+        # ran out to one point, back to the other, then to the target (a visible
+        # zig-zag). Helicopters never had this because both already used .ingress.
+        ingress = builder.ingress(
+            FlightWaypointType.INGRESS_AIR_ASSAULT,
+            self.package.waypoints.ingress,
+            self.package.target,
         )
 
         assault_area = builder.assault_area(self.package.target)

--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -126,10 +126,7 @@ class Builder(FormationAttackBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
             pickup_position = pickup.position
 
         # Use the package ingress point for the ingress waypoint -- the same point
-        # the join uses below. The Hercules previously ingressed via
-        # package.waypoints.initial while the join stayed at .ingress, so its route
-        # ran out to one point, back to the other, then to the target (a visible
-        # zig-zag). Helicopters never had this because both already used .ingress.
+        # the join uses below.        
         ingress = builder.ingress(
             FlightWaypointType.INGRESS_AIR_ASSAULT,
             self.package.waypoints.ingress,

--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -125,8 +125,10 @@ class Builder(FormationAttackBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
             pickup.alt = altitude
             pickup_position = pickup.position
 
-        # Use the package ingress point for the ingress waypoint -- the same point
-        # the join uses below.
+        # Ingress waypoint; for helos WaypointBuilder.ingress re-anchors this to
+        # 5 NM from the target, so join below uses ingress.position to stay
+        # coincident with it -- otherwise the route overshoots to the package IP
+        # and back (the zig-zag).
         ingress = builder.ingress(
             FlightWaypointType.INGRESS_AIR_ASSAULT,
             self.package.waypoints.ingress,
@@ -173,7 +175,7 @@ class Builder(FormationAttackBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
             divert=builder.divert(self.flight.divert),
             bullseye=builder.bullseye(),
             hold=None,
-            join=builder.join(self.package.waypoints.ingress),
+            join=builder.join(ingress.position),
             split=builder.split(self.flight.arrival.position),
             refuel=None,
             custom_waypoints=list(),

--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -126,7 +126,7 @@ class Builder(FormationAttackBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
             pickup_position = pickup.position
 
         # Use the package ingress point for the ingress waypoint -- the same point
-        # the join uses below.        
+        # the join uses below.
         ingress = builder.ingress(
             FlightWaypointType.INGRESS_AIR_ASSAULT,
             self.package.waypoints.ingress,

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
 #: sound update they resolve a sound scheme without the ``suppress_ballute``
 #: input port ("No input port in scheme: suppress_ballute" -> unhandled
 #: exception -> DCS closes). Strip them when equipping pylons so even loadouts
-#: stored in an old save never carry them. 
+#: stored in an old save never carry them.
 _CRASHY_BALLUTE_CLSIDS = frozenset({"Herc_Soldier_Squad"})
 
 

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -59,8 +59,7 @@ if TYPE_CHECKING:
 #: sound update they resolve a sound scheme without the ``suppress_ballute``
 #: input port ("No input port in scheme: suppress_ballute" -> unhandled
 #: exception -> DCS closes). Strip them when equipping pylons so even loadouts
-#: stored in an old save never carry them. ``Herc_GBU-43/B(MOAB)`` is a usable
-#: weapon and a rarer trigger, so it is deliberately kept (residual risk).
+#: stored in an old save never carry them. 
 _CRASHY_BALLUTE_CLSIDS = frozenset({"Herc_Soldier_Squad"})
 
 

--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -54,6 +54,16 @@ if TYPE_CHECKING:
     from game import Game
 
 
+#: Mod weapon CLSIDs that crash DCS when dropped or cooked off. The Anubis C-130
+#: airdrop weapons are class ``wAmmunitionBallute``; since the official C-130J
+#: sound update they resolve a sound scheme without the ``suppress_ballute``
+#: input port ("No input port in scheme: suppress_ballute" -> unhandled
+#: exception -> DCS closes). Strip them when equipping pylons so even loadouts
+#: stored in an old save never carry them. ``Herc_GBU-43/B(MOAB)`` is a usable
+#: weapon and a rarer trigger, so it is deliberately kept (residual risk).
+_CRASHY_BALLUTE_CLSIDS = frozenset({"Herc_Soldier_Squad"})
+
+
 class FlightGroupConfigurator:
     def __init__(
         self,
@@ -412,6 +422,10 @@ class FlightGroupConfigurator:
 
         for pylon_number, weapon in loadout.pylons.items():
             if weapon is None:
+                continue
+            if weapon.clsid in _CRASHY_BALLUTE_CLSIDS:
+                # Drop the crash-prone mod airdrop weapon even if a stored
+                # loadout still carries it; air-assault troops come from CTLD.
                 continue
             pylon = Pylon.for_aircraft(self.flight.unit_type, pylon_number)
             settings = self._merge_laser_code(

--- a/resources/customized_payloads/Hercules.lua
+++ b/resources/customized_payloads/Hercules.lua
@@ -8,10 +8,6 @@ local unitPayloads = {
 					["CLSID"] = "Herc_GBU-43/B(MOAB)",
 					["num"] = 11,
 				},
-				[2] = {
-					["CLSID"] = "Herc_Soldier_Squad",
-					["num"] = 12,
-				},
 			},
 			["tasks"] = {
 				[1] = 31,
@@ -21,10 +17,6 @@ local unitPayloads = {
 			["name"] = "STRIKE",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "Herc_Soldier_Squad",
-					["num"] = 12,
-				},
-				[2] = {
 					["CLSID"] = "Herc_GBU-43/B(MOAB)",
 					["num"] = 11,
 				},
@@ -40,10 +32,6 @@ local unitPayloads = {
 					["CLSID"] = "Herc_GBU-43/B(MOAB)",
 					["num"] = 11,
 				},
-				[2] = {
-					["CLSID"] = "Herc_Soldier_Squad",
-					["num"] = 12,
-				},
 			},
 			["tasks"] = {
 				[1] = 31,
@@ -53,10 +41,6 @@ local unitPayloads = {
 			["name"] = "OCA",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "Herc_Soldier_Squad",
-					["num"] = 12,
-				},
-				[2] = {
 					["CLSID"] = "Herc_GBU-43/B(MOAB)",
 					["num"] = 11,
 				},
@@ -72,10 +56,6 @@ local unitPayloads = {
 					["CLSID"] = "Herc_GBU-43/B(MOAB)",
 					["num"] = 11,
 				},
-				[2] = {
-					["CLSID"] = "Herc_Soldier_Squad",
-					["num"] = 12,
-				},
 			},
 			["tasks"] = {
 				[1] = 31,
@@ -87,10 +67,6 @@ local unitPayloads = {
 				[1] = {
 					["CLSID"] = "Herc_GBU-43/B(MOAB)",
 					["num"] = 11,
-				},
-				[2] = {
-					["CLSID"] = "Herc_Soldier_Squad",
-					["num"] = 12,
 				},
 			},
 			["tasks"] = {
@@ -109,10 +85,6 @@ local unitPayloads = {
 			["name"] = "RUNWAY_STRIKE",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "Herc_Soldier_Squad",
-					["num"] = 12,
-				},
-				[2] = {
 					["CLSID"] = "Herc_GBU-43/B(MOAB)",
 					["num"] = 11,
 				},
@@ -155,10 +127,6 @@ local unitPayloads = {
 			["name"] = "Retribution Air Assault",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "Herc_Soldier_Squad",
-					["num"] = 12,
-				},
-				[2] = {
 					["CLSID"] = "Herc_JATO",
 					["num"] = 1,
 				},


### PR DESCRIPTION
Two fixes: a crash workaround for the Anubis C-130 Hercules mod, and the air-assault zig-zag ingress route (for the C-130 **and** helicopters).

## 1. Workaround the `suppress_ballute` crash (DCS closes)

The Anubis C-130 airdrop weapons are class `wAmmunitionBallute`. Since the official C-130J sound update, dropping one (or having the carrying C-130 destroyed) makes DCS resolve a sound scheme that has no `suppress_ballute` input port, throws **`No input port in scheme: suppress_ballute`**, and the sim closes to desktop. The common trigger in Retribution is `Herc_Soldier_Squad`, the air-assault paratroop drop.

Fix: strip `Herc_Soldier_Squad` when equipping pylons (`flightgroupconfigurator.setup_payload`), so even loadouts already stored in a save never carry it — editing the payload `.lua` alone only affects newly-planned flights. The weapon is also removed from the customized Hercules payloads.

- **Air-assault base capture is unaffected**: the troops come from CTLD (`cabin_size` + target zone), not the cosmetic soldier-squad pylon.
- **The MOAB (`Herc_GBU-43/B(MOAB)`) is deliberately kept** — it's a usable weapon and a much rarer trigger (documented residual risk in the code comment). The AC-130 gunship loadout is untouched.

Paratroopers in air assaults still work as before.

## 2. Fix the air-assault zig-zag ingress route (C-130 + helicopters)

The Hercules air-assault used `package.waypoints.initial` for its ingress waypoint while the join used `package.waypoints.ingress`, so the route ran out to one point, back to the other, then to the target — a visible approach / retreat / approach zig-zag. Now the ingress waypoint uses `.ingress` too, so join and ingress coincide and the route runs straight to the target.

Helicopters had the same zig-zag for air assault from a different cause: `WaypointBuilder.ingress` re-anchors the helo ingress waypoint to 5 NM from the target, but the join was still built from the raw `package.waypoints.ingress` (the IP, typically 10–45 NM out), so the helo flew in, back out to the IP, then in again. The join now uses `ingress.position`, so it coincides with the (helo-adjusted) ingress and the route runs straight in.

