### PR TITLE
Let non-DEAD-role aircraft fly DEAD manually (secondary tasks)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[Loadouts]** Aircraft where DEAD isn't a natural role (A-10, F-35, Su-57, Su-35S, strategic bombers, etc.) can now fly DEAD when assigned manually, with a proper standoff loadout, without DEAD being auto-assigned to them by default. Aircraft yamls gain an optional `secondary_tasks` list for this.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.
 * **[UX]** Avoid having escorts from wondering off too far while chasing a target.

--- a/game/campaignloader/squadrondefgenerator.py
+++ b/game/campaignloader/squadrondefgenerator.py
@@ -50,7 +50,8 @@ class SquadronDefGenerator:
             aircraft=aircraft,
             livery=None,
             livery_set=[],
-            auto_assignable_mission_types=set(aircraft.iter_task_capabilities()),
+            auto_assignable_mission_types=set(aircraft.iter_task_capabilities())
+            - aircraft.secondary_tasks,
             radio_presets={},
             operating_bases=OperatingBases.default_for_aircraft(aircraft),
             female_pilot_percentage=6,

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -248,6 +248,11 @@ class AircraftType(UnitType[Type[FlyingType]]):
 
     use_f15e_waypoint_names: bool
 
+    #: Tasks the aircraft is capable of but that are not auto-assignable by default
+    #: (the squadron's mission-type checkbox starts unchecked). Still selectable
+    #: manually. Each must also appear in ``tasks`` to supply its priority.
+    secondary_tasks: frozenset[FlightType] = frozenset()
+
     _by_name: ClassVar[dict[str, AircraftType]] = {}
     _by_unit_type: ClassVar[dict[type[FlyingType], list[AircraftType]]] = defaultdict(
         list
@@ -569,6 +574,9 @@ class AircraftType(UnitType[Type[FlyingType]]):
             cls._set_props_overrides(prop_overrides, aircraft)
 
         task_priorities = cls.get_task_priorities(data)
+        secondary_tasks = frozenset(
+            FlightType(t) for t in data.get("secondary_tasks", [])
+        )
 
         cls._custom_weapon_injections(aircraft, data)
         cls._user_weapon_injections(aircraft)
@@ -608,6 +616,7 @@ class AircraftType(UnitType[Type[FlyingType]]):
             cabin_size=data.get("cabin_size", 10 if aircraft.helicopter else 0),
             can_carry_crates=data.get("can_carry_crates", aircraft.helicopter),
             task_priorities=task_priorities,
+            secondary_tasks=secondary_tasks,
             has_built_in_target_pod=data.get("has_built_in_target_pod", False),
             has_built_in_ecm=data.get("has_built_in_ecm", False),
             has_built_in_jamming=data.get("has_built_in_jamming", False),

--- a/game/squadrons/squadrondef.py
+++ b/game/squadrons/squadrondef.py
@@ -105,7 +105,8 @@ class SquadronDef:
             aircraft=unit_type,
             livery=data.get("livery"),
             livery_set=data.get("livery_set", []),
-            auto_assignable_mission_types=set(unit_type.iter_task_capabilities()),
+            auto_assignable_mission_types=set(unit_type.iter_task_capabilities())
+            - unit_type.secondary_tasks,
             radio_presets=radio_presets,
             operating_bases=OperatingBases.from_yaml(unit_type, data.get("bases", {})),
             female_pilot_percentage=female_pilot_percentage,

--- a/resources/customized_payloads/A-10A.lua
+++ b/resources/customized_payloads/A-10A.lua
@@ -136,6 +136,31 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
+		[6] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "LAU-105_2*AIM-9P5",
+					["num"] = 11,
+				},
+				[2] = {
+					["CLSID"] = "ALQ_184",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "LAU_117_AGM_65G",
+					["num"] = 9,
+				},
+				[4] = {
+					["CLSID"] = "LAU_117_AGM_65G",
+					["num"] = 3,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["unitType"] = "A-10A",
 }

--- a/resources/customized_payloads/A-10C.lua
+++ b/resources/customized_payloads/A-10C.lua
@@ -189,6 +189,35 @@ local unitPayloads = {
 				[1] = 31,
 			},
 		},
+		[7] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "ALQ_184",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{DB434044-F5D0-4F1F-9BA9-B73027E18DD3}",
+					["num"] = 11,
+				},
+				[3] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 10,
+				},
+				[4] = {
+					["CLSID"] = "{GBU-31}",
+					["num"] = 8,
+				},
+				[5] = {
+					["CLSID"] = "{GBU-31}",
+					["num"] = 4,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["unitType"] = "A-10C",
 }

