### PR TITLE
Finances dialog: show income, automated HQ spending and net per turn

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 * **[UX]** Show an "End of Mission Detected, processing Mission Data" busy dialog while turn results are processed, so the wait is not mistaken for a missed detection
 * **[Map]** Hovering a SAM threat or detection ring highlights its emitter — and hovering an emitter highlights its ring — making it easy to tell which site a ring belongs to. Can be disabled from the map's layer control.
+* **[UI]** The Finances dialog now spells out gross income, the HQ's automated per-category spending (front line, aircraft, runway repairs) and the resulting net for the turn, so the gap between income and the balance that actually lands is no longer a mystery. Building income is grouped into collapsible sections and the automation toggles can be flipped right from the dialog.
 
 ## Fixes
 * **[Mission]** Reliably auto-detect end of mission, even when DCS wrote the final state.json before the wait dialog started watching

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 * **[UX]** Show an "End of Mission Detected, processing Mission Data" busy dialog while turn results are processed, so the wait is not mistaken for a missed detection
 * **[Map]** Hovering a SAM threat or detection ring highlights its emitter — and hovering an emitter highlights its ring — making it easy to tell which site a ring belongs to. Can be disabled from the map's layer control.
-* **[UI]** The Finances dialog now spells out gross income, the HQ's automated per-category spending (front line, aircraft, runway repairs) and the resulting net for the turn, so the gap between income and the balance that actually lands is no longer a mystery. Building income is grouped into collapsible sections and the automation toggles can be flipped right from the dialog.
+* **[UI]** Reworked the Finances dialog to show gross income, the HQ's automated per-category spending and the resulting net per turn, with a collapsible income breakdown and in-dialog automation toggles.
 
 ## Fixes
 * **[Mission]** Reliably auto-detect end of mission, even when DCS wrote the final state.json before the wait dialog started watching

--- a/game/coalition.py
+++ b/game/coalition.py
@@ -47,6 +47,10 @@ class Coalition:
         self.air_wing = AirWing(player, game, self.faction)
         self.armed_forces = ArmedForces(self.faction)
         self.transfers = PendingTransfers(game, player)
+        # Money the automated HQ spent per category last turn (front_line,
+        # runways, buildings, ground_objects, aircraft). Surfaced in the
+        # Finances dialog so the player sees where their income went.
+        self.last_turn_expenses: dict[str, float] = {}
 
         # Late initialized because the two coalitions in the game are mutually
         # dependent, so must be both constructed before this property can be set.
@@ -243,14 +247,16 @@ class Coalition:
             manage_front_line = True
             manage_aircraft = True
 
-        self.budget = ProcurementAi(
+        procurement = ProcurementAi(
             self.game,
             self.player,
             self.faction,
             manage_runways,
             manage_front_line,
             manage_aircraft,
-        ).spend_budget(self.budget)
+        )
+        self.budget = procurement.spend_budget(self.budget)
+        self.last_turn_expenses = procurement.last_expenses
 
     def add_procurement_request(self, request: AircraftProcurementRequest) -> None:
         self.procurement_requests.add(request)

--- a/game/procurement.py
+++ b/game/procurement.py
@@ -48,6 +48,9 @@ class ProcurementAi:
         self.manage_front_line = manage_front_line
         self.manage_aircraft = manage_aircraft
         self.threat_zones = self.game.threat_zone_for(self.is_player.opponent)
+        # Money spent per automated category during spend_budget, so the
+        # Finances dialog can show the player where their income actually went.
+        self.last_expenses: dict[str, float] = {}
 
     def calculate_ground_unit_budget_share(self) -> float:
         armor_investment = 0
@@ -96,15 +99,25 @@ class ProcurementAi:
         return ground_unit_share
 
     def spend_budget(self, budget: float) -> float:
+        # Record how much each automated step spends so the Finances dialog can
+        # show the player where their income actually goes (the auto-spend often
+        # consumes most of it before the player sees the balance).
+        self.last_expenses = {}
         if self.manage_runways:
