### PR TITLE
Map tooltips: SAM rings (name + emitters) and package routes (flight/package info)

### DIFF
--- a/client/src/api/_liberationApi.ts
+++ b/client/src/api/_liberationApi.ts
@@ -404,6 +404,12 @@ export type Flight = {
   position?: LatLng;
   sidc: string;
   waypoints?: Waypoint[];
+  aircraft?: string;
+  num_aircraft?: number;
+  flight_type?: string;
+  callsign?: string | null;
+  package_target?: string;
+  package_tot?: string;
 };
 export type FrontLine = {
   id: string;

--- a/client/src/components/airdefenserangelayer/AirDefenseRangeLayer.test.tsx
+++ b/client/src/components/airdefenserangelayer/AirDefenseRangeLayer.test.tsx
@@ -12,6 +12,7 @@ jest.mock("react-leaflet", () => ({
   Circle: (props: any) => {
     mockCircle(props);
   },
+  Tooltip: (props: PropsWithChildren<any>) => <>{props.children}</>,
 }));
 
 describe("colorFor", () => {
@@ -102,7 +103,7 @@ describe("AirDefenseRangeLayer", () => {
         },
         radius: 10,
         color: colorFor(true, false),
-      })
+      }),
     );
   });
 
@@ -141,7 +142,7 @@ describe("AirDefenseRangeLayer", () => {
         },
         radius: 20,
         color: colorFor(true, true),
-      })
+      }),
     );
   });
 });