--- a/resources/customized_payloads/A-10C_2.lua
+++ b/resources/customized_payloads/A-10C_2.lua
@@ -277,6 +277,35 @@ local unitPayloads = {
 				[1] = 31,
 			},
 		},
+		[9] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "ALQ_184",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{GBU-31}",
+					["num"] = 4,
+				},
+				[3] = {
+					["CLSID"] = "{GBU-31}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{A111396E-D3E8-4b9c-8AC9-2432489304D5}",
+					["num"] = 10,
+				},
+				[5] = {
+					["CLSID"] = "{DB434044-F5D0-4F1F-9BA9-B73027E18DD3}",
+					["num"] = 11,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["unitType"] = "A-10C_2",
 }

--- a/resources/customized_payloads/CH_Tu-160M2.lua
+++ b/resources/customized_payloads/CH_Tu-160M2.lua
@@ -52,6 +52,23 @@ local unitPayloads = {
 				[1] = 31,
 			},
 		},
+		[4] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{Tu160M2_Kh101x6}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{Tu160M2_Kh101x6}",
+					["num"] = 2,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["tasks"] = {
 	},

--- a/resources/customized_payloads/F-117A.lua
+++ b/resources/customized_payloads/F-117A.lua
@@ -73,6 +73,23 @@ local unitPayloads = {
 				[1] = 33,
 			},
 		},
+		[6] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{51F9AAE5-964F-4D21-83FB-502E3BFE5F8A}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{51F9AAE5-964F-4D21-83FB-502E3BFE5F8A}",
+					["num"] = 2,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["unitType"] = "F-117A",
 }

--- a/resources/customized_payloads/F-16A.lua
+++ b/resources/customized_payloads/F-16A.lua
@@ -265,6 +265,51 @@ local unitPayloads = {
 				[1] = 11,
 			},
 		},
+		[7] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{6D21ECEA-F85B-4E8D-9D51-31DC9B8AA4EF}",
+					["num"] = 6,
+				},
+				[2] = {
+					["CLSID"] = "{444BA8AE-82A7-4345-842E-76154EFCCA46}",
+					["num"] = 3,
+				},
+				[3] = {
+					["CLSID"] = "{444BA8AE-82A7-4345-842E-76154EFCCA46}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{F376DBEE-4CAE-41BA-ADD9-B2910AC95DEC}",
+					["num"] = 4,
+				},
+				[5] = {
+					["CLSID"] = "{F376DBEE-4CAE-41BA-ADD9-B2910AC95DEC}",
+					["num"] = 7,
+				},
+				[6] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 2,
+				},
+				[7] = {
+					["CLSID"] = "{6CEB49FC-DED8-4DED-B053-E1F033FF72D3}",
+					["num"] = 9,
+				},
+				[8] = {
+					["CLSID"] = "{C8E06185-7CD6-4C90-959F-044679E90751}",
+					["num"] = 1,
+				},
+				[9] = {
+					["CLSID"] = "{C8E06185-7CD6-4C90-959F-044679E90751}",
+					["num"] = 10,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["unitType"] = "F-16A",
 }

--- a/resources/customized_payloads/MQ-9 Reaper.lua
+++ b/resources/customized_payloads/MQ-9 Reaper.lua
@@ -25,6 +25,31 @@ local unitPayloads = {
 				[1] = 17,
 			},
 		},
+		[2] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{GBU-38}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{GBU-38}",
+					["num"] = 2,
+				},
+				[3] = {
+					["CLSID"] = "{GBU-38}",
+					["num"] = 3,
+				},
+				[4] = {
+					["CLSID"] = "{GBU-38}",
+					["num"] = 4,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["tasks"] = {
 	},

--- a/resources/customized_payloads/Mirage-F1EQ.lua
+++ b/resources/customized_payloads/Mirage-F1EQ.lua
@@ -184,24 +184,16 @@ local unitPayloads = {
 					["num"] = 1,
 				},
 				[3] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
+					["CLSID"] = "{X-29T}",
 					["num"] = 5,
 				},
 				[4] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
