### PR TITLE
Fix aircraft sale exploit that corrupted squadron counts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 * **[Map]** Hovering a SAM threat or detection ring highlights its emitter — and hovering an emitter highlights its ring — making it easy to tell which site a ring belongs to. Can be disabled from the map's layer control.
 
 ## Fixes
+* **[AirWing]** Selling aircraft no longer lets the same units be re-sold (and re-flown) after a turn re-initialisation, which refunded their price repeatedly and could drive a squadron's aircraft count negative and then balloon it to ~airfield capacity on reload.
 * **[Mission]** Reliably auto-detect end of mission, even when DCS wrote the final state.json before the wait dialog started watching
 * **[Performance]** Faster post-mission turn processing
 * **[AirWing]** Track per-squadron campaign aircraft stats (initial/destroyed/purchased, save-compatible) and expose pilot experience level and living/dead pilot views for the UI

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -154,7 +154,7 @@ class Migrator:
                     if f.squadron == s:
                         count += f.count
                 s.return_all_pilots_and_aircraft()
-                new_claim = min(count, s.owned_aircraft)
+                new_claim = min(count, s.untasked_aircraft)
                 s.claim_inventory(new_claim)
                 for i in range(new_claim):
                     s.claim_available_pilot()
@@ -186,8 +186,17 @@ class Migrator:
                     s.owned_aircraft < 0
                     or s.location.unclaimed_parking(parking_type) < 0
                 ):
+                    # unclaimed_parking + owned is the capacity available to this
+                    # squadron alone; clamp an overfull squadron down to it. The
+                    # min() guards the negative-owned case: a negative count must
+                    # collapse to 0, not balloon up to the whole airfield.
                     s.owned_aircraft = max(
-                        0, s.location.unclaimed_parking(parking_type) + s.owned_aircraft
+                        0,
+                        min(
+                            s.owned_aircraft,
+                            s.location.unclaimed_parking(parking_type)
+                            + s.owned_aircraft,
+                        ),
                     )
 
                 if self.is_liberation:

--- a/game/squadrons/squadron.py
+++ b/game/squadrons/squadron.py
@@ -260,7 +260,10 @@ class Squadron:
 
     def return_all_pilots_and_aircraft(self) -> None:
         self.available_pilots = list(self.active_pilots)
-        self.untasked_aircraft = self.owned_aircraft
+        # Aircraft already sold this turn (negative pending) must not return to the
+        # taskable pool; otherwise a turn re-initialisation would let the same units
+        # be sold (and flown) again, refunding their price every time.
+        self.untasked_aircraft = self.owned_aircraft + min(0, self.pending_deliveries)
 
     @staticmethod
     def send_on_leave(pilot: Pilot) -> None:

--- a/tests/test_squadron_inventory.py
+++ b/tests/test_squadron_inventory.py
@@ -1,0 +1,42 @@
+"""Regression tests for squadron aircraft inventory accounting.
+
+The bug these pin: ``return_all_pilots_and_aircraft`` (run on every turn
+re-initialisation via ``AirWing.reset``) used to reset ``untasked_aircraft`` to
+``owned_aircraft``, ignoring ``pending_deliveries``. After selling aircraft
+(which decrements both ``untasked_aircraft`` and ``pending_deliveries``), a
+re-initialisation therefore made the just-sold aircraft taskable -- and
+sellable -- again, letting the player refund their price repeatedly and driving
+``owned_aircraft`` negative once ``deliver_orders`` applied the accumulated
+negative ``pending_deliveries`` at end of turn.
+"""
+
+from game.squadrons.squadron import Squadron
+
+
+def _bare_squadron(owned: int, untasked: int, pending: int) -> Squadron:
+    sq = Squadron.__new__(Squadron)
+    sq.current_roster = []  # active_pilots reads this; empty is fine here
+    sq.owned_aircraft = owned
+    sq.untasked_aircraft = untasked
+    sq.pending_deliveries = pending
+    return sq
+
+
+def test_reset_keeps_sold_aircraft_out_of_the_pool() -> None:
+    # Sold 3 of 5 this turn: untasked already down to 2, pending == -3.
+    sq = _bare_squadron(owned=5, untasked=2, pending=-3)
+    sq.return_all_pilots_and_aircraft()
+    assert sq.untasked_aircraft == 2
+
+
+def test_reset_restores_full_pool_when_nothing_sold() -> None:
+    sq = _bare_squadron(owned=5, untasked=0, pending=0)
+    sq.return_all_pilots_and_aircraft()
+    assert sq.untasked_aircraft == 5
+
+
+def test_pending_purchases_do_not_inflate_the_pool() -> None:
+    # Bought 4 (pending == +4), not yet delivered: only the owned 5 fly now.
+    sq = _bare_squadron(owned=5, untasked=0, pending=4)
+    sq.return_all_pilots_and_aircraft()
+    assert sq.untasked_aircraft == 5


### PR DESCRIPTION
### The bug

Selling aircraft was exploitable. Anything that makes the game re-plan the turn — selling, buying or repairing a unit on the map, or a cheat capture — handed the just-sold aircraft back as if they had never been sold. So you could:

- **Sell the same aircraft over and over**, getting refunded their full price each time → effectively unlimited money.
- **Still fly the "sold" aircraft** on missions that same turn.

Selling more aircraft than a squadron actually owns also left it with a *negative* aircraft count at the end of the turn. On the next load the save-repair step turned that negative count into a number close to the airfield's entire parking capacity — e.g. a 6-aircraft B-52 squadron reappearing with ~994 aircraft.

### The fix

- Sold aircraft stay sold when the turn re-plans: they can no longer be re-sold or flown, and selling refunds their price exactly once.
- The save-repair step no longer inflates a corrupted (negative) count into a near-full airfield — it resets it to zero, while still trimming a genuinely overcrowded base down to what its parking can hold.
- Campaigns already corrupted by this bug still load.

Includes a regression test; full test suite passes.