### PR TITLE
feat(tracker): show runway destruction in mid-mission progress tracker

### DIFF
--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -102,6 +102,7 @@ class SideLossCounts:
     ground_objects: int
     scenery: int
     bases_lost: int
+    runways_destroyed: int
 
 
 @dataclass(frozen=True)
@@ -305,6 +306,7 @@ class Debriefing:
             airlifts = gl.player_airlifts
             ground_objects = gl.player_ground_objects
             scenery = gl.player_scenery
+            airfields = gl.player_airfields
         else:
             air = self.air_losses.enemy
             front_line = gl.enemy_front_line
@@ -313,6 +315,7 @@ class Debriefing:
             airlifts = gl.enemy_airlifts
             ground_objects = gl.enemy_ground_objects
             scenery = gl.enemy_scenery
+            airfields = gl.enemy_airfields
         return SideLossCounts(
             aircraft=len(air),
             front_line=len(front_line),
@@ -326,6 +329,7 @@ class Debriefing:
                 for capture in self.base_captures
                 if capture.captured_by_player == player.opponent
             ),
+            runways_destroyed=len(airfields),
         )
 
     def dead_aircraft(self) -> AirLosses:

--- a/qt_ui/windows/QWaitingForMissionResultWindow.py
+++ b/qt_ui/windows/QWaitingForMissionResultWindow.py
@@ -172,6 +172,7 @@ class QWaitingForMissionResultWindow(QDialog):
             ("Ground Objects lost", blue.ground_objects, red.ground_objects),
             ("Scenery Objects lost", blue.scenery, red.scenery),
             ("Bases lost", blue.bases_lost, red.bases_lost),
+            ("Runways destroyed", blue.runways_destroyed, red.runways_destroyed),
         ]
         for label, blue_count, red_count in rows:
             self.add_update_row(label, blue_count, red_count, update_layout)

--- a/tests/test_debriefing.py
+++ b/tests/test_debriefing.py
@@ -44,6 +44,8 @@ def _sample_debriefing() -> Debriefing:
         enemy_ground_objects=_items(2),
         player_scenery=_items(0),
         enemy_scenery=_items(1),
+        player_airfields=_items(1),
+        enemy_airfields=_items(2),
     )
     captures = [
         _capture(Player.BLUE),
@@ -68,6 +70,7 @@ def test_loss_counts_blue_side() -> None:
         ground_objects=5,
         scenery=0,
         bases_lost=1,  # one base captured by RED == one base Blue lost
+        runways_destroyed=1,
     )
 
 
@@ -82,6 +85,7 @@ def test_loss_counts_red_side() -> None:
         ground_objects=2,
         scenery=1,
         bases_lost=2,  # two bases captured by BLUE == two bases Red lost
+        runways_destroyed=2,
     )
 
 
@@ -105,3 +109,6 @@ def test_loss_counts_partition_matches_combined_totals() -> None:
     )
     assert blue.scenery + red.scenery == len(list(debriefing.scenery_object_losses))
     assert blue.bases_lost + red.bases_lost == len(debriefing.base_captures)
+    assert blue.runways_destroyed + red.runways_destroyed == len(
+        list(debriefing.damaged_runways)
+    )


### PR DESCRIPTION
  ## What

  The mid-mission progress tracker already received destroyed-airfield data
  via `Debriefing.damaged_runways`, but never surfaced it to the player. This
  adds a **"Runways destroyed"** count to the tracker grid so runway kills show
  up alongside the other mid-mission loss/progress stats.

  ## How

  - Add `runways_destroyed` to `SideLossCounts` / `loss_counts` in
    `game/debriefing.py`, derived from the existing `damaged_runways` data.
  - Add a "Runways destroyed" row to the tracker grid in
    `QWaitingForMissionResultWindow.py`.
  - Cover the new count in `tests/test_debriefing.py`.

  No new data plumbing — the debrief already carried the runway info; this just
  counts and displays it.

  Closes #285 (item #9).