+					["CLSID"] = "{X-29T}",
 					["num"] = 3,
 				},
 				[5] = {
 					["CLSID"] = "PTB-1200-F1",
 					["num"] = 4,
-				},
-				[6] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
-					["num"] = 2,
 				},
 			},
 			["tasks"] = {

--- a/resources/customized_payloads/Su-25.lua
+++ b/resources/customized_payloads/Su-25.lua
@@ -257,6 +257,47 @@ local unitPayloads = {
 				[1] = 34,
 			},
 		},
+		[7] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{682A481F-0CB5-4693-A382-D00DD4A156D7}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{79D73885-0801-45a9-917F-C90FE1CE3DFC}",
+					["num"] = 3,
+				},
+				[3] = {
+					["CLSID"] = "{79D73885-0801-45a9-917F-C90FE1CE3DFC}",
+					["num"] = 4,
+				},
+				[4] = {
+					["CLSID"] = "{D4A8D9B9-5C45-42e7-BBD2-0E54F8308432}",
+					["num"] = 5,
+				},
+				[5] = {
+					["CLSID"] = "{D4A8D9B9-5C45-42e7-BBD2-0E54F8308432}",
+					["num"] = 6,
+				},
+				[6] = {
+					["CLSID"] = "{79D73885-0801-45a9-917F-C90FE1CE3DFC}",
+					["num"] = 7,
+				},
+				[7] = {
+					["CLSID"] = "{79D73885-0801-45a9-917F-C90FE1CE3DFC}",
+					["num"] = 8,
+				},
+				[8] = {
+					["CLSID"] = "{682A481F-0CB5-4693-A382-D00DD4A156D7}",
+					["num"] = 10,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["unitType"] = "Su-25",
 }

--- a/resources/customized_payloads/Su-35S.lua
+++ b/resources/customized_payloads/Su-35S.lua
@@ -174,6 +174,47 @@ local unitPayloads = {
 				[1] = 29,
 			},
 		},
+		[4] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{Su30-R-74M2-AA}",
+					["num"] = 2,
+				},
+				[2] = {
+					["CLSID"] = "{Su30-R-74M2-AA}",
+					["num"] = 11,
+				},
+				[3] = {
+					["CLSID"] = "{DUAL_77M}",
+					["num"] = 6,
+				},
+				[4] = {
+					["CLSID"] = "{DUAL_77M}",
+					["num"] = 7,
+				},
+				[5] = {
+					["CLSID"] = "{SU30_KH59MK2}",
+					["num"] = 3,
+				},
+				[6] = {
+					["CLSID"] = "{SU30_KH59MK2}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{SU30_KH59MK2}",
+					["num"] = 9,
+				},
+				[8] = {
+					["CLSID"] = "{SU30_KH59MK2}",
+					["num"] = 10,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["tasks"] = {
 	},

--- a/resources/customized_payloads/Su-57.lua
+++ b/resources/customized_payloads/Su-57.lua
@@ -331,6 +331,63 @@ local unitPayloads = {
 				[2] = 34,
 			},
 		},
+		[7] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{FBC29BFE-3D24-4C64-B81D-941239D12249}",
+					["num"] = 12,
+				},
+				[2] = {
+					["CLSID"] = "{FBC29BFE-3D24-4C64-B81D-941239D12249}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{B4FC81C9-B861-4E87-BBDC-A1158E648EBF}",
+					["num"] = 2,
+				},
+				[4] = {
+					["CLSID"] = "{FBC29BFE-3D24-4C64-B81D-941239D12249}",
+					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "{B4FC81C9-B861-4E87-BBDC-A1158E648EBF}",
+					["num"] = 11,
+				},
+				[6] = {
+					["CLSID"] = "{RVV-AE}",
+					["num"] = 4,
+				},
+				[7] = {
+					["CLSID"] = "{RVV-AE}",
+					["num"] = 5,
+				},
+				[8] = {
+					["CLSID"] = "{RVV-AE}",
+					["num"] = 6,
+				},
+				[9] = {
+					["CLSID"] = "{RVV-AE}",
+					["num"] = 7,
+				},
+				[10] = {
+					["CLSID"] = "{RVV-AE}",
+					["num"] = 8,
+				},
+				[11] = {
+					["CLSID"] = "{RVV-AE}",
+					["num"] = 9,
+				},
+				[12] = {
+					["CLSID"] = "{FBC29BFE-3D24-4C64-B81D-941239D12249}",
+					["num"] = 10,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["tasks"] = {
 	},

--- a/resources/customized_payloads/Tu-160.lua
+++ b/resources/customized_payloads/Tu-160.lua
@@ -76,6 +76,23 @@ local unitPayloads = {
 			["tasks"] = {
 			},
 		},
+		[6] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{0290F5DE-014A-4BB1-9843-D717749B1DED}",
+					["num"] = 1,
+				},
+				[2] = {
+					["CLSID"] = "{0290F5DE-014A-4BB1-9843-D717749B1DED}",
+					["num"] = 2,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["unitType"] = "Tu-160",
 }

