### PR TITLE
feat(waypoint): propagate edited waypoint names to the aircraft CDU/HUD

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 * **[Modding]** Update to CJS Super Hornet Mod to v2.4.5.260501.RC1
 * **[Modding]** Update Community A4EC Mod to 2.3.0 (May 2025)
 
+* **[Flight Plans]** Renaming a waypoint in the flight-plan list now propagates to the aircraft CDU/HUD and the kneeboard, not just the list — one name in all three places (#695).
 
 ## Fixes
 * **[Plugins]** Fix the escort leash never running (DCS has no `Group.getByID`; look the group up by name via mist), so escorts are actually held to their engagement range.

--- a/game/ato/flightwaypoint.py
+++ b/game/ato/flightwaypoint.py
@@ -34,6 +34,9 @@ class FlightWaypoint:
     targets: list[TheaterUnit] = field(default_factory=list)
     obj_name: str = ""
     pretty_name: str = ""
+    # User override; None = follow the auto names. Invariant: never "" — apply_name_edit
+    # stores None instead of an empty string, so `custom_name or pretty_name` is safe.
+    custom_name: str | None = None
     only_for_player: bool = False
     flyover: bool = False
 
@@ -55,8 +58,35 @@ class FlightWaypoint:
     def y(self) -> float:
         return self.position.y
 
+    @property
+    def display_name(self) -> str:
+        """User-facing name for Retribution displays: the override if the player set
+        one, otherwise the auto pretty_name."""
+        return self.custom_name or self.pretty_name
+
+    def apply_name_edit(self, raw: str) -> None:
+        """Record (or clear) a user rename from the flight-plan list cell.
+
+        The cell text is "{:<16}".format(display_name), so it arrives padded; strip it.
+        Only a value that differs from the auto pretty_name is a real override — a blank
+        or back-to-auto entry reverts so the waypoint resumes following its auto name.
+        pretty_name is stripped on the other side of the comparison too: saves made before
+        this change carry pretty_name padded by the old on_changed handler, and we must not
+        read that padding as a difference (it would set a phantom override).
+        """
+        stripped = raw.strip()
+        self.custom_name = (
+            stripped if stripped and stripped != self.pretty_name.strip() else None
+        )
+
     def __hash__(self) -> int:
         return hash(id(self))
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        # Saves made before custom_name existed won't carry the key; default it so
+        # attribute access on a reloaded waypoint is safe.
+        state.setdefault("custom_name", None)
+        self.__dict__.update(state)
 
     def __deepcopy__(self, memo: Optional[Dict[int, Any]] = None) -> FlightWaypoint:
         obj = FlightWaypoint(self.name, self.waypoint_type, self.position)

--- a/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
+++ b/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
@@ -23,6 +23,15 @@ TARGET_WAYPOINTS = (
     FlightWaypointType.TARGET_SHIP,
 )
 
+# Waypoints whose generated .miz name is matched as a structural identifier downstream --
+# CTLD air-assault split (landingzone.py: name == "DROPOFFZONE"), EW jamming placement and
+# formation join/split (aircraftgenerator.py / missiongenerator.py: name in {"JOIN", "SPLIT",
+# "RACETRACK START", "RACETRACK END"}). A player rename must NOT reach the .miz for these or
+# that logic silently breaks, so they keep their canonical name regardless of custom_name.
+STRUCTURAL_WAYPOINT_NAMES = frozenset(
+    {"JOIN", "SPLIT", "RACETRACK START", "RACETRACK END", "DROPOFFZONE"}
+)
+
 
 class PydcsWaypointBuilder:
     def __init__(
@@ -43,7 +52,14 @@ class PydcsWaypointBuilder:
         self.mission_data = mission_data
 
     def dcs_name_for_waypoint(self) -> str:
-        return self.waypoint.name
+        # Structural waypoints are matched by name downstream; never let a rename reach the
+        # .miz for them (see STRUCTURAL_WAYPOINT_NAMES). The UI still allows the edit, but it
+        # is a harmless no-op in the cockpit for these.
+        if self.waypoint.name in STRUCTURAL_WAYPOINT_NAMES:
+            return self.waypoint.name
+        # Prefer the player's rename; otherwise the terse auto .miz name. NB the CDU
+        # fallback is `name`, not `pretty_name` (the list/kneeboard fallback) — by design.
+        return self.waypoint.custom_name or self.waypoint.name
 
     def build(self) -> MovingPoint:
         waypoint = self.group.add_waypoint(

--- a/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
+++ b/game/missiongenerator/aircraft/waypoints/pydcswaypointbuilder.py
@@ -59,6 +59,13 @@ class PydcsWaypointBuilder:
             return self.waypoint.name
         # Prefer the player's rename; otherwise the terse auto .miz name. NB the CDU
         # fallback is `name`, not `pretty_name` (the list/kneeboard fallback) — by design.
+        #
+        # Flight-agnostic by design: AI flights are unaffected by a player's rename
+        # because a rename is written only to the player's own flight-plan waypoints
+        # (FlightWaypoint.apply_name_edit), and the player-only waypoint types a rename
+        # usually targets (target/divert/bullseye) are filtered out for AI flights
+        # upstream in WaypointGenerator.create_waypoints (only_for_player, client_count).
+        # See test_divert_and_bullseye_waypoints_are_player_only.
         return self.waypoint.custom_name or self.waypoint.name
 
     def build(self) -> MovingPoint:

--- a/game/missiongenerator/aircraft/waypoints/target.py
+++ b/game/missiongenerator/aircraft/waypoints/target.py
@@ -9,6 +9,7 @@ class TargetBuilder(PydcsWaypointBuilder):
     """
 
     def dcs_name_for_waypoint(self) -> str:
+        resolved = super().dcs_name_for_waypoint()  # honors custom_name override
         if self.flight.unit_type.use_f15e_waypoint_names:
-            return f"#T {self.waypoint.name}"
-        return super().dcs_name_for_waypoint()
+            return f"#T {resolved}"
+        return resolved

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -258,7 +258,7 @@ class FlightPlanBuilder:
             [
                 str(waypoint.number),
                 KneeboardPageWriter.wrap_line(
-                    waypoint.waypoint.pretty_name,
+                    waypoint.waypoint.display_name,
                     FlightPlanBuilder.WAYPOINT_DESC_MAX_LEN,
                 ),
                 self._format_alt(waypoint.waypoint.alt),
@@ -772,33 +772,45 @@ class StrikeTaskPage(KneeboardPage):
             custom_name_title = ""
         writer.title(f"{self.flight.callsign} Strike Task Info{custom_name_title}")
 
-        if self.flight.units[0].unit_type == F_15ESE:
-            i: int = 0
-            for target in self.targets:
-                if not target.waypoint.pretty_name.__contains__("DTC"):
-                    target.waypoint.pretty_name = (
-                        f"{target.waypoint.pretty_name} (DTC M{(i//8)+1}.{i%9+1})"
-                    )
-                    i = i + 1
-
+        is_f15e = self.flight.units[0].unit_type == F_15ESE
         writer.table(
-            [self.target_info_row(t, writer) for t in self.targets],
+            [
+                [
+                    str(target.number),
+                    writer.wrap_line(
+                        self._target_description(
+                            target.waypoint.display_name, i, is_f15e
+                        ),
+                        self.WAYPOINT_DESC_MAX_LEN,
+                    ),
+                    target.waypoint.position.latlng().format_dms(
+                        include_decimal_seconds=True
+                    ),
+                ]
+                for i, target in enumerate(self.targets)
+            ],
             headers=["STPT", "Description", "Location"],
         )
 
         writer.write(path)
 
     @staticmethod
-    def target_info_row(
-        target: NumberedWaypoint, writer: KneeboardPageWriter
-    ) -> list[str]:
-        return [
-            str(target.number),
-            writer.wrap_line(
-                target.waypoint.pretty_name, StrikeTaskPage.WAYPOINT_DESC_MAX_LEN
-            ),
-            target.waypoint.position.latlng().format_dms(include_decimal_seconds=True),
-        ]
+    def _target_description(display_name: str, index: int, is_f15e: bool) -> str:
+        """The Strike Task 'Description' cell for one target.
+
+        Built from the waypoint's display_name so a player's rename shows here too, and
+        NOT written back to the waypoint: the F15E DTC data-cartridge slot reference stays
+        confined to this page. (The previous code mutated pretty_name in place, which both
+        leaked the DTC tag into the list / flight-plan kneeboard and, once renames moved to
+        custom_name, regressed this page to the long auto name.)
+        """
+        if is_f15e:
+            # Slot math must match the CDU data-cartridge programming in
+            # PydcsWaypointBuilder.register_special_strike_points ("M{i//8+1}.{i%8+1}")
+            # so the kneeboard label points at the slot the jet was actually programmed
+            # with -- 8 minor slots per major group.
+            return f"{display_name} (DTC M{(index // 8) + 1}.{index % 8 + 1})"
+        return display_name
 
 
 class NotesPage(KneeboardPage):

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointItem.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointItem.py
@@ -4,9 +4,9 @@ from game.ato.flightwaypoint import FlightWaypoint
 
 
 class QWaypointItem(QStandardItem):
-    def __init__(self, point: FlightWaypoint, number):
+    def __init__(self, point: FlightWaypoint, number: int) -> None:
         super(QWaypointItem, self).__init__()
         self.setData(point, Qt.ItemDataRole.UserRole)
         self.number = number
-        self.setText("{:<16}".format(point.pretty_name))
+        self.setText("{:<16}".format(point.display_name))
         self.setEditable(True)

--- a/qt_ui/windows/mission/flight/waypoints/QFlightWaypointList.py
+++ b/qt_ui/windows/mission/flight/waypoints/QFlightWaypointList.py
@@ -112,11 +112,12 @@ class QFlightWaypointList(QTableView):
 
     def on_changed(self) -> None:
         for i in range(self.model.rowCount()):
-            altitude = self.model.item(i, 1).text()
-            altitude_feet = float(altitude)
-            self.flight.flight_plan.waypoints[i].alt = Distance.from_feet(altitude_feet)
-            name = self.model.item(i, 0).text()
-            self.flight.flight_plan.waypoints[i].pretty_name = name
+            # waypoints materializes a fresh list each access; resolve once per row so the
+            # altitude and name edits land on the same waypoint object.
+            waypoint = self.flight.flight_plan.waypoints[i]
+            altitude_feet = float(self.model.item(i, 1).text())
+            waypoint.alt = Distance.from_feet(altitude_feet)
+            waypoint.apply_name_edit(self.model.item(i, 0).text())
 
     def tot_text(
         self,

--- a/tests/ato/test_flightwaypoint_custom_name.py
+++ b/tests/ato/test_flightwaypoint_custom_name.py
@@ -1,0 +1,87 @@
+import copy
+
+from dcs import Point
+from dcs.terrain import Caucasus
+
+from game.ato.flightwaypoint import FlightWaypoint
+from game.ato.flightwaypointtype import FlightWaypointType
+
+
+def _wp(pretty_name: str = "[OBJ] : Scud #0") -> FlightWaypoint:
+    wp = FlightWaypoint("auto-name", FlightWaypointType.CUSTOM, Point(0, 0, Caucasus()))
+    wp.pretty_name = pretty_name
+    return wp
+
+
+def test_custom_name_defaults_to_none() -> None:
+    assert _wp().custom_name is None
+
+
+def test_display_name_falls_back_to_pretty_name() -> None:
+    assert _wp("Pretty").display_name == "Pretty"
+
+
+def test_display_name_prefers_custom_name() -> None:
+    wp = _wp("Pretty")
+    wp.custom_name = "SCUD1"
+    assert wp.display_name == "SCUD1"
+
+
+def test_apply_name_edit_sets_override_when_different() -> None:
+    wp = _wp("Pretty")
+    wp.apply_name_edit("SCUD1")
+    assert wp.custom_name == "SCUD1"
+
+
+def test_apply_name_edit_strips_padding() -> None:
+    wp = _wp("Pretty")
+    wp.apply_name_edit("SCUD1           ")  # cell text is "{:<16}".format(...)
+    assert wp.custom_name == "SCUD1"
+
+
+def test_apply_name_edit_back_to_auto_clears_override() -> None:
+    wp = _wp("Pretty")
+    wp.custom_name = "SCUD1"
+    wp.apply_name_edit("Pretty")
+    assert wp.custom_name is None
+
+
+def test_apply_name_edit_blank_clears_override() -> None:
+    wp = _wp("Pretty")
+    wp.custom_name = "SCUD1"
+    wp.apply_name_edit("   ")
+    assert wp.custom_name is None
+
+
+def test_apply_name_edit_no_phantom_override_when_pretty_name_padded() -> None:
+    # Old saves carry pretty_name padded by the previous on_changed handler. Typing the
+    # (unpadded) auto name must still read as "no override", not a phantom rename.
+    wp = _wp("Hold            ")  # pre-existing padded pretty_name
+    wp.apply_name_edit("Hold")
+    assert wp.custom_name is None
+
+
+def test_apply_name_edit_keeps_existing_override_on_padded_redraw() -> None:
+    # on_changed re-applies apply_name_edit to every row whenever any cell changes,
+    # feeding back the list cell's "{:<16}".format(display_name). For a row that already
+    # has an override, that cell text is the padded custom_name, so re-applying it must be
+    # idempotent and never clobber the override back to None.
+    wp = _wp("Pretty")
+    wp.custom_name = "SCUD1"
+    wp.apply_name_edit("{:<16}".format(wp.display_name))
+    assert wp.custom_name == "SCUD1"
+
+
+def test_setstate_defaults_custom_name_for_old_saves() -> None:
+    wp = _wp("Pretty")
+    state = dict(wp.__dict__)
+    del state["custom_name"]
+    restored = FlightWaypoint.__new__(FlightWaypoint)
+    restored.__setstate__(state)
+    assert restored.custom_name is None
+
+
+def test_deepcopy_preserves_custom_name() -> None:
+    wp = _wp("Pretty")
+    wp.custom_name = "SCUD1"
+    assert copy.deepcopy(wp).custom_name == "SCUD1"

--- a/tests/missiongenerator/aircraft/test_pydcswaypointbuilder.py
+++ b/tests/missiongenerator/aircraft/test_pydcswaypointbuilder.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from dcs import Point
 from dcs.terrain import Caucasus
 
+from game.ato.flightplans.waypointbuilder import WaypointBuilder
 from game.ato.flightwaypoint import FlightWaypoint
 from game.ato.flightwaypointtype import FlightWaypointType
 from game.missiongenerator.aircraft.waypoints.pydcswaypointbuilder import (
@@ -69,3 +70,23 @@ def test_target_builder_f15e_falls_back_to_name() -> None:
     assert (
         _target_builder(None, f15e=True).dcs_name_for_waypoint() == "#T [OBJ] : Scud #0"
     )
+
+
+def test_divert_and_bullseye_waypoints_are_player_only() -> None:
+    # PR #820 propagates a player's waypoint rename to the .miz CDU name. AI-only flights
+    # must never receive that rename. The safety is structural, not a guard in
+    # dcs_name_for_waypoint: a rename is written only to the player's own flight-plan
+    # waypoints (FlightWaypoint.apply_name_edit), and the waypoint types a rename most
+    # often targets are constructed only_for_player=True so WaypointGenerator.create
+    # waypoints drops them for AI flights (client_count == 0). Lock that flag here -- if
+    # it is ever removed, AI flights would silently start emitting these waypoints and the
+    # "AI unaffected" guarantee would break. (Target waypoints set the same flag in
+    # waypointbuilder.py, near the strike-area / target builders.)
+    builder = WaypointBuilder.__new__(WaypointBuilder)
+    builder._bullseye = SimpleNamespace(position=Point(0, 0, Caucasus()))  # type: ignore[assignment]
+    divert_point = SimpleNamespace(position=Point(1, 1, Caucasus()))
+
+    assert builder.bullseye().only_for_player is True
+    divert = builder.divert(divert_point)  # type: ignore[arg-type]
+    assert divert is not None
+    assert divert.only_for_player is True

--- a/tests/missiongenerator/aircraft/test_pydcswaypointbuilder.py
+++ b/tests/missiongenerator/aircraft/test_pydcswaypointbuilder.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+from dcs import Point
+from dcs.terrain import Caucasus
+
+from game.ato.flightwaypoint import FlightWaypoint
+from game.ato.flightwaypointtype import FlightWaypointType
+from game.missiongenerator.aircraft.waypoints.pydcswaypointbuilder import (
+    PydcsWaypointBuilder,
+)
+from game.missiongenerator.aircraft.waypoints.target import TargetBuilder
+
+
+def _waypoint(custom_name: str | None) -> FlightWaypoint:
+    wp = FlightWaypoint(
+        "[OBJ] : Scud #0", FlightWaypointType.TARGET_POINT, Point(0, 0, Caucasus())
+    )
+    wp.custom_name = custom_name
+    return wp
+
+
+def _base_builder(custom_name: str | None) -> PydcsWaypointBuilder:
+    builder = PydcsWaypointBuilder.__new__(PydcsWaypointBuilder)
+    builder.waypoint = _waypoint(custom_name)
+    return builder
+
+
+def _target_builder(custom_name: str | None, f15e: bool) -> TargetBuilder:
+    builder = TargetBuilder.__new__(TargetBuilder)
+    builder.waypoint = _waypoint(custom_name)
+    builder.flight = SimpleNamespace(  # type: ignore[assignment]
+        unit_type=SimpleNamespace(use_f15e_waypoint_names=f15e)
+    )
+    return builder
+
+
+def test_dcs_name_uses_custom_name_when_set() -> None:
+    assert _base_builder("SCUD1").dcs_name_for_waypoint() == "SCUD1"
+
+
+def test_dcs_name_falls_back_to_name_when_unset() -> None:
+    assert _base_builder(None).dcs_name_for_waypoint() == "[OBJ] : Scud #0"
+
+
+def test_dcs_name_ignores_override_for_structural_join_waypoint() -> None:
+    # JOIN's generated name is matched downstream (formation/EW jamming); a rename must not
+    # reach the .miz or that logic breaks, so the canonical name wins.
+    builder = _base_builder("MyJoin")
+    builder.waypoint.name = "JOIN"
+    assert builder.dcs_name_for_waypoint() == "JOIN"
+
+
+def test_dcs_name_ignores_override_for_dropoffzone_waypoint() -> None:
+    # DROPOFFZONE drives the CTLD air-assault split trigger (landingzone.py).
+    builder = _base_builder("LZ Alpha")
+    builder.waypoint.name = "DROPOFFZONE"
+    assert builder.dcs_name_for_waypoint() == "DROPOFFZONE"
+
+
+def test_target_builder_non_f15e_uses_custom_name() -> None:
+    assert _target_builder("SCUD1", f15e=False).dcs_name_for_waypoint() == "SCUD1"
+
+
+def test_target_builder_f15e_wraps_custom_name() -> None:
+    assert _target_builder("SCUD1", f15e=True).dcs_name_for_waypoint() == "#T SCUD1"
+
+
+def test_target_builder_f15e_falls_back_to_name() -> None:
+    assert (
+        _target_builder(None, f15e=True).dcs_name_for_waypoint() == "#T [OBJ] : Scud #0"
+    )

--- a/tests/missiongenerator/test_strike_task_page.py
+++ b/tests/missiongenerator/test_strike_task_page.py
@@ -1,0 +1,26 @@
+from game.missiongenerator.kneeboard import StrikeTaskPage
+
+
+def test_target_description_non_f15e_returns_display_name() -> None:
+    assert StrikeTaskPage._target_description("SCUD1", 0, False) == "SCUD1"
+
+
+def test_target_description_f15e_appends_dtc_slot() -> None:
+    assert StrikeTaskPage._target_description("SCUD1", 0, True) == "SCUD1 (DTC M1.1)"
+
+
+def test_target_description_f15e_reflects_rename() -> None:
+    # The DTC reference is built from display_name, so a renamed target reads "SCUD1",
+    # not the long auto pretty_name.
+    assert StrikeTaskPage._target_description("SCUD1", 1, True) == "SCUD1 (DTC M1.2)"
+
+
+def test_target_description_f15e_slot_matches_cdu_formula() -> None:
+    # Slot math mirrors the CDU programming (M{i//8+1}.{i%8+1}): 8 minor slots per major
+    # group, so index 8 is the first slot of group 2 -> M2.1 (NOT M2.9).
+    assert StrikeTaskPage._target_description("Tgt", 8, True) == "Tgt (DTC M2.1)"
+
+
+def test_target_description_f15e_minor_slot_advances_within_group() -> None:
+    # Index 9 is the second slot of group 2 -> M2.2, matching the CDU.
+    assert StrikeTaskPage._target_description("Tgt", 9, True) == "Tgt (DTC M2.2)"


### PR DESCRIPTION
 ## What

  When you rename a waypoint in the flight plan editor, that custom name now
  follows through to the aircraft's CDU/HUD in-cockpit — not just the
  Retribution UI list and kneeboard. Previously the cockpit always showed the
  long auto-generated name regardless of your edit.
  One name, three places: flight plan list, kneeboard, and the in-cockpit CDU.

  ## How

  - `FlightWaypoint` gains a `custom_name` override (`game/ato/flightwaypoint.py`):
    - `display_name` returns `custom_name or pretty_name`.
    - `apply_name_edit(raw)` stores the trimmed name, or `None` when it's empty
      or equals the auto name (so it never persists a phantom override).
  - `dcs_name_for_waypoint()` (`pydcswaypointbuilder.py`) emits `custom_name`
    into the `.miz` for normal waypoints, with the F-15E target page wired the
    same way.
  - Structural routing markers are left untouched — `JOIN`, `SPLIT`,
    `RACETRACK START`, `RACETRACK END`, `DROPOFFZONE` keep their canonical
    cockpit names even if renamed in the list (rename is a harmless no-op for
    those).
  - UI list + kneeboard wiring so the edited name shows everywhere.

  ## Scope / notes

  - Renamed-only: a waypoint left at its default auto name behaves exactly as
    before; only an explicit edit propagates.
  - AI-only flights are unaffected — target/divert/bullseye waypoints are
    player-only and never emitted for AI flights, so there's nothing to
    propagate there.

  Closes #695.