+            before = budget
             budget = self.repair_runways(budget)
+            self.last_expenses["runways"] = before - budget
         if self.manage_front_line:
             armor_budget = budget * self.calculate_ground_unit_budget_share()
             budget -= armor_budget
-            budget += self.reinforce_front_line(armor_budget)
+            leftover = self.reinforce_front_line(armor_budget)
+            self.last_expenses["front_line"] = armor_budget - leftover
+            budget += leftover
 
         if self.manage_aircraft:
+            before = budget
             budget = self.purchase_aircraft(budget)
+            self.last_expenses["aircraft"] = before - budget
         return budget
 
     def repair_runways(self, budget: float) -> float:

--- a/qt_ui/windows/finances/QFinancesMenu.py
+++ b/qt_ui/windows/finances/QFinancesMenu.py
@@ -111,11 +111,17 @@ class FinancesLayout(QGridLayout):
         self.addWidget(QHorizontalSeparationLine(), next(self.row), 0, 1, 3)
 
 
-#: Automated-spending categories shown in the dialog, in display order. Each is
+#: Automated-spending categories the dialog *can* show, in display order. Each is
 #: (last_turn_expenses key, label, the settings flag that toggles it for blue).
+#: A category is only shown if its settings flag exists in the running build, so
+#: the dialog adapts automatically: builds without the building/ground-object
+#: repair automation simply omit those rows, and they appear on their own once
+#: that automation is present - no change to this dialog needed.
 _EXPENSE_CATEGORIES = [
     ("front_line", "Front line reinforcement", "automate_front_line_reinforcements"),
     ("aircraft", "Aircraft purchases", "automate_aircraft_reinforcements"),
+    ("ground_objects", "SAM / ground repairs", "automate_ground_object_repairs"),
+    ("buildings", "Building repairs", "automate_building_repairs"),
     ("runways", "Runway repairs", "automate_runway_repair"),
 ]
 
@@ -351,6 +357,14 @@ class QFinancesMenu(QDialog):
             row += 1
 
         for key, label, flag in _EXPENSE_CATEGORIES:
+            # Only show categories whose automation exists in this build. We probe
+            # the Settings *class* (not the instance): a loaded save can carry
+            # settings attributes pickled by a fork build that declared them, but
+            # the running code is what decides whether the feature actually exists.
+            # This is what lets the dialog adapt to optional repair features
+            # without code changes here when they land.
+            if not hasattr(type(settings), flag):
+                continue
             enabled = bool(getattr(settings, flag, False))
             grid.addWidget(_label(label), row, 0)
 

--- a/qt_ui/windows/finances/QFinancesMenu.py
+++ b/qt_ui/windows/finances/QFinancesMenu.py
@@ -1,12 +1,19 @@
 import itertools
-from typing import Optional
+from typing import List, Optional
 
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QDialog,
     QFrame,
     QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
     QLabel,
+    QPushButton,
+    QScrollArea,
     QSizePolicy,
+    QVBoxLayout,
+    QWidget,
 )
 
 import qt_ui.uiconstants as CONST
@@ -16,7 +23,7 @@ from game.theater import ControlPoint, Player
 
 
 class QHorizontalSeparationLine(QFrame):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.setMinimumWidth(1)
         self.setFixedHeight(20)
@@ -26,6 +33,8 @@ class QHorizontalSeparationLine(QFrame):
 
 
 class FinancesLayout(QGridLayout):
+    """Compact income-only breakdown, embedded in the intel panel."""
+
     def __init__(self, game: Game, player: Player, total_at_top: bool = False) -> None:
         super().__init__()
         self.row = itertools.count(0)
@@ -52,7 +61,7 @@ class FinancesLayout(QGridLayout):
             self.add_line()
             self.add_total(game, income, player)
 