--- a/resources/customized_payloads/VSN_F35A_AG.lua
+++ b/resources/customized_payloads/VSN_F35A_AG.lua
@@ -633,6 +633,55 @@ local unitPayloads = {
 				[1] = 31,
 			},
 		},
+		[9] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{0519A264-0AB6-11d6-9193-00A0249B6F00}",
+					["num"] = 13,
+				},
+				[2] = {
+					["CLSID"] = "{44EE8698-89F9-48EE-AF36-5FD31896A82F}",
+					["num"] = 12,
+				},
+				[3] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 11,
+				},
+				[4] = {
+					["CLSID"] = "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}",
+					["num"] = 9,
+				},
+				[5] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 8,
+				},
+				[6] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 7,
+				},
+				[7] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 5,
+				},
+				[8] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 4,
+				},
+				[9] = {
+					["CLSID"] = "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}",
+					["num"] = 3,
+				},
+				[10] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["tasks"] = {
 	},

--- a/resources/customized_payloads/VSN_F35B_AG.lua
+++ b/resources/customized_payloads/VSN_F35B_AG.lua
@@ -633,6 +633,63 @@ local unitPayloads = {
 				[1] = 31,
 			},
 		},
+		[9] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{0519A264-0AB6-11d6-9193-00A0249B6F00}",
+					["num"] = 13,
+				},
+				[2] = {
+					["CLSID"] = "{44EE8698-89F9-48EE-AF36-5FD31896A82F}",
+					["num"] = 12,
+				},
+				[3] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 11,
+				},
+				[4] = {
+					["CLSID"] = "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}",
+					["num"] = 10,
+				},
+				[5] = {
+					["CLSID"] = "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}",
+					["num"] = 9,
+				},
+				[6] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 8,
+				},
+				[7] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 5,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 4,
+				},
+				[10] = {
+					["CLSID"] = "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}",
+					["num"] = 3,
+				},
+				[11] = {
+					["CLSID"] = "{AF42E6DF-9A60-46D8-A9A0-1708B241AADB}",
+					["num"] = 2,
+				},
+				[12] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["tasks"] = {
 	},

--- a/resources/customized_payloads/VSN_F35C_AG.lua
+++ b/resources/customized_payloads/VSN_F35C_AG.lua
@@ -568,6 +568,63 @@ local unitPayloads = {
 				[1] = 31,
 			},
 		},
+		[8] = {
+			["displayName"] = "Retribution DEAD",
+			["name"] = "Retribution DEAD",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{0519A264-0AB6-11d6-9193-00A0249B6F00}",
+					["num"] = 13,
+				},
+				[2] = {
+					["CLSID"] = "{44EE8698-89F9-48EE-AF36-5FD31896A82F}",
+					["num"] = 12,
+				},
+				[3] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 11,
+				},
+				[4] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 10,
+				},
+				[5] = {
+					["CLSID"] = "LAU_117_AGM_65G",
+					["num"] = 9,
+				},
+				[6] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 8,
+				},
+				[7] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 7,
+				},
+				[8] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 5,
+				},
+				[9] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 4,
+				},
+				[10] = {
+					["CLSID"] = "LAU_117_AGM_65G",
+					["num"] = 3,
+				},
+				[11] = {
+					["CLSID"] = "{40EF17B7-F508-45de-8566-6FFECC0C1AB8}",
+					["num"] = 2,
+				},
+				[12] = {
+					["CLSID"] = "{5CE2FF2A-645A-4197-B48D-8720AC69394F}",
+					["num"] = 1,
+				},
+			},
+			["tasks"] = {
+				[1] = 31,
+			},
+		},
 	},
 	["tasks"] = {
 	},

--- a/resources/units/aircraft/A-10A.yaml
+++ b/resources/units/aircraft/A-10A.yaml
@@ -20,6 +20,9 @@ altitudes:
   cruise: 15000
   combat: 10000
 tasks:
