### PR TITLE
debriefing: summarise untracked ground-unit deaths in one log line (fixes ~20seconds end-of-mission UI freeze)

### DIFF
--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -344,6 +344,7 @@ class Debriefing:
 
     def dead_ground_units(self) -> GroundLosses:
         losses = GroundLosses()
+        untracked: List[str] = []
         for unit_name in self.state_data.killed_ground_units:
             front_line_unit = self.unit_map.front_line_unit(unit_name)
             if front_line_unit is not None:
@@ -398,13 +399,19 @@ class Debriefing:
                     losses.enemy_airfields.append(airfield)
                 continue
 
-            # Only logging as debug because we don't currently track infantry
-            # deaths, so we expect to see quite a few unclaimed dead ground
-            # units. We should start tracking those and covert this to a
-            # warning.
+            # We don't track infantry or map/scenery objects, so a mission can
+            # end with thousands of these unclaimed deaths. Collect them and log
+            # one summary instead of a line each: per-unit logging here floods
+            # the handlers (a file stat + flush per line, plus the log-window UI
+            # hook) and froze the debrief for ~20s on busy missions.
+            untracked.append(unit_name)
+
+        if untracked:
             logging.debug(
-                f"Death of untracked ground unit {unit_name} will "
-                "have no effect. This may be normal behavior."
+                "%d untracked ground unit deaths had no effect (untracked "
+                "infantry or map/scenery objects). First few: %s",
+                len(untracked),
+                ", ".join(untracked[:10]),
             )
 
         for unit_name in self.state_data.killed_aircraft:


### PR DESCRIPTION
## Problem

When a mission ends, `Debriefing.dead_ground_units` logs one `logging.debug` line for **every** killed unit that maps to nothing we track — infantry and map/scenery objects. A busy mission produces thousands of those, a real `state.json` here ended with ~8000 dead map objects, taking 16 seconds to process. With this PR, the same `state.json` takes less than a second to process.

The cost is entirely the logging, not the parsing or the loss bookkeeping. 

## Fix

Collect the untracked unit names and emit a **single summary** `debug` line instead of one per unit. No behaviour change — these deaths were already only logged, never acted on (the code comment notes they're expected in bulk).