-    def add_total(self, game, income, player):
+    def add_total(self, game: Game, income: Income, player: Player) -> None:
         self.add_row(
             middle=f"Income multiplier: {income.multiplier:.1f}",
             right=f"<b>{income.total:.1f}M</b>",
@@ -102,14 +111,228 @@ class FinancesLayout(QGridLayout):
         self.addWidget(QHorizontalSeparationLine(), next(self.row), 0, 1, 3)
 
 
-class QFinancesMenu(QDialog):
-    def __init__(self, game: Game):
-        super(QFinancesMenu, self).__init__()
+#: Automated-spending categories shown in the dialog, in display order. Each is
+#: (last_turn_expenses key, label, the settings flag that toggles it for blue).
+_EXPENSE_CATEGORIES = [
+    ("front_line", "Front line reinforcement", "automate_front_line_reinforcements"),
+    ("aircraft", "Aircraft purchases", "automate_aircraft_reinforcements"),
+    ("runways", "Runway repairs", "automate_runway_repair"),
+]
 
+_RIGHT = Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+_CENTER = Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+
+
+def _money(value: float, signed: bool = False) -> str:
+    rounded = round(value)
+    if signed:
+        sign = "+" if rounded > 0 else ("-" if rounded < 0 else "")
+        return f"{sign}{abs(rounded)}M"
+    return f"{rounded}M"
+
+
+def _label(
+    text: str,
+    style: Optional[str] = None,
+    *,
+    right: bool = False,
+    center: bool = False,
+    bold: bool = False,
+) -> QLabel:
+    label = QLabel(text)
+    if right:
+        label.setAlignment(_RIGHT)
+    elif center:
+        label.setAlignment(_CENTER)
+    if style is not None:
+        label.setProperty("style", style)
+    if bold:
+        font = label.font()
+        font.setBold(True)
+        label.setFont(font)
+    return label
+
+
+def _hline() -> QFrame:
+    line = QFrame()
+    line.setFrameShape(QFrame.Shape.HLine)
+    line.setFrameShadow(QFrame.Shadow.Sunken)
+    return line
+
+
+class QFinancesMenu(QDialog):
+    """Finances dialog showing gross income, automated HQ spending and net.
+
+    The income the player sees on the map is mostly auto-spent on reinforcements
+    and repairs (when the matching automation is enabled) before they ever touch
+    it. This dialog spells out income, that spending per category, and the net
+    that actually reaches the budget, so the gap is no longer a mystery.
+    """
+
+    def __init__(self, game: Game) -> None:
+        super().__init__()
         self.game = game
         self.setModal(True)
-        self.setWindowTitle("Finances")
+        self.setWindowTitle(f"Finances - Turn {game.turn}")
         self.setWindowIcon(CONST.ICONS["Money"])
-        self.setMinimumSize(450, 200)
+        self.setMinimumSize(520, 420)
 
-        self.setLayout(FinancesLayout(game, player=Player.BLUE))
+        income = Income(game, Player.BLUE)
+        coalition = game.coalition_for(Player.BLUE)
+        expenses = getattr(coalition, "last_turn_expenses", {}) or {}
+        total_spent = sum(expenses.values())
+        gross = income.total
+        net = gross - total_spent
+        balance = coalition.budget
+
+        root = QVBoxLayout(self)
+        root.addWidget(self._summary(gross, total_spent, net, balance))
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        content = QWidget()
+        detail = QVBoxLayout(content)
+        detail.addWidget(self._income_box(income))
+        detail.addWidget(self._expenses_box(expenses, total_spent))
+        detail.addStretch(1)
+        scroll.setWidget(content)
+        root.addWidget(scroll, 1)
+
+        buttons = QHBoxLayout()
+        buttons.addStretch(1)
+        close = QPushButton("Close")
+        close.clicked.connect(self.accept)
+        buttons.addWidget(close)
+        root.addLayout(buttons)
+
+    def _summary(
+        self, gross: float, spent: float, net: float, balance: float
+    ) -> QFrame:
+        frame = QFrame()
+        frame.setProperty("style", "summary-box")
+        grid = QGridLayout(frame)
+        grid.addWidget(_label("Gross income"), 0, 0)
+        grid.addWidget(_label(_money(gross, signed=True), "green", right=True), 0, 1)
+        grid.addWidget(_label("HQ auto-spending"), 1, 0)
+        grid.addWidget(_label(_money(-spent, signed=True), "expense", right=True), 1, 1)
+        grid.addWidget(_hline(), 2, 0, 1, 2)
+        grid.addWidget(_label("NET THIS TURN", bold=True), 3, 0)
+        grid.addWidget(
+            _label(
+                _money(net, signed=True),
+                "net" if net >= 0 else "net-neg",
+                right=True,
+            ),
+            3,
+            1,
+        )
+        grid.addWidget(_label("Available balance"), 4, 0)
+        grid.addWidget(_label(_money(balance), "balance", right=True), 4, 1)
+        return frame
+
+    def _income_box(self, income: Income) -> QGroupBox:
+        box = QGroupBox(f"Income - multiplier x{income.multiplier:.2f}")
+        layout = QVBoxLayout(box)
+        gross_pre = income.total_buildings + income.from_bases
+        layout.addWidget(
+            _label(
+                f"{_money(gross_pre)} -> {_money(income.total)}", "muted", right=True
+            )
+        )
+
+        layout.addWidget(_label("Bases", bold=True))
+        bases = QGridLayout()
+        control_points = reversed(
+            sorted(income.control_points, key=lambda c: c.income_per_turn)
+        )
+        for i, cp in enumerate(control_points):
+            bases.addWidget(_label(f"    {cp.name}"), i, 0)
+            bases.addWidget(_label(_money(cp.income_per_turn), right=True), i, 1)
+        layout.addLayout(bases)
+        layout.addWidget(_hline())
+
+        layout.addWidget(_label("Buildings", bold=True))
+        by_category: dict[str, List[BuildingIncome]] = {}
+        for building in income.buildings:
+            by_category.setdefault(building.category, []).append(building)
+        for category in sorted(
+            by_category, key=lambda c: -sum(b.income for b in by_category[c])
+        ):
+            rows = sorted(by_category[category], key=lambda b: -b.income)
+            subtotal = sum(b.income for b in rows)
+            layout.addWidget(self._category_group(category, subtotal, rows))
+        return box
+
+    def _category_group(
+        self, category: str, subtotal: float, rows: List[BuildingIncome]
+    ) -> QGroupBox:
+        box = QGroupBox(f"{category.upper()} - {_money(subtotal)}")
+        box.setCheckable(True)
+        box.setChecked(False)  # collapsed by default; only subtotals show
+
+        inner = QWidget()
+        grid = QGridLayout(inner)
+        grid.setContentsMargins(0, 0, 0, 0)
+        for i, building in enumerate(rows):
+            dead = round(building.income) == 0
+            style = "muted" if dead else None
+            grid.addWidget(_label(f"    {building.name}", style), i, 0)
+            grid.addWidget(
+                _label(
+                    f"{building.number} x {building.income_per_building}M =",
+                    "muted",
+                    right=True,
+                ),
+                i,
+                1,
+            )
+            grid.addWidget(_label(_money(building.income), style, right=True), i, 2)
+
+        outer = QVBoxLayout(box)
+        outer.setContentsMargins(6, 0, 6, 6)
+        outer.addWidget(inner)
+        inner.setVisible(False)
+        box.toggled.connect(inner.setVisible)
+        return box
+
+    def _expenses_box(
+        self, expenses: dict[str, float], total_spent: float
+    ) -> QGroupBox:
+        box = QGroupBox("HQ auto-spending - last turn")
+        grid = QGridLayout(box)
+        settings = self.game.settings
+        row = 0
+        for key, label, flag in _EXPENSE_CATEGORIES:
+            enabled = bool(getattr(settings, flag, False))
+            amount = expenses.get(key, 0.0)
+            grid.addWidget(_label(label), row, 0)
+            grid.addWidget(
+                _label(
+                    " ON " if enabled else " OFF",
+                    "pill-on" if enabled else "pill-off",
+                    center=True,
+                ),
+                row,
+                1,
+            )
+            zero = (not enabled) or round(amount) == 0
+            grid.addWidget(
+                _label(
+                    _money(0) if zero else _money(-amount, signed=True),
+                    "muted" if zero else "expense",
+                    right=True,
+                ),
+                row,
+                2,
+            )
+            row += 1
+
+        grid.addWidget(_hline(), row, 0, 1, 3)
+        grid.addWidget(_label("Total spent by HQ", bold=True), row + 1, 0)
+        grid.addWidget(
+            _label(_money(-total_spent, signed=True), "expense", right=True),
+            row + 1,
+            2,
+        )
+        return box

--- a/qt_ui/windows/finances/QFinancesMenu.py
+++ b/qt_ui/windows/finances/QFinancesMenu.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
@@ -121,6 +121,8 @@ _EXPENSE_CATEGORIES = [
 
 _RIGHT = Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
 _CENTER = Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+_COLLAPSED = "▶"  # ▶
+_EXPANDED = "▼"  # ▼
 
 
 def _money(value: float, signed: bool = False) -> str:
@@ -153,6 +155,14 @@ def _label(
     return label
 
 
+def _restyle(widget: QWidget, style: str) -> None:
+    """Swap a widget's `style` property and force a QSS re-evaluation."""
+    widget.setProperty("style", style)
+    qstyle = widget.style()
+    qstyle.unpolish(widget)
+    qstyle.polish(widget)
+
+
 def _hline() -> QFrame:
     line = QFrame()
     line.setFrameShape(QFrame.Shape.HLine)
@@ -175,18 +185,21 @@ class QFinancesMenu(QDialog):
         self.setModal(True)
         self.setWindowTitle(f"Finances - Turn {game.turn}")
         self.setWindowIcon(CONST.ICONS["Money"])
-        self.setMinimumSize(520, 420)
+        self.setMinimumSize(540, 440)
 
         income = Income(game, Player.BLUE)
         coalition = game.coalition_for(Player.BLUE)
         expenses = getattr(coalition, "last_turn_expenses", {}) or {}
+        # No spend has been recorded yet on saves created before this feature,
+        # or before the first turn is ended. Don't fake a net in that case.
+        recorded = bool(expenses)
         total_spent = sum(expenses.values())
         gross = income.total
         net = gross - total_spent
         balance = coalition.budget
 
         root = QVBoxLayout(self)
-        root.addWidget(self._summary(gross, total_spent, net, balance))
+        root.addWidget(self._summary(gross, total_spent, net, balance, recorded))
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
@@ -194,7 +207,7 @@ class QFinancesMenu(QDialog):
         content = QWidget()
         detail = QVBoxLayout(content)
         detail.addWidget(self._income_box(income))
-        detail.addWidget(self._expenses_box(expenses, total_spent))
+        detail.addWidget(self._expenses_box(expenses, total_spent, recorded))
         detail.addStretch(1)
         scroll.setWidget(content)
         root.addWidget(scroll, 1)
@@ -207,28 +220,41 @@ class QFinancesMenu(QDialog):
         root.addLayout(buttons)
 
     def _summary(
-        self, gross: float, spent: float, net: float, balance: float
+        self,
+        gross: float,
+        spent: float,
+        net: float,
+        balance: float,
+        recorded: bool,
     ) -> QFrame:
         frame = QFrame()
         frame.setProperty("style", "summary-box")
         grid = QGridLayout(frame)
-        grid.addWidget(_label("Gross income"), 0, 0)
+        grid.addWidget(_label("Gross income (next turn)"), 0, 0)
         grid.addWidget(_label(_money(gross, signed=True), "green", right=True), 0, 1)
-        grid.addWidget(_label("HQ auto-spending"), 1, 0)
-        grid.addWidget(_label(_money(-spent, signed=True), "expense", right=True), 1, 1)
+        grid.addWidget(_label("HQ auto-spending (last turn)"), 1, 0)
+        if recorded:
+            grid.addWidget(
+                _label(_money(-spent, signed=True), "expense", right=True), 1, 1
+            )
+        else:
+            grid.addWidget(_label("n/a", "muted", right=True), 1, 1)
         grid.addWidget(_hline(), 2, 0, 1, 2)
-        grid.addWidget(_label("NET THIS TURN", bold=True), 3, 0)
-        grid.addWidget(
-            _label(
-                _money(net, signed=True),
-                "net" if net >= 0 else "net-neg",
-                right=True,
-            ),
-            3,
-            1,
-        )
+        grid.addWidget(_label("NET (est.)", bold=True), 3, 0)
+        if recorded:
+            grid.addWidget(
+                _label(
+                    _money(net, signed=True),
+                    "net" if net >= 0 else "net-neg",
+                    right=True,
+                ),
+                3,
+                1,
+            )
+        else:
+            grid.addWidget(_label("n/a", "muted", right=True), 3, 1)
         grid.addWidget(_label("Available balance"), 4, 0)
-        grid.addWidget(_label(_money(balance), "balance", right=True), 4, 1)
+        grid.addWidget(_label(f"{balance:.1f}M", "balance", right=True), 4, 1)
         return frame
 
     def _income_box(self, income: Income) -> QGroupBox:
@@ -266,18 +292,28 @@ class QFinancesMenu(QDialog):
 
     def _category_group(
         self, category: str, subtotal: float, rows: List[BuildingIncome]
-    ) -> QGroupBox:
-        box = QGroupBox(f"{category.upper()} - {_money(subtotal)}")
-        box.setCheckable(True)
-        box.setChecked(False)  # collapsed by default; only subtotals show
+    ) -> QWidget:
+        """A disclosure section: an arrow header that expands its building rows."""
+        title = f"{category.upper()} - {_money(subtotal)}"
+
+        container = QWidget()
+        outer = QVBoxLayout(container)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        header = QPushButton(f"{_COLLAPSED}  {title}")
+        header.setProperty("style", "disclosure")
+        header.setCheckable(True)
+        header.setChecked(False)
+        outer.addWidget(header)
 
         inner = QWidget()
         grid = QGridLayout(inner)
-        grid.setContentsMargins(0, 0, 0, 0)
+        grid.setContentsMargins(18, 0, 6, 4)
         for i, building in enumerate(rows):
             dead = round(building.income) == 0
             style = "muted" if dead else None
-            grid.addWidget(_label(f"    {building.name}", style), i, 0)
+            grid.addWidget(_label(building.name, style), i, 0)
             grid.addWidget(
                 _label(
                     f"{building.number} x {building.income_per_building}M =",
@@ -288,51 +324,73 @@ class QFinancesMenu(QDialog):
                 1,
             )
             grid.addWidget(_label(_money(building.income), style, right=True), i, 2)
-
-        outer = QVBoxLayout(box)
-        outer.setContentsMargins(6, 0, 6, 6)
-        outer.addWidget(inner)
         inner.setVisible(False)
-        box.toggled.connect(inner.setVisible)
-        return box
+        outer.addWidget(inner)
+
+        def toggle(checked: bool) -> None:
+            inner.setVisible(checked)
+            arrow = _EXPANDED if checked else _COLLAPSED
+            header.setText(f"{arrow}  {title}")
+
+        header.toggled.connect(toggle)
+        return container
 
     def _expenses_box(
-        self, expenses: dict[str, float], total_spent: float
+        self, expenses: dict[str, float], total_spent: float, recorded: bool
     ) -> QGroupBox:
         box = QGroupBox("HQ auto-spending - last turn")
         grid = QGridLayout(box)
         settings = self.game.settings
         row = 0
+
+        if not recorded:
+            note = _label(
+                "No spending recorded yet - end a turn to populate these.", "muted"
+            )
+            grid.addWidget(note, row, 0, 1, 3)
+            row += 1
+
         for key, label, flag in _EXPENSE_CATEGORIES:
             enabled = bool(getattr(settings, flag, False))
-            amount = expenses.get(key, 0.0)
             grid.addWidget(_label(label), row, 0)
-            grid.addWidget(
-                _label(
-                    " ON " if enabled else " OFF",
-                    "pill-on" if enabled else "pill-off",
-                    center=True,
-                ),
-                row,
-                1,
-            )
-            zero = (not enabled) or round(amount) == 0
-            grid.addWidget(
-                _label(
-                    _money(0) if zero else _money(-amount, signed=True),
-                    "muted" if zero else "expense",
-                    right=True,
-                ),
-                row,
-                2,
-            )
+
+            toggle = QPushButton(" ON " if enabled else " OFF")
+            toggle.setCheckable(True)
+            toggle.setChecked(enabled)
+            toggle.setProperty("style", "pill-on" if enabled else "pill-off")
+            toggle.setToolTip("Click to toggle. Takes effect from the next turn.")
+            toggle.toggled.connect(self._make_automation_toggle(flag, toggle))
+            grid.addWidget(toggle, row, 1)
+
+            if not enabled:
+                amount_text, amount_style = _money(0), "muted"
+            elif not recorded or key not in expenses:
+                amount_text, amount_style = "-", "muted"  # on, but not recorded yet
+            else:
+                amount = expenses[key]
+                if round(amount) == 0:
+                    amount_text, amount_style = _money(0), "muted"
+                else:
+                    amount_text, amount_style = _money(-amount, signed=True), "expense"
+            grid.addWidget(_label(amount_text, amount_style, right=True), row, 2)
             row += 1
 
         grid.addWidget(_hline(), row, 0, 1, 3)
         grid.addWidget(_label("Total spent by HQ", bold=True), row + 1, 0)
+        total_text = _money(-total_spent, signed=True) if recorded else "n/a"
         grid.addWidget(
-            _label(_money(-total_spent, signed=True), "expense", right=True),
+            _label(total_text, "expense" if recorded else "muted", right=True),
             row + 1,
             2,
         )
         return box
+
+    def _make_automation_toggle(
+        self, flag: str, button: QPushButton
+    ) -> Callable[[bool], None]:
+        def handler(checked: bool) -> None:
+            setattr(self.game.settings, flag, checked)
+            button.setText(" ON " if checked else " OFF")
+            _restyle(button, "pill-on" if checked else "pill-off")
+
+        return handler

--- a/qt_ui/windows/finances/QFinancesMenu.py
+++ b/qt_ui/windows/finances/QFinancesMenu.py
@@ -111,12 +111,8 @@ class FinancesLayout(QGridLayout):
         self.addWidget(QHorizontalSeparationLine(), next(self.row), 0, 1, 3)
 
 
-#: Automated-spending categories the dialog *can* show, in display order. Each is
-#: (last_turn_expenses key, label, the settings flag that toggles it for blue).
-#: A category is only shown if its settings flag exists in the running build, so
-#: the dialog adapts automatically: builds without the building/ground-object
-#: repair automation simply omit those rows, and they appear on their own once
-#: that automation is present - no change to this dialog needed.
+#: Auto-spend categories: (last_turn_expenses key, label, settings flag). A row is
+#: shown only if its flag exists in the running build.
 _EXPENSE_CATEGORIES = [
     ("front_line", "Front line reinforcement", "automate_front_line_reinforcements"),
     ("aircraft", "Aircraft purchases", "automate_aircraft_reinforcements"),
@@ -357,12 +353,7 @@ class QFinancesMenu(QDialog):
             row += 1
 
         for key, label, flag in _EXPENSE_CATEGORIES:
-            # Only show categories whose automation exists in this build. We probe
-            # the Settings *class* (not the instance): a loaded save can carry
-            # settings attributes pickled by a fork build that declared them, but
-            # the running code is what decides whether the feature actually exists.
-            # This is what lets the dialog adapt to optional repair features
-            # without code changes here when they land.
+            # Only show categories whose automation exists in this build.
             if not hasattr(type(settings), flag):
                 continue
             enabled = bool(getattr(settings, flag, False))

--- a/resources/stylesheets/style-dcs.css
+++ b/resources/stylesheets/style-dcs.css
@@ -225,6 +225,33 @@ QPushButton:disabled{
     background:#d6d6d6;
 }
 
+/* ── Finances dialog: income / expense / net hierarchy ─────────── */
+QLabel[style="green"]   { color: #8FBF6A; font-weight: 700; }   /* income  */
+QLabel[style="expense"] { color: #E06C5E; font-weight: 700; }   /* spending */
+QLabel[style="muted"]   { color: #7E8C99; }                     /* 0 / OFF / sub-text */
+QLabel[style="balance"] { color: #3592C4; font-weight: 700; }   /* current balance */
+
+QLabel[style="net"]     { font-size: 18px; font-weight: 800; color: #8FBF6A; }
+QLabel[style="net-neg"] { font-size: 18px; font-weight: 800; color: #E06C5E; }
+
+/* Summary band: a darker recessed box to set it apart from the detail. */
+QFrame[style="summary-box"] {
+    background-color: #1D2731;
+    border: 1px solid #435466;
+    border-radius: 3px;
+}
+QFrame[style="summary-box"] QLabel { background: transparent; }
+
+/* ON / OFF pills for the auto-spending categories. */
+QLabel[style="pill-on"] {
+    border: 1px solid #5C863F; color: #8FBF6A;
+    padding: 1px 8px; font-weight: 700;
+}
+QLabel[style="pill-off"] {
+    border: 1px solid #435466; color: #7E8C99;
+    padding: 1px 8px; font-weight: 700;
+}
+
 /*QLabel*/
 QLabel{
     border: none;

--- a/resources/stylesheets/style-dcs.css
+++ b/resources/stylesheets/style-dcs.css
@@ -242,15 +242,24 @@ QFrame[style="summary-box"] {
 }
 QFrame[style="summary-box"] QLabel { background: transparent; }
 
-/* ON / OFF pills for the auto-spending categories. */
-QLabel[style="pill-on"] {
-    border: 1px solid #5C863F; color: #8FBF6A;
-    padding: 1px 8px; font-weight: 700;
+/* Clickable ON / OFF pills that toggle each auto-spending setting. */
+QPushButton[style="pill-on"] {
+    border: 1px solid #5C863F; color: #8FBF6A; background: transparent;
+    padding: 2px 10px; font-weight: 700;
 }
-QLabel[style="pill-off"] {
-    border: 1px solid #435466; color: #7E8C99;
-    padding: 1px 8px; font-weight: 700;
+QPushButton[style="pill-on"]:hover { background: #243024; }
+QPushButton[style="pill-off"] {
+    border: 1px solid #435466; color: #7E8C99; background: transparent;
+    padding: 2px 10px; font-weight: 700;
 }
+QPushButton[style="pill-off"]:hover { background: #28323C; }
+
+/* Collapsible building-category header (arrow + title, no button chrome). */
+QPushButton[style="disclosure"] {
+    border: none; background: transparent; color: #B7C0C6;
+    font-weight: 700; text-align: left; padding: 3px 2px;
+}
+QPushButton[style="disclosure"]:hover { color: #ffffff; }
 
 /*QLabel*/
 QLabel{


### PR DESCRIPTION
Reworks the **Finances** dialog so the gap between income and the balance that actually lands is explicit: gross income, the HQ's automated per-category spending, and the resulting net per turn. Income breaks down per base and per (collapsible) building category, and the automation toggles can be flipped from the dialog.

![Finances dialog](https://raw.githubusercontent.com/juanjux/dcs-retribution/assets-screenshots/screenshots/finances-dialog.png)

The auto-spend rows adapt to the build: front line, aircraft and runway repairs out of the box; building / ground-object repair rows appear on their own if that automation is present. `ProcurementAi.spend_budget` records per-category spend, `Coalition` exposes it as `last_turn_expenses`. The compact `FinancesLayout` used by the intel panel is unchanged.