+  DEAD: 680
   BAI: 680
   CAS: 680
   OCA/Aircraft: 680
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/A-10C.yaml
+++ b/resources/units/aircraft/A-10C.yaml
@@ -26,8 +26,11 @@ radios:
     intra_flight_radio_index: 1
     inter_flight_radio_index: 2
 tasks:
+  DEAD: 380
   BAI: 820
   CAS: 820
   OCA/Aircraft: 820
   OCA/Runway: 380
   Strike: 380
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/A-10C_2.yaml
+++ b/resources/units/aircraft/A-10C_2.yaml
@@ -32,8 +32,11 @@ radios:
     intra_flight_radio_index: 2
     inter_flight_radio_index: 1
 tasks:
+  DEAD: 390
   BAI: 830
   CAS: 830
   OCA/Aircraft: 830
   OCA/Runway: 390
   Strike: 390
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/CH_Tu-160M2.yaml
+++ b/resources/units/aircraft/CH_Tu-160M2.yaml
@@ -21,3 +21,5 @@ tasks:
   BAI: 370
   DEAD: 210
   Strike: 680
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/F-117A.yaml
+++ b/resources/units/aircraft/F-117A.yaml
@@ -19,4 +19,7 @@ variants:
   F-117A Nighthawk: {}
 has_built_in_target_pod: true
 tasks:
+  DEAD: 710
   Strike: 710
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/F-16A.yaml
+++ b/resources/units/aircraft/F-16A.yaml
@@ -4,6 +4,7 @@ max_range: 350
 variants:
   F-16A: null
 tasks:
+  DEAD: 150
   BARCAP: 420
   CAS: 340
   Escort: 420
@@ -15,3 +16,5 @@ tasks:
   TARCAP: 420
   SEAD: 150
   SEAD Escort: 150
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/MQ-9 Reaper.yaml
+++ b/resources/units/aircraft/MQ-9 Reaper.yaml
@@ -2,6 +2,9 @@ price: 10
 variants:
   MQ-9 Reaper: null
 tasks:
+  DEAD: 10
   BAI: 10
   CAS: 10
   OCA/Aircraft: 10
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/Mirage-F1EQ.yaml
+++ b/resources/units/aircraft/Mirage-F1EQ.yaml
@@ -12,6 +12,7 @@ max_range: 200
 variants:
   Mirage-F1EQ: {}
 tasks:
+  DEAD: 270
   BAI: 300
   BARCAP: 290
   CAS: 300
@@ -22,3 +23,5 @@ tasks:
   OCA/Runway: 270
   Strike: 270
   TARCAP: 290
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/Su-25.yaml
+++ b/resources/units/aircraft/Su-25.yaml
@@ -17,8 +17,11 @@ variants:
   Su-25 Frogfoot: {}
 kneeboard_units: "metric"
 tasks:
+  DEAD: 480
   BAI: 770
   CAS: 770
   OCA/Aircraft: 770
   OCA/Runway: 480
   Strike: 480
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/Su-35S.yaml
+++ b/resources/units/aircraft/Su-35S.yaml
@@ -24,9 +24,12 @@ radios:
   intra_flight: R-800
   inter_flight: R-800
 tasks:
+  DEAD: 550
   BARCAP: 700
   Escort: 700
   Fighter sweep: 800
   Intercept: 850
   SEAD Escort: 550
   TARCAP: 700
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/Su-57.yaml
+++ b/resources/units/aircraft/Su-57.yaml
@@ -14,8 +14,11 @@ role: Stealth Air-Superiority Fighter
 variants:
   Su-57 Felon: {}
 tasks:
+  DEAD: 560
   BARCAP: 560
   Escort: 560
   Fighter sweep: 560
   Intercept: 560
   TARCAP: 560
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/Tu-16.yaml
+++ b/resources/units/aircraft/Tu-16.yaml
@@ -21,3 +21,5 @@ tasks:
   OCA/Aircraft: 370
   OCA/Runway: 630
   Strike: 640
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/Tu-160.yaml
+++ b/resources/units/aircraft/Tu-160.yaml
@@ -20,3 +20,5 @@ tasks:
   BAI: 370
   DEAD: 210
   Strike: 680
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/Tu-4K.yaml
+++ b/resources/units/aircraft/Tu-4K.yaml
@@ -16,3 +16,5 @@ tasks:
   Anti-ship: 200
   BAI: 270
   DEAD: 245
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/Tu-95MS.yaml
+++ b/resources/units/aircraft/Tu-95MS.yaml
@@ -18,4 +18,7 @@ role: Strategic Bomber
 variants:
   Tu-95MS Bear-H: {}
 tasks:
+  DEAD: 670
   Strike: 670
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/Tu_95K.yaml
+++ b/resources/units/aircraft/Tu_95K.yaml
@@ -20,3 +20,5 @@ tasks:
   Strike: 650
   Anti-ship: 490
   DEAD: 290
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/VSN_F35A_AG.yaml
+++ b/resources/units/aircraft/VSN_F35A_AG.yaml
@@ -29,6 +29,7 @@ variants:
   F-35A Lightning II (A/G): {}
 utc_kneeboard: true
 tasks:
+  DEAD: 500
   Armed Recon: 500
   BAI: 740
   CAS: 740
@@ -38,3 +39,5 @@ tasks:
   Strike: 600
 
 has_built_in_ecm: true
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/VSN_F35B_AG.yaml
+++ b/resources/units/aircraft/VSN_F35B_AG.yaml
@@ -28,6 +28,7 @@ variants:
   F-35B Lightning II (A/G): {}
 utc_kneeboard: true
 tasks:
+  DEAD: 500
   Anti-ship: 600
   Armed Recon: 500
   BAI: 740
@@ -38,3 +39,5 @@ tasks:
   Strike: 600
   
 has_built_in_ecm: true
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/VSN_F35C_AG.yaml
+++ b/resources/units/aircraft/VSN_F35C_AG.yaml
@@ -27,6 +27,7 @@ variants:
   F-35C Lightning II (A/G): {}
 utc_kneeboard: true
 tasks:
+  DEAD: 500
   Armed Recon: 500
   BAI: 740
   CAS: 740
@@ -36,3 +37,5 @@ tasks:
   Strike: 600
   
 has_built_in_ecm: true
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/tu_22D.yaml
+++ b/resources/units/aircraft/tu_22D.yaml
@@ -20,3 +20,5 @@ tasks:
   OCA/Aircraft: 350
   OCA/Runway: 600
   Strike: 600
+secondary_tasks:
+  - DEAD

--- a/resources/units/aircraft/tu_22KD.yaml
+++ b/resources/units/aircraft/tu_22KD.yaml
@@ -23,3 +23,5 @@ tasks:
   Strike: 600
   SEAD: 30
   SEAD Escort: 30
+secondary_tasks:
+  - DEAD


### PR DESCRIPTION
Some aircraft can carry a good standoff/PGM weapon but DEAD is not one of their natural roles (A-10, F-35, Su-57, Su-35S, F-117A, strategic bombers…). Auto-assigning them to DEAD would be wrong, but a player may still want to task them with it manually.

**Mechanism:** aircraft yamls gain an optional `secondary_tasks` list. A task listed there is a real capability — `capable_of()` is true, it shows in the UI and can be assigned manually — but it is left out of a squadron's **default** auto-assignable mission types, so its checkbox starts **unchecked** (the AI won't auto-plan it; the player can tick it or assign manually). `capable_of` / `iter_task_capabilities` are unchanged; only the default auto-assignable set built by the squadron-def generators subtracts the secondary tasks.

DEAD is marked secondary for these airframes, each given a valid, sensible DEAD loadout (best standoff PGM it can field, preferring fire-and-forget GPS/INS over TV/laser; no anti-radar, decoys or cluster bombs):

| Aircraft | Weapon |
|---|---|
| A-10C / A-10C_2, MQ-9 Reaper | JDAM (GPS) |
| A-10A, F-16A, F-35C | Maverick (imaging-IR) |
| F-35A / F-35B | AGM-84E SLAM |
| Su-57, Mirage-F1EQ | Kh-29T (TV) |
| Su-35S | Kh-59MK2 |
| F-117A | GBU-10 (built-in designation) |
| Su-25 | Kh-29L / Kh-25ML |
| Tu-95MS, CH_Tu-160M2 | Kh-101 cruise |
| Tu-160 | Kh-65 cruise |
| Tu-16, Tu-4K, Tu_95K, tu_22D, tu_22KD | (kept their existing DEAD task, now secondary — only dumb bombs, no preset) |

Left out: M-2000C, Mirage-F1 (BE/CE/CT/EE/M-CE/M-EE/C-200) and F-5E — they can only carry laser bombs and have no self-designation pod, so they cannot employ the weapon autonomously.

Every loadout was validated against pydcs pylon data (mods via their sibling presets).