--- a/client/src/components/airdefenserangelayer/AirDefenseRangeLayer.tsx
+++ b/client/src/components/airdefenserangelayer/AirDefenseRangeLayer.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../api/mapSlice";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { Fragment } from "react";
-import { Circle, CircleMarker, LayerGroup } from "react-leaflet";
+import { Circle, CircleMarker, LayerGroup, Tooltip } from "react-leaflet";
 
 interface TgoRangeCirclesProps {
   tgo: Tgo;
@@ -26,6 +26,14 @@ export function colorFor(blue: boolean, detection: boolean) {
 // Bright colour used to mark the hovered ring and its emitter.
 const HIGHLIGHT_COLOR = "#ffff00";
 
+// Collapse a unit list like ["SA-6 TEL", "SA-6 TEL", "Straight Flush"] into
+// ["2x SA-6 TEL", "Straight Flush"] so the ring tooltip names the SAM compactly.
+function summarizeUnits(units: string[]): string[] {
+  const counts = new Map<string, number>();
+  units.forEach((unit) => counts.set(unit, (counts.get(unit) ?? 0) + 1));
+  return Array.from(counts, ([name, n]) => (n > 1 ? `${n}x ${name}` : name));
+}
+
 const TgoRangeCircles = (props: TgoRangeCirclesProps) => {
   const radii = props.detection
     ? props.tgo.detection_ranges
@@ -40,14 +48,14 @@ const TgoRangeCircles = (props: TgoRangeCirclesProps) => {
   const highlighted = useAppSelector(
     (state) =>
       selectHighlightEmitters(state) &&
-      selectHoveredEmitter(state) === props.tgo.id
+      selectHoveredEmitter(state) === props.tgo.id,
   );
   // Mark the emitter with a blob only when the hover came from a ring, to help
   // locate it (associating ring <-> emitter). When the emitter icon itself is
   // hovered we don't blob it, since we're already pointing at it. The ring
   // itself always lights up while highlighted, in either direction.
   const markEmitter = useAppSelector(
-    (state) => highlighted && selectHoveredEmitterSource(state) === "ring"
+    (state) => highlighted && selectHoveredEmitterSource(state) === "ring",
   );
 
   const hover = {
@@ -88,7 +96,14 @@ const TgoRangeCircles = (props: TgoRangeCirclesProps) => {
             weight={18}
             className="air-defense-ring-hit"
             eventHandlers={hover}
-          />
+          >
+            <Tooltip sticky className="tooltip-delayed">
+              <b>{props.tgo.name}</b>
+              {summarizeUnits(props.tgo.units).map((unit, i) => (
+                <div key={i}>{unit}</div>
+              ))}
+            </Tooltip>
+          </Circle>
         </Fragment>
       ))}
       {markEmitter && (

--- a/client/src/components/airdefenserangelayer/AirDefenseRangeLayer.tsx
+++ b/client/src/components/airdefenserangelayer/AirDefenseRangeLayer.tsx
@@ -1,4 +1,8 @@
-import { Tgo } from "../../api/liberationApi";
+import {
+  Tgo,
+  useOpenNewTgoPackageDialogMutation,
+  useOpenTgoInfoDialogMutation,
+} from "../../api/liberationApi";
 import { selectTgos } from "../../api/tgosSlice";
 import {
   selectHighlightEmitters,
@@ -58,10 +62,18 @@ const TgoRangeCircles = (props: TgoRangeCirclesProps) => {
     (state) => highlighted && selectHoveredEmitterSource(state) === "ring",
   );
 
-  const hover = {
+  const [openInfoDialog] = useOpenTgoInfoDialogMutation();
+  const [openNewPackageDialog] = useOpenNewTgoPackageDialogMutation();
+
+  // The ring mirrors the emitter icon's clicks, so you can reach a SAM site
+  // whose icon is buried under another marker: left-click opens its info
+  // dialog, right-click starts a new package against it.
+  const handlers = {
     mouseover: () =>
       dispatch(setHoveredEmitter({ id: props.tgo.id, source: "ring" })),
     mouseout: () => dispatch(setHoveredEmitter(null)),
+    click: () => openInfoDialog({ tgoId: props.tgo.id }),
+    contextmenu: () => openNewPackageDialog({ tgoId: props.tgo.id }),
   };
 
   return (
@@ -95,7 +107,7 @@ const TgoRangeCircles = (props: TgoRangeCirclesProps) => {
             opacity={0}
             weight={18}
             className="air-defense-ring-hit"
-            eventHandlers={hover}
+            eventHandlers={handlers}
           >
             <Tooltip sticky className="tooltip-delayed">
               <b>{props.tgo.name}</b>

--- a/client/src/components/flightplan/FlightPlan.tsx
+++ b/client/src/components/flightplan/FlightPlan.tsx
@@ -6,7 +6,7 @@ import {
 import WaypointMarker from "../waypointmarker";
 import { Polyline as LPolyline } from "leaflet";
 import { ReactElement, useEffect, useRef } from "react";
-import { Polyline } from "react-leaflet";
+import { Polyline, Tooltip } from "react-leaflet";
 
 const BLUE_PATH = "#0084ff";
 const RED_PATH = "#c85050";
@@ -27,6 +27,29 @@ const pathColor = (props: FlightPlanProps) => {
     return RED_PATH;
   }
 };
+
+// Hover summary of a package's intent: callsign / composition, task, target and
+// time-over-target. Fields are optional so it degrades gracefully if the server
+// hasn't supplied them (older data); the live server always populates them.
+function FlightTooltip({ flight }: { flight: Flight }) {
+  const composition =
+    flight.aircraft != null
+      ? `${flight.num_aircraft ?? "?"}x ${flight.aircraft}`
+      : null;
+  return (
+    <Tooltip sticky className="tooltip-delayed">
+      <b>{flight.callsign || composition || "Flight"}</b>
+      {flight.flight_type ? ` - ${flight.flight_type}` : ""}
+      {flight.callsign && composition ? <div>{composition}</div> : null}
+      {flight.package_target ? (
+        <div>
+          Target: {flight.package_target}
+          {flight.package_tot ? ` (TOT ${flight.package_tot})` : ""}
+        </div>
+      ) : null}
+    </Tooltip>
+  );
+}
 
 function FlightPlanPath(props: FlightPlanProps) {
   const color = pathColor(props);
@@ -51,10 +74,9 @@ function FlightPlanPath(props: FlightPlanProps) {
   // goes on top.
   useEffect(() => {
     if (props.selected) {
-        polylineRef.current?.bringToFront();
-    }
-    else {
-        polylineRef.current?.bringToBack();
+      polylineRef.current?.bringToFront();
+    } else {
+      polylineRef.current?.bringToBack();
     }
   });
 
@@ -70,31 +92,52 @@ function FlightPlanPath(props: FlightPlanProps) {
   // sidebar via a round-trip through the server.
   const interactive = props.flight.blue;
 
-  return (
+  // The thin visible route never catches the mouse itself. For blue flights a
+  // wide, invisible overlay polyline sits on top and handles hover (yellow
+  // highlight + tooltip) and the click-to-select, so the route is easy to grab
+  // without looking any thicker -- the same trick the SAM rings use.
+  const visible = (
     <Polyline
       positions={points}
-      pathOptions={{ color: color, interactive: interactive }}
+      pathOptions={{ color: color, interactive: false }}
       ref={polylineRef}
-      eventHandlers={
-        interactive
-          ? {
-              mouseover: () => {
-                polylineRef.current?.setStyle({ color: SELECTED_PATH });
-                polylineRef.current?.bringToFront();
-              },
-              mouseout: () => {
-                if (!props.selected) {
-                  polylineRef.current?.setStyle({ color: color });
-                  polylineRef.current?.bringToBack();
-                }
-              },
-              click: () => {
-                selectFlight({ flightId: props.flight.id });
-              },
-            }
-          : undefined
-      }
     />
+  );
+
+  if (!interactive) {
+    return visible;
+  }
+
+  return (
+    <>
+      {visible}
+      <Polyline
+        positions={points}
+        pathOptions={{
+          color: color,
+          weight: 16,
+          opacity: 0,
+          interactive: true,
+        }}
+        eventHandlers={{
+          mouseover: () => {
+            polylineRef.current?.setStyle({ color: SELECTED_PATH });
+            polylineRef.current?.bringToFront();
+          },
+          mouseout: () => {
+            if (!props.selected) {
+              polylineRef.current?.setStyle({ color: color });
+              polylineRef.current?.bringToBack();
+            }
+          },
+          click: () => {
+            selectFlight({ flightId: props.flight.id });
+          },
+        }}
+      >
+        <FlightTooltip flight={props.flight} />
+      </Polyline>
+    </>
   );
 }
 
@@ -112,7 +155,7 @@ const WaypointMarkers = (props: FlightPlanProps) => {
           number={idx}
           waypoint={p}
           flight={props.flight}
-        />
+        />,
       );
     }
   });
@@ -136,7 +179,7 @@ function CommitBoundary(props: CommitBoundaryProps) {
     //
     // This isn't perfect. It won't redraw until the component remounts. There
     // doesn't appear to be a better way.
-    { refetchOnMountOrArgChange: true }
+    { refetchOnMountOrArgChange: true },
   );
   if (isLoading) {
     return <></>;
@@ -147,7 +190,7 @@ function CommitBoundary(props: CommitBoundaryProps) {
   }
   if (!data) {
     console.log(
-      `Null response data when loading commit boundary for ${props.flightId}`
+      `Null response data when loading commit boundary for ${props.flightId}`,
     );
     return <></>;
   }

--- a/client/src/components/flightplanslayer/FlightPlansLayer.test.tsx
+++ b/client/src/components/flightplanslayer/FlightPlansLayer.test.tsx
@@ -96,10 +96,11 @@ describe("FlightPlansLayer", () => {
         },
       });
 
-      // For some reason passing ref to PolyLine causes it and its group to be
-      // redrawn, so these numbers don't match what you'd expect from the test.
-      // It probably needs to be rewritten without mocks.
-      expect(mockPolyline).toHaveBeenCalledTimes(3);
+      // Each drawn blue flight renders two polylines now: the visible route and
+      // a wide invisible hover overlay. Passing a ref to the visible one also
+      // causes a redraw, so these counts are higher than the flight count. (It
+      // probably needs to be rewritten without mocks.)
+      expect(mockPolyline).toHaveBeenCalledTimes(5);
       expect(mockLayerGroup).toBeCalledTimes(2);
     });
     it("are not drawn if wrong coalition", () => {
@@ -178,7 +179,7 @@ describe("FlightPlansLayer", () => {
           },
         },
       });
-      expect(mockPolyline).toHaveBeenCalledTimes(1);
+      expect(mockPolyline).toHaveBeenCalledTimes(2);
       expect(mockLayerGroup).toBeCalledTimes(1);
     });
     it("are not drawn when only selected flights are to be drawn", () => {
@@ -305,7 +306,7 @@ describe("FlightPlansLayer", () => {
           },
         },
       });
-      expect(mockPolyline).toHaveBeenCalledTimes(2);
+      expect(mockPolyline).toHaveBeenCalledTimes(4);
       expect(mockLayerGroup).toBeCalledTimes(1);
     });
     it("are not drawn twice", () => {
@@ -351,7 +352,7 @@ describe("FlightPlansLayer", () => {
           },
         },
       });
-      expect(mockPolyline).toHaveBeenCalledTimes(1);
+      expect(mockPolyline).toHaveBeenCalledTimes(2);
       expect(mockLayerGroup).toBeCalledTimes(1);
     });
     it("are not drawn if red", () => {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,15 +1,15 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
 /* Wide, invisible hover target for SAM threat/detection rings. pointer-events:
@@ -17,4 +17,19 @@ code {
    though it is not painted, so the ring is easy to hover when zoomed out. */
 .air-defense-ring-hit {
   pointer-events: stroke !important;
+}
+
+/* Hover delay for the SAM-ring and package-route tooltips, so they don't flicker
+   when the cursor merely sweeps past. Leaflet has no open-delay option, so we
+   hold the tooltip invisible for the animation's duration; once it ends the
+   element reverts to Leaflet's inline opacity and appears. (Animations override
+   inline styles while running.) Scoped by class so other tooltips are instant. */
+.leaflet-tooltip.tooltip-delayed {
+  animation: tooltip-hover-delay 0.3s;
+}
+@keyframes tooltip-hover-delay {
+  0%,
+  100% {
+    opacity: 0;
+  }
 }

--- a/game/server/flights/models.py
+++ b/game/server/flights/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -22,6 +23,14 @@ class FlightJs(BaseModel):
     position: LeafletPoint | None
     sidc: str
     waypoints: list[FlightWaypointJs] | None
+    # Summary of the flight and its package, surfaced as a map route tooltip so
+    # the player can read a package's intent without opening the Qt sidebar.
+    aircraft: str
+    num_aircraft: int
+    flight_type: str
+    callsign: str | None
+    package_target: str
+    package_tot: str
 
     class Config:
         title = "Flight"
@@ -45,12 +54,20 @@ class FlightJs(BaseModel):
             blue = True
         else:
             blue = False
+        package = flight.package
+        tot = package.time_over_target
         return FlightJs(
             id=flight.id,
             blue=blue,
             position=position,
             sidc=str(flight.sidc()),
             waypoints=waypoints,
+            aircraft=flight.unit_type.display_name,
+            num_aircraft=flight.count,
+            flight_type=flight.flight_type.value,
+            callsign=flight.custom_name,
+            package_target=package.target.name,
+            package_tot=tot.strftime("%H:%M:%SZ") if tot != datetime.min else "",
         )
 
     @staticmethod


### PR DESCRIPTION
## What

Two map hover tooltips, so you can read what's on the map without clicking through.

**SAM / air-defense rings** — hovering a threat or detection ring shows the site's name (its codename) and a compact, de-duplicated list of the units that make it up, e.g.:

> **AUROCHS**
> 2x SA-6 TEL
> Straight Flush STR

**Package routes** — hovering a friendly route line shows the flight's callsign or composition, its task, the package target and the time-over-target, e.g.:

> **2x F/A-18C Hornet** - CAS
> Target: AUROCHS (TOT 14:16:32Z)

## Notes

- The route tooltip needs information the `Flight` API model didn't carry, so `FlightJs` now also serialises `aircraft`, `num_aircraft`, `flight_type`, `callsign`, `package_target` and `package_tot`. The corresponding fields were hand-added to the generated client `Flight` type (optional, so they degrade gracefully); they'll be reproduced next time the API types are regenerated. The SAM tooltip needs no backend change — it reuses `name` + `units` already on the TGO.

- The route line was only as hoverable as its ~3 px visible width. It now keeps the thin visible line non-interactive and lays a wide, invisible overlay polyline over it that carries the hover (yellow highlight + tooltip) and the click-to-select — the route looks identical but is far easier to grab, mirroring the SAM rings' invisible hover band.
