### PR TITLE
Enhanced Front Line Stances + Movement

### DIFF
--- a/game/ground_forces/ai_ground_planner.py
+++ b/game/ground_forces/ai_ground_planner.py
@@ -6,7 +6,7 @@ import logging
 import random
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, TYPE_CHECKING
 from uuid import UUID
 
 from game.data.units import UnitClass
@@ -55,6 +55,13 @@ class CombatGroup:
         # wedge itself and for unclustered groups (artillery/logi). Spec B reads
         # this to make the cluster maneuver as a unit.
         self.anchor: Optional[CombatGroup] = None
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        # Saves made before the cluster work (dr-588t) have no ``anchor``; pickle
+        # skips ``__init__`` so backfill the default for those old CombatGroups.
+        self.__dict__.update(state)
+        if not hasattr(self, "anchor"):
+            self.anchor = None
 
     def __str__(self) -> str:
         s = f"ROLE : {self.role}\n"

--- a/game/ground_forces/ai_ground_planner.py
+++ b/game/ground_forces/ai_ground_planner.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
+import collections
+import itertools
 import logging
 import random
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 from uuid import UUID
 
 from game.data.units import UnitClass
 from game.dcs.groundunittype import GroundUnitType
-from .combat_stance import CombatStance
+from .frontline_clustering import allocate_largest_remainder
 
 if TYPE_CHECKING:
     from game import Game
     from game.theater import ControlPoint
-
-MAX_COMBAT_GROUP_PER_CP = 10
 
 
 class CombatGroupRole(Enum):
@@ -41,15 +42,6 @@ DISTANCE_FROM_FRONTLINE = {
     CombatGroupRole.RECON: (2000, 3000),
 }
 
-GROUP_SIZES_BY_COMBAT_STANCE = {
-    CombatStance.DEFENSIVE: [2, 4, 6],
-    CombatStance.AGGRESSIVE: [2, 4, 6],
-    CombatStance.RETREAT: [2, 4, 6, 8],
-    CombatStance.BREAKTHROUGH: [4, 6, 6, 8],
-    CombatStance.ELIMINATION: [2, 4, 4, 4, 6],
-    CombatStance.AMBUSH: [1, 1, 2, 2, 2, 2, 4],
-}
-
 
 class CombatGroup:
     def __init__(
@@ -59,6 +51,10 @@ class CombatGroup:
         self.size = size
         self.role = role
         self.start_position = None
+        # Set for clustered members to their cluster's armor wedge; None for the
+        # wedge itself and for unclustered groups (artillery/logi). Spec B reads
+        # this to make the cluster maneuver as a unit.
+        self.anchor: Optional[CombatGroup] = None
 
     def __str__(self) -> str:
         s = f"ROLE : {self.role}\n"
@@ -135,6 +131,156 @@ def reserve_armor_for(cp: ControlPoint) -> dict[GroundUnitType, int]:
     return reserve
 
 
+WEDGE_ROLES: frozenset[CombatGroupRole] = frozenset(
+    {CombatGroupRole.TANK, CombatGroupRole.IFV, CombatGroupRole.APC}
+)
+
+# Deterministic iteration order for collecting wedges in assemble_clusters.
+_WEDGE_ROLE_ORDER: tuple[CombatGroupRole, ...] = (
+    CombatGroupRole.TANK,
+    CombatGroupRole.IFV,
+    CombatGroupRole.APC,
+)
+
+WEDGE_SIZE_MIN = 5
+WEDGE_SIZE_MAX = 7
+
+# Depth of a cluster member relative to its armor wedge, in metres. Negative is
+# toward the enemy (in front of the wedge); positive is behind it. Applied on top
+# of the wedge's own distance-from-frontline at placement time (Task 6).
+CLUSTER_DEPTH_OFFSET: dict[CombatGroupRole, int] = {
+    CombatGroupRole.RECON: -800,
+    CombatGroupRole.SHORAD: 800,
+    CombatGroupRole.ATGM: 2000,
+}
+
+_ROLE_BY_UNIT_CLASS: dict[UnitClass, CombatGroupRole] = {
+    UnitClass.TANK: CombatGroupRole.TANK,
+    UnitClass.APC: CombatGroupRole.APC,
+    UnitClass.IFV: CombatGroupRole.IFV,
+    UnitClass.ARTILLERY: CombatGroupRole.ARTILLERY,
+    UnitClass.LOGISTICS: CombatGroupRole.LOGI,
+    UnitClass.ATGM: CombatGroupRole.ATGM,
+    UnitClass.SHORAD: CombatGroupRole.SHORAD,
+    UnitClass.AAA: CombatGroupRole.SHORAD,
+    UnitClass.RECON: CombatGroupRole.RECON,
+}
+
+# Fixed group sizes per role (replaces stance-based sizing for Spec A).
+_FIXED_GROUP_SIZE_BY_ROLE: dict[CombatGroupRole, int] = {
+    CombatGroupRole.SHORAD: 1,
+    CombatGroupRole.ATGM: 2,
+    CombatGroupRole.RECON: 2,
+}
+
+
+@dataclass
+class Cluster:
+    wedge: CombatGroup
+    members: list[CombatGroup] = field(default_factory=list)
+
+
+def interleave_by_unit_type(groups: list[CombatGroup]) -> list[CombatGroup]:
+    """Reorder so consecutive groups prefer distinct unit types (round-robin)."""
+    by_type: dict[GroundUnitType, collections.deque[CombatGroup]] = {}
+    for g in groups:
+        by_type.setdefault(g.unit_type, collections.deque()).append(g)
+    ordered: list[CombatGroup] = []
+    queues = list(by_type.values())
+    while any(queues):
+        for q in queues:
+            if q:
+                ordered.append(q.popleft())
+    return ordered
+
+
+def assemble_clusters(
+    buckets: dict[CombatGroupRole, list[CombatGroup]],
+) -> list[Cluster]:
+    """Group pre-sized single-type CombatGroups into combat clusters.
+
+    Each WEDGE_ROLES group becomes a cluster anchor. Wedges are interleaved by
+    unit_type so adjacent clusters alternate armor types. RECON and ATGM groups
+    are attached round-robin (one per cluster first, then spares). SHORAD groups
+    are attached with a distinct-type rule: each cluster gets at most 1 SHORAD of
+    any given type (a 2nd SHORAD is only attached if it is a different unit_type
+    than the cluster's existing SHORAD). Unattached SHORAD keep ``anchor = None``
+    so that ``plan_groundwar``'s unclustered path places them independently.
+
+    Roles missing from ``buckets`` are skipped, so a cluster degrades to
+    armor-only when no members are available.
+    """
+    wedges: list[CombatGroup] = []
+    for role in _WEDGE_ROLE_ORDER:
+        wedges.extend(buckets.get(role, []))
+    if not wedges:
+        return []
+
+    # I2: interleave wedges by type so adjacent clusters alternate armor type.
+    wedges = interleave_by_unit_type(wedges)
+    clusters = [Cluster(wedge=w, members=[]) for w in wedges]
+
+    # RECON and ATGM: simple round-robin, one per cluster first then spares.
+    for role in (CombatGroupRole.RECON, CombatGroupRole.ATGM):
+        members = list(buckets.get(role, []))
+        for member, cluster in zip(members, itertools.cycle(clusters)):
+            member.anchor = cluster.wedge
+            cluster.members.append(member)
+
+    # I1: SHORAD — 1 per cluster; 2nd only if a distinct unit_type from the
+    # cluster's existing SHORAD. Same-type extras are left unattached (anchor
+    # stays None) so plan_groundwar's unclustered path picks them up.
+    shorad_groups = list(buckets.get(CombatGroupRole.SHORAD, []))
+    if shorad_groups:
+        # First pass: one SHORAD per cluster (round-robin).
+        cluster_shorad_types: list[set[GroundUnitType]] = [set() for _ in clusters]
+        remaining_shorad: list[CombatGroup] = []
+        for shorad, cluster_idx in zip(
+            shorad_groups,
+            itertools.islice(itertools.cycle(range(len(clusters))), len(shorad_groups)),
+        ):
+            c = clusters[cluster_idx]
+            seen = cluster_shorad_types[cluster_idx]
+            if not seen:
+                # First SHORAD on this cluster — always attach.
+                shorad.anchor = c.wedge
+                c.members.append(shorad)
+                seen.add(shorad.unit_type)
+            else:
+                remaining_shorad.append(shorad)
+
+        # Second pass: attach remaining SHORAD only if distinct type.
+        unattached_idx = 0
+        for shorad in remaining_shorad:
+            # Try each cluster (starting from unattached_idx to distribute evenly).
+            for offset in range(len(clusters)):
+                idx = (unattached_idx + offset) % len(clusters)
+                seen = cluster_shorad_types[idx]
+                if shorad.unit_type not in seen:
+                    c = clusters[idx]
+                    shorad.anchor = c.wedge
+                    c.members.append(shorad)
+                    seen.add(shorad.unit_type)
+                    unattached_idx = (idx + 1) % len(clusters)
+                    break
+            # If not placed, shorad.anchor remains None → unclustered.
+
+    return clusters
+
+
+def _fixed_size_groups(
+    role: CombatGroupRole, unit_type: GroundUnitType, n: int, size: int
+) -> list[CombatGroup]:
+    """Return groups of ``size`` units; the last group may be smaller."""
+    groups: list[CombatGroup] = []
+    remaining = n
+    while remaining > 0:
+        group_size = min(remaining, size)
+        groups.append(CombatGroup(role, unit_type, group_size))
+        remaining -= group_size
+    return groups
+
+
 class GroundPlanner:
     def __init__(self, cp: ControlPoint, game: Game) -> None:
         self.cp = cp
@@ -142,14 +288,6 @@ class GroundPlanner:
         self.connected_enemy_cp = [
             cp for cp in self.cp.connected_points if cp.captured != self.cp.captured
         ]
-        self.tank_groups: List[CombatGroup] = []
-        self.apc_group: List[CombatGroup] = []
-        self.ifv_group: List[CombatGroup] = []
-        self.art_group: List[CombatGroup] = []
-        self.atgm_group: List[CombatGroup] = []
-        self.logi_groups: List[CombatGroup] = []
-        self.shorad_groups: List[CombatGroup] = []
-        self.recon_groups: List[CombatGroup] = []
 
         self.units_per_cp: dict[UUID, List[CombatGroup]] = {}
         for cp in self.connected_enemy_cp:
@@ -157,90 +295,84 @@ class GroundPlanner:
         self.reserve: List[CombatGroup] = []
 
     def plan_groundwar(self) -> None:
-        ground_unit_limit = self.cp.frontline_unit_count_limit
+        limit = self.cp.frontline_unit_count_limit
+        total = self.cp.base.total_armor
+        if total <= 0 or limit <= 0:
+            return
+        ratio = min(limit / total, 1)
 
-        remaining_available_frontline_units = ground_unit_limit
-        # Now applies the ratio between ground unit limit and the total number of ground units to each unit type
-        # when planning the ground war. This will help with monocultures of certain unit types when the control
-        # point has more units than can be spawned in one mission. In short, this will make more unit types to spawn.
-        if self.cp.base.total_armor > 0:
-            ratio_of_frontline_units_to_reserves = min(
-                ground_unit_limit / self.cp.base.total_armor, 1
-            )
-        else:
-            ratio_of_frontline_units_to_reserves = 1
-
-        # Create combat groups and assign them randomly to each enemy CP
-        for unit_type in self.cp.base.armor:
-            unit_class = unit_type.unit_class
-            if unit_class is UnitClass.TANK:
-                collection = self.tank_groups
-                role = CombatGroupRole.TANK
-            elif unit_class is UnitClass.APC:
-                collection = self.apc_group
-                role = CombatGroupRole.APC
-            elif unit_class is UnitClass.ARTILLERY:
-                collection = self.art_group
-                role = CombatGroupRole.ARTILLERY
-            elif unit_class is UnitClass.IFV:
-                collection = self.ifv_group
-                role = CombatGroupRole.IFV
-            elif unit_class is UnitClass.LOGISTICS:
-                collection = self.logi_groups
-                role = CombatGroupRole.LOGI
-            elif unit_class is UnitClass.ATGM:
-                collection = self.atgm_group
-                role = CombatGroupRole.ATGM
-            elif unit_class in [UnitClass.SHORAD, UnitClass.AAA]:
-                collection = self.shorad_groups
-                role = CombatGroupRole.SHORAD
-            elif unit_class is UnitClass.RECON:
-                collection = self.recon_groups
-                role = CombatGroupRole.RECON
-            else:
+        # 1. Proportional deployable count per unit type, capped at the limit.
+        weights: dict[GroundUnitType, float] = {}
+        for unit_type, count in self.cp.base.armor.items():
+            if unit_type.unit_class not in _ROLE_BY_UNIT_CLASS:
                 logging.warning(
                     f"Unused front line vehicle at base {unit_type}: unknown unit class"
                 )
                 continue
+            weights[unit_type] = count * ratio
+        deploy = allocate_largest_remainder(weights, limit)
 
-            available = (
-                self.cp.base.armor[unit_type] * ratio_of_frontline_units_to_reserves
+        # 2. Split each type's allocation into correctly-sized single-type groups,
+        #    bucketed by role. Wedges get 5-7 (small leftover absorbed); SHORAD/
+        #    ATGM/RECON get their fixed sizes.
+        buckets: dict[CombatGroupRole, list[CombatGroup]] = {}
+        for unit_type, n in deploy.items():
+            if n <= 0:
+                continue
+            role = _ROLE_BY_UNIT_CLASS[unit_type.unit_class]
+            for group in self._split_into_groups(role, unit_type, n):
+                buckets.setdefault(role, []).append(group)
+
+        # Order SHORAD so distinct types lead: the distinct-type attach pass in
+        # assemble_clusters handles the 2nd-per-cluster rule correctly when types
+        # are interleaved first.
+        if CombatGroupRole.SHORAD in buckets:
+            buckets[CombatGroupRole.SHORAD] = interleave_by_unit_type(
+                buckets[CombatGroupRole.SHORAD]
             )
-            if 0 < available < 1:
-                available = 1
 
-            # Round the number of units to an integer
-            if available > remaining_available_frontline_units:
-                available = remaining_available_frontline_units
-            available = round(available)
+        # 3. Assemble clusters (sets anchors on members).
+        clusters = assemble_clusters(buckets)
 
-            remaining_available_frontline_units -= available
+        # 4. Unclustered groups: artillery + logi (+ any role with no wedge).
+        clustered = {id(c.wedge) for c in clusters}
+        clustered |= {id(m) for c in clusters for m in c.members}
+        unclustered = [
+            g for gs in buckets.values() for g in gs if id(g) not in clustered
+        ]
 
-            while available > 0:
-                if len(self.connected_enemy_cp) > 0:
-                    enemy_cp: ControlPoint = random.choice(self.connected_enemy_cp)
-                    frontline_stance = self.cp.stances.get(enemy_cp.id)
-                    if not frontline_stance:
-                        logging.warning(
-                            f"{self.cp.name} lost its frontline stance for {enemy_cp.name}"
-                        )
-                        frontline_stance = CombatStance.DEFENSIVE
-                    group_size_choice = GROUP_SIZES_BY_COMBAT_STANCE[frontline_stance]
-                    if role == CombatGroupRole.SHORAD:
-                        count = 1
-                    else:
-                        choices = [s for s in group_size_choice if s <= available]
-                        if not choices:
-                            choices.append(1)
-                        count = random.choice(choices)
+        # 5. Distribute clusters + unclustered groups across enemy CPs.
+        if not self.connected_enemy_cp:
+            for c in clusters:
+                self.reserve.extend([c.wedge, *c.members])
+            self.reserve.extend(unclustered)
+            return
 
-                    available -= count
-                    group = CombatGroup(role, unit_type, count)
-                    self.units_per_cp[enemy_cp.id].append(group)
-                else:
-                    group = CombatGroup(role, unit_type, available)
-                    self.reserve.append(CombatGroup(role, unit_type, available))
-                collection.append(group)
+        for i, cluster in enumerate(clusters):
+            enemy_cp = self.connected_enemy_cp[i % len(self.connected_enemy_cp)]
+            self.units_per_cp[enemy_cp.id].extend([cluster.wedge, *cluster.members])
+        for i, group in enumerate(unclustered):
+            enemy_cp = self.connected_enemy_cp[i % len(self.connected_enemy_cp)]
+            self.units_per_cp[enemy_cp.id].append(group)
 
-            if remaining_available_frontline_units == 0:
-                break
+    def _split_into_groups(
+        self, role: CombatGroupRole, unit_type: GroundUnitType, n: int
+    ) -> list[CombatGroup]:
+        groups: list[CombatGroup] = []
+        if role in WEDGE_ROLES:
+            remaining = n
+            while remaining > 0:
+                size = min(remaining, random.randint(WEDGE_SIZE_MIN, WEDGE_SIZE_MAX))
+                # Absorb a tiny trailing leftover (1) into this wedge rather than
+                # spawning a lone vehicle.
+                if 0 < remaining - size < 2:
+                    size = remaining
+                groups.append(CombatGroup(role, unit_type, size))
+                remaining -= size
+        elif role in _FIXED_GROUP_SIZE_BY_ROLE:
+            groups = _fixed_size_groups(
+                role, unit_type, n, _FIXED_GROUP_SIZE_BY_ROLE[role]
+            )
+        else:  # ARTILLERY, LOGI: one group per type (current behaviour).
+            groups = [CombatGroup(role, unit_type, n)]
+        return groups

--- a/game/ground_forces/frontline_clustering.py
+++ b/game/ground_forces/frontline_clustering.py
@@ -1,0 +1,48 @@
+"""Pure, game-object-free helpers for frontline cluster planning.
+
+Kept dependency-free (no imports from game.*) so the planner can import these
+without a circular dependency and so they are trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def allocate_largest_remainder(weights: dict[T, float], total: int) -> dict[T, int]:
+    """Distribute integer units across keys proportional to ``weights``.
+
+    Allocates ``min(total, round(sum(weights)))`` units. Each key gets the floor
+    of its proportional share; the leftover units go to the keys with the largest
+    fractional remainders. Guarantees the returned counts sum to the target.
+    """
+    if not weights:
+        return {}
+    weight_sum = sum(weights.values())
+    if weight_sum <= 0:
+        return {key: 0 for key in weights}
+    target = min(total, round(weight_sum))
+    if target <= 0:
+        return {key: 0 for key in weights}
+
+    exact = {key: value / weight_sum * target for key, value in weights.items()}
+    floored = {key: math.floor(value) for key, value in exact.items()}
+    remainder = target - sum(floored.values())
+    # Hand out the remaining units to the largest fractional parts first.
+    by_frac = sorted(
+        exact, key=lambda k: (exact[k] - floored[k], weights[k]), reverse=True
+    )
+    for key in by_frac[:remainder]:
+        floored[key] += 1
+    return floored
+
+
+def even_slot_centers(count: int, size: int) -> list[float]:
+    """Return ``count`` evenly-spaced centers across the segment ``[0, size]``."""
+    if count <= 0:
+        return []
+    step = size / count
+    return [(i + 0.5) * step for i in range(count)]

--- a/game/missiongenerator/flotgenerator.py
+++ b/game/missiongenerator/flotgenerator.py
@@ -33,10 +33,13 @@ from game.data.units import UnitClass
 from game.dcs.aircrafttype import AircraftType
 from game.dcs.groundunittype import GroundUnitType
 from game.ground_forces.ai_ground_planner import (
+    CLUSTER_DEPTH_OFFSET,
     CombatGroup,
     CombatGroupRole,
     DISTANCE_FROM_FRONTLINE,
+    WEDGE_ROLES,
 )
+from game.ground_forces.frontline_clustering import even_slot_centers
 from game.ground_forces.combat_stance import CombatStance
 from game.naming import namegen
 from game.radio.radios import RadioRegistry
@@ -52,9 +55,6 @@ from ..ato import FlightType
 if TYPE_CHECKING:
     from game import Game
 
-SPREAD_DISTANCE_FACTOR = 0.1, 0.3
-SPREAD_DISTANCE_SIZE_FACTOR = 0.1
-
 FRONTLINE_CAS_FIGHTS_COUNT = 16, 24
 FRONTLINE_CAS_GROUP_MIN = 1, 2
 FRONTLINE_CAS_PADDING = 12000
@@ -68,6 +68,34 @@ FIGHT_DISTANCE = 3500
 RANDOM_OFFSET_ATTACK = 250
 
 INFANTRY_GROUP_SIZE = 5
+INFANTRY_FORWARD_OFFSET = 400
+INFANTRY_SCATTER_RADIUS = 150
+
+# Maximum lateral (along-frontline) jitter applied to a wedge and all its cluster
+# members.  Members share their anchor's jitter so the cluster stays laterally
+# aligned; each independent group gets its own random value in [-JITTER, JITTER].
+CLUSTER_LATERAL_JITTER = 150
+
+
+def frontline_offsets(groups: list[CombatGroup], size: int) -> dict[int, float]:
+    """Along-front offset (metres from one end) for each group.
+
+    Armor wedges are spread evenly across the front. Each clustered member shares
+    its anchor wedge's offset (so the cluster stays together). Unclustered groups
+    (artillery/logi, or members whose cluster has no wedge) are spread across
+    their own even slots.
+    """
+    wedges = [g for g in groups if g.anchor is None and g.role in WEDGE_ROLES]
+    offsets: dict[int, float] = {}
+    for wedge, center in zip(wedges, even_slot_centers(len(wedges), size)):
+        offsets[id(wedge)] = center
+    for g in groups:
+        if g.anchor is not None and id(g.anchor) in offsets:
+            offsets[id(g)] = offsets[id(g.anchor)]
+    leftover = [g for g in groups if id(g) not in offsets]
+    for g, center in zip(leftover, even_slot_centers(len(leftover), size)):
+        offsets[id(g)] = center
+    return offsets
 
 
 class FlotGenerator:
@@ -221,8 +249,12 @@ class FlotGenerator:
         side: Country,
         forward_heading: Heading,
     ) -> None:
+        # Lead the wedge: seed the infantry ~400m toward the enemy, then scatter.
+        in_front = group.points[0].position.point_from_heading(
+            forward_heading.degrees, INFANTRY_FORWARD_OFFSET
+        )
         infantry_position = self.conflict.find_ground_position(
-            group.points[0].position.random_point_within(250, 50),
+            in_front.random_point_within(INFANTRY_SCATTER_RADIUS, 50),
             500,
             forward_heading,
             self.conflict.theater,
@@ -745,13 +777,13 @@ class FlotGenerator:
         return rg
 
     def get_valid_position_for_group(
-        self, distance_from_frontline: int, spawn_heading: Heading
+        self, distance_from_frontline: int, spawn_heading: Heading, along_offset: float
     ) -> Point:
         assert self.conflict.heading is not None
         assert self.conflict.size is not None
+        clamped = max(0, min(int(along_offset), self.conflict.size))
         shifted = self.conflict.position.point_from_heading(
-            self.conflict.heading.degrees,
-            random.randint(0, self.conflict.size),
+            self.conflict.heading.degrees, clamped
         )
         desired_point = shifted.point_from_heading(
             spawn_heading.degrees, distance_from_frontline
@@ -766,9 +798,10 @@ class FlotGenerator:
     def _generate_groups(
         self, groups: list[CombatGroup], is_player: Player
     ) -> List[Tuple[VehicleGroup, CombatGroup]]:
-        """Finds valid positions for planned groups and generates a pydcs group for them"""
+        """Finds valid positions for planned groups and generates a pydcs group."""
         positioned_groups = []
         assert self.conflict.heading is not None
+        assert self.conflict.size is not None
         spawn_heading = (
             self.conflict.heading.left
             if is_player.is_blue
@@ -776,19 +809,49 @@ class FlotGenerator:
         )
         country = self.game.coalition_for(is_player).faction.country
         country = self.mission.country(country.name)
+
+        along = frontline_offsets(groups, self.conflict.size)
+
+        # Pass 1: pre-compute depth and lateral jitter for every wedge.
+        # This removes the implicit ordering dependency: members no longer need to
+        # follow their anchor wedge in the list.
+        wedge_depth: dict[int, int] = {}
+        wedge_jitter: dict[int, int] = {}
+        for wg in groups:
+            if wg.anchor is None and wg.role in WEDGE_ROLES:
+                wedge_depth[id(wg)] = random.randint(
+                    DISTANCE_FROM_FRONTLINE[wg.role][0],
+                    DISTANCE_FROM_FRONTLINE[wg.role][1],
+                )
+                wedge_jitter[id(wg)] = random.randint(
+                    -CLUSTER_LATERAL_JITTER, CLUSTER_LATERAL_JITTER
+                )
+
+        # Pass 2: place every group using the pre-computed values where available.
         for group in groups:
             if group.role == CombatGroupRole.ARTILLERY:
-                distance_from_frontline = (
-                    self.get_artilery_group_distance_from_frontline(group)
+                depth = self.get_artilery_group_distance_from_frontline(group)
+                jitter = random.randint(-CLUSTER_LATERAL_JITTER, CLUSTER_LATERAL_JITTER)
+            elif group.anchor is not None and id(group.anchor) in wedge_depth:
+                # Cluster member: share anchor's depth+offset and lateral jitter.
+                depth = wedge_depth[id(group.anchor)] + CLUSTER_DEPTH_OFFSET.get(
+                    group.role, 0
                 )
+                jitter = wedge_jitter[id(group.anchor)]
+            elif id(group) in wedge_depth:
+                # Wedge: use its pre-computed depth and jitter.
+                depth = wedge_depth[id(group)]
+                jitter = wedge_jitter[id(group)]
             else:
-                distance_from_frontline = random.randint(
+                # Unclustered/orphan group.
+                depth = random.randint(
                     DISTANCE_FROM_FRONTLINE[group.role][0],
                     DISTANCE_FROM_FRONTLINE[group.role][1],
                 )
+                jitter = random.randint(-CLUSTER_LATERAL_JITTER, CLUSTER_LATERAL_JITTER)
 
             final_position = self.get_valid_position_for_group(
-                distance_from_frontline, spawn_heading
+                depth, spawn_heading, along_offset=along[id(group)] + jitter
             )
 
             g = self._generate_group(
@@ -807,10 +870,7 @@ class FlotGenerator:
 
             if group.role in [CombatGroupRole.APC, CombatGroupRole.IFV]:
                 self.gen_infantry_group_for_group(
-                    g,
-                    is_player,
-                    country,
-                    spawn_heading.opposite,
+                    g, is_player, country, spawn_heading.opposite
                 )
 
         return positioned_groups

--- a/game/missiongenerator/flotgenerator.py
+++ b/game/missiongenerator/flotgenerator.py
@@ -98,6 +98,40 @@ def frontline_offsets(groups: list[CombatGroup], size: int) -> dict[int, float]:
     return offsets
 
 
+def follower_advance_distance(stance: CombatStance) -> Optional[int]:
+    """Metres an anchored cluster member advances toward the enemy for ``stance``.
+
+    Mirrors the armor wedge's per-stance push so the whole cluster keeps its
+    shape: every member advances the *same* distance from its own (already
+    offset, per Spec A) spawn, so recon stays ahead and SHORAD/ATGM stay behind.
+    ``None`` means add no advance waypoint — DEFENSIVE/AMBUSH hold in place, and
+    RETREAT is handled by the universal fallback block in plan_action_for_groups.
+    """
+    if stance in (CombatStance.AGGRESSIVE, CombatStance.ELIMINATION):
+        return AGGRESIVE_MOVE_DISTANCE
+    if stance == CombatStance.BREAKTHROUGH:
+        return BREAKTHROUGH_OFFENSIVE_DISTANCE
+    return None
+
+
+_MOVE_FORMATION_BY_ROLE: dict[CombatGroupRole, PointAction] = {
+    # Armor wedge (TANK/IFV/APC) advances in a Vee — pydcs has no "wedge".
+    CombatGroupRole.TANK: PointAction.Vee,
+    CombatGroupRole.IFV: PointAction.Vee,
+    CombatGroupRole.APC: PointAction.Vee,
+    # ATGM standoff pair spreads into a line (pydcs LineAbreast == DCS "Rank").
+    CombatGroupRole.ATGM: PointAction.LineAbreast,
+}
+
+
+def move_formation_for_role(role: CombatGroupRole) -> Optional[PointAction]:
+    """``move_formation`` for a combat group's role, or ``None`` to keep the
+    ``vehicle_group`` default (``OffRoad``). Recon scatters off-road, single-unit
+    SHORAD needs no formation, and artillery/logi are unchanged.
+    """
+    return _MOVE_FORMATION_BY_ROLE.get(role)
+
+
 class FlotGenerator:
     def __init__(
         self,
@@ -563,6 +597,46 @@ class FlotGenerator:
             return True
         return False
 
+    def _plan_follower_action(
+        self,
+        stance: CombatStance,
+        dcs_group: VehicleGroup,
+        forward_heading: Heading,
+        to_cp: ControlPoint,
+    ) -> bool:
+        """Tasks an anchored cluster member (recon leading, SHORAD/ATGM trailing)
+        to maneuver with its wedge: advance the wedge's per-stance distance from
+        this group's own offset position, preserving lead/trail spacing.
+
+        Returns True if tasking was added; False for RETREAT, where the universal
+        fallback block in plan_action_for_groups adds the retreat waypoints (so we
+        must NOT double-add them or attach a morale trigger here).
+        """
+        duration = timedelta()
+        if stance in [CombatStance.DEFENSIVE, CombatStance.AGGRESSIVE]:
+            duration = self._earliest_tot_on_flot(to_cp.coalition.player.opponent)
+        self._set_reform_waypoint(dcs_group, forward_heading, duration)
+
+        distance = follower_advance_distance(stance)
+        if distance is not None:
+            if (
+                to_cp.position.distance_to_point(dcs_group.points[0].position)
+                <= distance
+            ):
+                attack_point = self.conflict.theater.nearest_land_pos(
+                    to_cp.position.random_point_within(500, 0)
+                )
+            else:
+                attack_point = self.find_offensive_point(
+                    dcs_group, forward_heading, distance
+                )
+            dcs_group.add_waypoint(attack_point, self.wpt_pointaction)
+
+        if stance != CombatStance.RETREAT:
+            self.add_morale_trigger(dcs_group, forward_heading)
+            return True
+        return False
+
     def plan_action_for_groups(
         self,
         stance: CombatStance,
@@ -586,13 +660,36 @@ class FlotGenerator:
                             stance, group, dcs_group, forward_heading, target
                         )
 
-            elif group.role in [CombatGroupRole.TANK, CombatGroupRole.IFV]:
+            # APC is part of the armor wedge (Spec A WEDGE_ROLES), so it maneuvers
+            # as a wedge core — advance + attack at the full per-stance distance,
+            # not the old soft-follow cap, so an APC-type wedge stays cohesive with
+            # its TANK/IFV peers and its own followers (which advance 35 km in
+            # BREAKTHROUGH).
+            elif group.role in [
+                CombatGroupRole.TANK,
+                CombatGroupRole.IFV,
+                CombatGroupRole.APC,
+            ]:
                 self._plan_tank_ifv_action(
                     stance, enemy_groups, dcs_group, forward_heading, to_cp
                 )
 
-            elif group.role in [CombatGroupRole.APC, CombatGroupRole.ATGM]:
-                self._plan_apc_atgm_action(stance, dcs_group, forward_heading, to_cp)
+            elif group.role in [
+                CombatGroupRole.ATGM,
+                CombatGroupRole.SHORAD,
+                CombatGroupRole.RECON,
+            ]:
+                if group.anchor is not None:
+                    # Clustered: maneuver with the wedge.
+                    self._plan_follower_action(
+                        stance, dcs_group, forward_heading, to_cp
+                    )
+                else:
+                    # Unanchored spare: fall back to today's generic per-stance
+                    # advance (16 km soft-follow), per the spec's fallback decision.
+                    self._plan_apc_atgm_action(
+                        stance, dcs_group, forward_heading, to_cp
+                    )
 
             if stance == CombatStance.RETREAT:
                 # In retreat mode, the units will fall back
@@ -861,6 +958,9 @@ class FlotGenerator:
                 group.size,
                 final_position,
                 heading=spawn_heading.opposite,
+                # None (recon/SHORAD/arty/logi) keeps the OffRoad default.
+                move_formation=move_formation_for_role(group.role)
+                or PointAction.OffRoad,
             )
             if is_player == Player.BLUE:
                 g.set_skill(Skill(self.game.settings.player_skill))
@@ -883,6 +983,7 @@ class FlotGenerator:
         count: int,
         at: Point,
         heading: Heading,
+        move_formation: PointAction = PointAction.OffRoad,
     ) -> VehicleGroup:
         cp = self.conflict.front_line.control_point_friendly_to(player)
         faction = self.game.faction_for(player)
@@ -894,6 +995,7 @@ class FlotGenerator:
             position=at,
             group_size=count,
             heading=heading.degrees,
+            move_formation=move_formation,
         )
         group.hidden_on_mfd = True
         if self.game.settings.perf_red_alert_state:

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -14,6 +14,7 @@ from .minutesoption import minutes_option
 from .optiondescription import OptionDescription, SETTING_DESCRIPTION_KEY
 from .skilloption import skill_option
 from ..ato.starttype import StartType
+from ..ground_forces.combat_stance import CombatStance
 
 Views = ForcedOptions.Views
 
@@ -721,6 +722,25 @@ class Settings:
         CAMPAIGN_MANAGEMENT_PAGE,
         HQ_AUTOMATION_SECTION,
         default=True,
+    )
+    default_front_line_stance: CombatStance = choices_option(
+        "Default front line stance",
+        CAMPAIGN_MANAGEMENT_PAGE,
+        HQ_AUTOMATION_SECTION,
+        # RETREAT is intentionally omitted -- never a sensible standing default.
+        choices={
+            "Aggressive": CombatStance.AGGRESSIVE,
+            "Defensive": CombatStance.DEFENSIVE,
+            "Ambush": CombatStance.AMBUSH,
+            "Elimination": CombatStance.ELIMINATION,
+            "Breakthrough": CombatStance.BREAKTHROUGH,
+        },
+        default=CombatStance.AGGRESSIVE,
+        detail=(
+            "Starting stance for your front lines at campaign start and after a "
+            "capture. Only applies when 'Automatically manage front line stances' "
+            "is off; otherwise the AI commander chooses the stance."
+        ),
     )
     auto_procurement_balance: int = bounded_int_option(
         "AI ground unit procurement budget ratio (%) for OWNFOR",

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -786,6 +786,28 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
         self.convoy_routes[to] = tuple(waypoints)
         self.convoy_spawns[to] = tuple(spawns)
 
+    def seed_front_line_stances(self, stance: CombatStance) -> None:
+        """Overwrite every per-neighbor stance with ``stance``.
+
+        Used to apply the configured default front-line stance. Inert for
+        neighbors with no active front line; their entries are re-seeded on a
+        future capture if they become enemies.
+        """
+        for connected_id in self.stances:
+            self.stances[connected_id] = stance
+
+    def apply_default_stance_on_capture(self, game: Game, for_player: Player) -> None:
+        """Seed this control point's stances with the configured default when the
+        player captures it and automatic stance management is off.
+
+        The enemy commander always manages its own stances, and with auto
+        management on it manages the player's too -- in both cases seeding would
+        lock the stance at >= the seed. So only a player capture with auto off
+        applies the default.
+        """
+        if for_player.is_blue and not game.settings.automate_front_line_stance:
+            self.seed_front_line_stances(game.settings.default_front_line_stance)
+
     def create_shipping_lane(
         self, to: ControlPoint, waypoints: Iterable[Point]
     ) -> None:
@@ -1042,6 +1064,7 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
         self.base.set_strength_to_minimum()
         self._clear_front_lines(events)
         self._create_missing_front_lines(game.laser_code_registry, events)
+        self.apply_default_stance_on_capture(game, for_player)
         events.update_control_point(self)
 
         # All the attached TGOs have either been depopulated or captured. Tell the UI to

--- a/game/theater/start_generator.py
+++ b/game/theater/start_generator.py
@@ -125,6 +125,17 @@ class ModSettings:
     VSN_F35: bool = False
 
 
+def apply_default_player_stances(theater: ConflictTheater, settings: Settings) -> None:
+    """Seed the configured default stance for player control points at new-game
+    time. Only applies when automatic stance management is off; the enemy and
+    auto-managed player stances are left to the commander (see ControlPoint.
+    apply_default_stance_on_capture)."""
+    if settings.automate_front_line_stance:
+        return
+    for control_point in theater.player_points():
+        control_point.seed_front_line_stances(settings.default_front_line_stance)
+
+
 class GameGenerator:
     def __init__(
         self,
@@ -165,6 +176,9 @@ class GameGenerator:
                 campaign_name=self.campaign_name,
             )
 
+            # Coalitions are wired by Game.__init__ (finish_init), so cp.captured
+            # is valid here. Runs only for new games -- never on save load.
+            apply_default_player_stances(self.theater, self.settings)
             GroundObjectGenerator(game, self.generator_settings).generate()
         game.settings.version = VERSION
         return game

--- a/tests/ground_forces/test_ai_ground_planner.py
+++ b/tests/ground_forces/test_ai_ground_planner.py
@@ -30,6 +30,32 @@ def test_combat_group_anchor_settable() -> None:
     assert shorad.anchor is wedge
 
 
+def test_combat_group_setstate_backfills_anchor_for_old_saves() -> None:
+    # Saves predating dr-588t have no ``anchor`` in their pickled state; pickle
+    # skips ``__init__`` so __setstate__ must backfill the default.
+    unit_type = MagicMock(spec=GroundUnitType)
+    group = CombatGroup(CombatGroupRole.TANK, unit_type, 5)
+    old_state = dict(group.__dict__)
+    del old_state["anchor"]
+
+    restored = CombatGroup.__new__(CombatGroup)
+    restored.__setstate__(old_state)
+
+    assert restored.anchor is None
+
+
+def test_combat_group_setstate_preserves_existing_anchor() -> None:
+    unit_type = MagicMock(spec=GroundUnitType)
+    wedge = CombatGroup(CombatGroupRole.TANK, unit_type, 5)
+    member = CombatGroup(CombatGroupRole.SHORAD, unit_type, 1)
+    member.anchor = wedge
+
+    restored = CombatGroup.__new__(CombatGroup)
+    restored.__setstate__(dict(member.__dict__))
+
+    assert restored.anchor is wedge
+
+
 def _grp(role: CombatGroupRole, size: int) -> CombatGroup:
     return CombatGroup(role, MagicMock(spec=GroundUnitType), size)
 

--- a/tests/ground_forces/test_ai_ground_planner.py
+++ b/tests/ground_forces/test_ai_ground_planner.py
@@ -1,0 +1,264 @@
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from game.data.units import UnitClass
+from game.dcs.groundunittype import GroundUnitType
+from game.ground_forces.ai_ground_planner import CombatGroup, CombatGroupRole
+from game.ground_forces.ai_ground_planner import (
+    Cluster,
+    CLUSTER_DEPTH_OFFSET,
+    WEDGE_ROLES,
+    assemble_clusters,
+    interleave_by_unit_type,
+    GroundPlanner,
+)
+
+
+def test_combat_group_anchor_defaults_to_none() -> None:
+    unit_type = MagicMock(spec=GroundUnitType)
+    group = CombatGroup(CombatGroupRole.TANK, unit_type, 5)
+    assert group.anchor is None
+
+
+def test_combat_group_anchor_settable() -> None:
+    unit_type = MagicMock(spec=GroundUnitType)
+    wedge = CombatGroup(CombatGroupRole.TANK, unit_type, 5)
+    shorad = CombatGroup(CombatGroupRole.SHORAD, unit_type, 1)
+    shorad.anchor = wedge
+    assert shorad.anchor is wedge
+
+
+def _grp(role: CombatGroupRole, size: int) -> CombatGroup:
+    return CombatGroup(role, MagicMock(spec=GroundUnitType), size)
+
+
+def test_assemble_attaches_members_and_sets_anchor() -> None:
+    wedge = _grp(CombatGroupRole.TANK, 6)
+    shorad = _grp(CombatGroupRole.SHORAD, 1)
+    atgm = _grp(CombatGroupRole.ATGM, 2)
+    clusters = assemble_clusters(
+        {
+            CombatGroupRole.TANK: [wedge],
+            CombatGroupRole.SHORAD: [shorad],
+            CombatGroupRole.ATGM: [atgm],
+        }
+    )
+    assert len(clusters) == 1
+    assert clusters[0].wedge is wedge
+    assert shorad in clusters[0].members
+    assert atgm in clusters[0].members
+    assert shorad.anchor is wedge
+    assert atgm.anchor is wedge
+    assert wedge.anchor is None
+
+
+def test_assemble_armor_only_when_no_members() -> None:
+    wedge = _grp(CombatGroupRole.IFV, 5)
+    clusters = assemble_clusters({CombatGroupRole.IFV: [wedge]})
+    assert len(clusters) == 1
+    assert clusters[0].members == []
+
+
+def test_assemble_distributes_spares_round_robin() -> None:
+    w1 = _grp(CombatGroupRole.TANK, 6)
+    w2 = _grp(CombatGroupRole.TANK, 6)
+    s1 = _grp(CombatGroupRole.SHORAD, 1)
+    s2 = _grp(CombatGroupRole.SHORAD, 1)
+    s3 = _grp(CombatGroupRole.SHORAD, 1)
+    clusters = assemble_clusters(
+        {CombatGroupRole.TANK: [w1, w2], CombatGroupRole.SHORAD: [s1, s2, s3]}
+    )
+    assert len(clusters) == 2
+    # _grp() creates a fresh MagicMock unit_type each call, so all 3 SHORAD are
+    # distinct types and all 3 attach via the distinct-type path (2 clusters × ≥1
+    # SHORAD each, with the 3rd placed on whichever cluster the round-robin picks).
+    total_shorad = sum(len(c.members) for c in clusters)
+    assert total_shorad == 3
+    assert all(m.anchor in (w1, w2) for c in clusters for m in c.members)
+
+
+def test_assemble_no_wedges_returns_empty() -> None:
+    clusters = assemble_clusters(
+        {CombatGroupRole.SHORAD: [_grp(CombatGroupRole.SHORAD, 1)]}
+    )
+    assert clusters == []
+
+
+def test_cluster_depth_offsets_signs() -> None:
+    assert CLUSTER_DEPTH_OFFSET[CombatGroupRole.RECON] < 0  # in front
+    assert CLUSTER_DEPTH_OFFSET[CombatGroupRole.SHORAD] > 0  # behind
+    assert (
+        CLUSTER_DEPTH_OFFSET[CombatGroupRole.ATGM]
+        > CLUSTER_DEPTH_OFFSET[CombatGroupRole.SHORAD]
+    )  # further behind
+    assert CombatGroupRole.TANK in WEDGE_ROLES
+
+
+# ---------------------------------------------------------------------------
+# plan_groundwar cluster tests (Task 5)
+# ---------------------------------------------------------------------------
+
+
+def _unit(unit_class: UnitClass) -> MagicMock:
+    ut = MagicMock(spec=GroundUnitType)
+    ut.unit_class = unit_class
+    return ut
+
+
+def _planner_with(armor: dict[MagicMock, int], limit: int) -> tuple[GroundPlanner, Any]:
+    enemy = SimpleNamespace(id=uuid4(), captured=SimpleNamespace())
+    cp = SimpleNamespace(
+        captured=SimpleNamespace(),
+        connected_points=[enemy],
+        frontline_unit_count_limit=limit,
+        base=SimpleNamespace(armor=armor, total_armor=sum(armor.values())),
+        stances={},
+    )
+    # connected_enemy_cp filter compares captured identity; make them differ.
+    cp.captured = object()
+    enemy.captured = object()
+    planner = GroundPlanner.__new__(GroundPlanner)
+    planner.cp = cp  # type: ignore[assignment]
+    planner.game = MagicMock()
+    planner.connected_enemy_cp = [enemy]  # type: ignore[list-item]
+    planner.units_per_cp = {enemy.id: []}
+    planner.reserve = []
+    return planner, enemy
+
+
+def test_plan_groundwar_builds_clusters_with_anchors() -> None:
+    tank = _unit(UnitClass.TANK)
+    shorad = _unit(UnitClass.SHORAD)
+    planner, enemy = _planner_with({tank: 12, shorad: 3}, limit=15)
+    planner.plan_groundwar()
+    groups = planner.units_per_cp[enemy.id]
+    wedges = [g for g in groups if g.role in WEDGE_ROLES]
+    shorads = [g for g in groups if g.role == CombatGroupRole.SHORAD]
+    assert wedges, "expected at least one armor wedge"
+    assert all(2 <= w.size <= 7 for w in wedges)
+    # Anchored SHORADs must point to a real wedge; unattached ones (same-type
+    # extras per the distinct-type rule) are valid with anchor=None.
+    assert all(s.anchor in wedges or s.anchor is None for s in shorads)
+
+
+def test_plan_groundwar_respects_cap() -> None:
+    tank = _unit(UnitClass.TANK)
+    planner, enemy = _planner_with({tank: 100}, limit=15)
+    planner.plan_groundwar()
+    deployed = sum(g.size for g in planner.units_per_cp[enemy.id])
+    assert deployed <= 15
+
+
+# ---------------------------------------------------------------------------
+# I2 — adjacent clusters alternate armor type
+# ---------------------------------------------------------------------------
+
+
+def _grp_typed(
+    role: CombatGroupRole, unit_type: GroundUnitType, size: int
+) -> CombatGroup:
+    return CombatGroup(role, unit_type, size)
+
+
+def test_assemble_clusters_alternates_armor_types() -> None:
+    """Adjacent clusters must not all share one armor type when two types present."""
+    type_a = MagicMock(spec=GroundUnitType)
+    type_b = MagicMock(spec=GroundUnitType)
+    # 3 wedges of type A, 3 of type B — without interleaving they'd be AAABBB
+    wedges_a = [_grp_typed(CombatGroupRole.TANK, type_a, 5) for _ in range(3)]
+    wedges_b = [_grp_typed(CombatGroupRole.TANK, type_b, 5) for _ in range(3)]
+    clusters = assemble_clusters({CombatGroupRole.TANK: wedges_a + wedges_b})
+    assert len(clusters) == 6
+    types_in_order = [c.wedge.unit_type for c in clusters]
+    # Must not be all type_a first then all type_b (i.e. not [A,A,A,B,B,B]).
+    # Round-robin interleave gives [A,B,A,B,A,B]; assert no run of 3+ same type.
+    runs = 1
+    for i in range(1, len(types_in_order)):
+        if types_in_order[i] == types_in_order[i - 1]:
+            runs += 1
+            assert (
+                runs < 3
+            ), f"Got a run of same armor type >= 3 at position {i}: {types_in_order}"
+        else:
+            runs = 1
+
+
+def test_interleave_by_unit_type_is_module_level() -> None:
+    """interleave_by_unit_type must be importable at module level."""
+    type_a = MagicMock(spec=GroundUnitType)
+    type_b = MagicMock(spec=GroundUnitType)
+    groups = [
+        _grp_typed(CombatGroupRole.SHORAD, type_a, 1),
+        _grp_typed(CombatGroupRole.SHORAD, type_a, 1),
+        _grp_typed(CombatGroupRole.SHORAD, type_b, 1),
+    ]
+    result = interleave_by_unit_type(groups)
+    # First two should not both be type_a (interleaved: A, B, A)
+    assert (
+        result[0].unit_type != result[1].unit_type
+        or result[1].unit_type != result[2].unit_type
+    )
+
+
+# ---------------------------------------------------------------------------
+# I1 — SHORAD 2nd-per-cluster only if DISTINCT type
+# ---------------------------------------------------------------------------
+
+
+def test_assemble_same_type_shorad_leaves_3rd_unattached() -> None:
+    """2 clusters + 3 same-type SHORAD → each cluster ≤1 SHORAD; 3rd unattached."""
+    w1 = _grp(CombatGroupRole.TANK, 6)
+    w2 = _grp(CombatGroupRole.TANK, 6)
+    # All three SHORAD are the same unit_type (same MagicMock identity via _grp)
+    s1 = _grp(CombatGroupRole.SHORAD, 1)
+    s2 = _grp(CombatGroupRole.SHORAD, 1)
+    s3 = _grp(CombatGroupRole.SHORAD, 1)
+    # All _grp() calls use a fresh MagicMock — make them explicitly same type.
+    shared_type = MagicMock(spec=GroundUnitType)
+    s1.unit_type = shared_type
+    s2.unit_type = shared_type
+    s3.unit_type = shared_type
+
+    buckets = {
+        CombatGroupRole.TANK: [w1, w2],
+        CombatGroupRole.SHORAD: [s1, s2, s3],
+    }
+    clusters = assemble_clusters(buckets)
+    assert len(clusters) == 2
+    # Each cluster must have at most 1 SHORAD member.
+    for c in clusters:
+        shorad_members = [m for m in c.members if m.role == CombatGroupRole.SHORAD]
+        assert (
+            len(shorad_members) <= 1
+        ), f"Cluster got {len(shorad_members)} same-type SHORAD, expected ≤1"
+    # The 3rd SHORAD must remain unattached (anchor is None).
+    all_anchored_ids = {id(m) for c in clusters for m in c.members}
+    unattached_shorad = [g for g in [s1, s2, s3] if id(g) not in all_anchored_ids]
+    assert (
+        len(unattached_shorad) == 1
+    ), f"Expected 1 unattached SHORAD, got {len(unattached_shorad)}"
+    assert unattached_shorad[0].anchor is None
+
+
+def test_assemble_distinct_type_shorad_both_attached() -> None:
+    """1 cluster + 2 SHORAD of distinct types → cluster gets both."""
+    wedge = _grp(CombatGroupRole.TANK, 6)
+    type_a = MagicMock(spec=GroundUnitType)
+    type_b = MagicMock(spec=GroundUnitType)
+    sa = CombatGroup(CombatGroupRole.SHORAD, type_a, 1)
+    sb = CombatGroup(CombatGroupRole.SHORAD, type_b, 1)
+
+    clusters = assemble_clusters(
+        {CombatGroupRole.TANK: [wedge], CombatGroupRole.SHORAD: [sa, sb]}
+    )
+    assert len(clusters) == 1
+    shorad_members = [
+        m for m in clusters[0].members if m.role == CombatGroupRole.SHORAD
+    ]
+    assert (
+        len(shorad_members) == 2
+    ), f"Expected 2 distinct-type SHORAD in cluster, got {len(shorad_members)}"
+    assert sa.anchor is wedge
+    assert sb.anchor is wedge

--- a/tests/ground_forces/test_frontline_clustering.py
+++ b/tests/ground_forces/test_frontline_clustering.py
@@ -1,0 +1,44 @@
+from game.ground_forces.frontline_clustering import (
+    allocate_largest_remainder,
+    even_slot_centers,
+)
+
+
+def test_allocate_proportional_even_split() -> None:
+    # 10 Abrams + 10 Linebackers, deployable target 15 -> ~even, not 10/5.
+    result = allocate_largest_remainder({"abrams": 7.5, "linebacker": 7.5}, 15)
+    assert sum(result.values()) == 15
+    assert abs(result["abrams"] - result["linebacker"]) <= 1
+
+
+def test_allocate_caps_total() -> None:
+    result = allocate_largest_remainder({"a": 100.0, "b": 100.0}, 15)
+    assert sum(result.values()) == 15
+
+
+def test_allocate_under_target_deploys_all() -> None:
+    # sum(weights) rounds to 8 < cap 15 -> deploy 8.
+    result = allocate_largest_remainder({"a": 4.0, "b": 4.0}, 15)
+    assert sum(result.values()) == 8
+
+
+def test_allocate_largest_remainder_distribution() -> None:
+    # 3 units across weights 1:1:1 -> 1 each.
+    result = allocate_largest_remainder({"a": 1.0, "b": 1.0, "c": 1.0}, 3)
+    assert result == {"a": 1, "b": 1, "c": 1}
+
+
+def test_allocate_empty() -> None:
+    assert allocate_largest_remainder({}, 10) == {}
+
+
+def test_even_slot_centers_basic() -> None:
+    assert even_slot_centers(2, 1000) == [250.0, 750.0]
+
+
+def test_even_slot_centers_single() -> None:
+    assert even_slot_centers(1, 1000) == [500.0]
+
+
+def test_even_slot_centers_zero() -> None:
+    assert even_slot_centers(0, 1000) == []

--- a/tests/missiongenerator/test_flotgenerator_movement.py
+++ b/tests/missiongenerator/test_flotgenerator_movement.py
@@ -1,0 +1,56 @@
+from dcs.point import PointAction
+
+from game.ground_forces.ai_ground_planner import CombatGroupRole
+from game.ground_forces.combat_stance import CombatStance
+from game.missiongenerator.flotgenerator import (
+    AGGRESIVE_MOVE_DISTANCE,
+    BREAKTHROUGH_OFFENSIVE_DISTANCE,
+    follower_advance_distance,
+    move_formation_for_role,
+)
+
+
+def test_aggressive_and_elimination_advance_the_wedge_distance() -> None:
+    # Anchored members keep up with an attacking/advancing wedge.
+    assert follower_advance_distance(CombatStance.AGGRESSIVE) == AGGRESIVE_MOVE_DISTANCE
+    assert (
+        follower_advance_distance(CombatStance.ELIMINATION) == AGGRESIVE_MOVE_DISTANCE
+    )
+
+
+def test_breakthrough_advances_the_full_breakthrough_distance() -> None:
+    # Must match the wedge's 35 km push or the cluster splits apart.
+    assert (
+        follower_advance_distance(CombatStance.BREAKTHROUGH)
+        == BREAKTHROUGH_OFFENSIVE_DISTANCE
+    )
+
+
+def test_hold_and_static_stances_produce_no_advance() -> None:
+    # DEFENSIVE/AMBUSH hold in place; RETREAT is handled by the universal
+    # fallback block in plan_action_for_groups, not here.
+    assert follower_advance_distance(CombatStance.DEFENSIVE) is None
+    assert follower_advance_distance(CombatStance.AMBUSH) is None
+    assert follower_advance_distance(CombatStance.RETREAT) is None
+
+
+def test_armor_wedge_roles_get_vee() -> None:
+    for role in (CombatGroupRole.TANK, CombatGroupRole.IFV, CombatGroupRole.APC):
+        assert move_formation_for_role(role) == PointAction.Vee
+
+
+def test_atgm_gets_line_abreast() -> None:
+    # pydcs LineAbreast serialises to the DCS "Rank" formation.
+    assert move_formation_for_role(CombatGroupRole.ATGM) == PointAction.LineAbreast
+
+
+def test_other_roles_keep_the_default() -> None:
+    # None => caller leaves the vehicle_group OffRoad default (recon scatter,
+    # single-unit SHORAD, artillery, logi).
+    for role in (
+        CombatGroupRole.RECON,
+        CombatGroupRole.SHORAD,
+        CombatGroupRole.ARTILLERY,
+        CombatGroupRole.LOGI,
+    ):
+        assert move_formation_for_role(role) is None

--- a/tests/missiongenerator/test_flotgenerator_placement.py
+++ b/tests/missiongenerator/test_flotgenerator_placement.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+
+from game.dcs.groundunittype import GroundUnitType
+from game.ground_forces.ai_ground_planner import CombatGroup, CombatGroupRole
+from game.missiongenerator.flotgenerator import frontline_offsets
+
+
+def _grp(role: CombatGroupRole) -> CombatGroup:
+    return CombatGroup(role, MagicMock(spec=GroundUnitType), 1)
+
+
+def test_wedges_evenly_spaced() -> None:
+    w1 = _grp(CombatGroupRole.TANK)
+    w2 = _grp(CombatGroupRole.TANK)
+    offsets = frontline_offsets([w1, w2], 1000)
+    assert offsets[id(w1)] == 250.0
+    assert offsets[id(w2)] == 750.0
+
+
+def test_member_shares_anchor_offset() -> None:
+    wedge = _grp(CombatGroupRole.TANK)
+    shorad = _grp(CombatGroupRole.SHORAD)
+    shorad.anchor = wedge
+    offsets = frontline_offsets([wedge, shorad], 1000)
+    assert offsets[id(shorad)] == offsets[id(wedge)]
+
+
+def test_unclustered_gets_an_offset() -> None:
+    wedge = _grp(CombatGroupRole.TANK)
+    arty = _grp(CombatGroupRole.ARTILLERY)
+    offsets = frontline_offsets([wedge, arty], 1000)
+    assert id(arty) in offsets
+    assert 0 <= offsets[id(arty)] <= 1000

--- a/tests/test_default_front_line_stance_settings.py
+++ b/tests/test_default_front_line_stance_settings.py
@@ -1,0 +1,67 @@
+from game.ground_forces.combat_stance import CombatStance
+from game.settings.optiondescription import SETTING_DESCRIPTION_KEY
+from game.settings.settings import Settings
+
+
+def test_default_front_line_stance_defaults_to_aggressive() -> None:
+    assert Settings().default_front_line_stance is CombatStance.AGGRESSIVE
+
+
+def test_default_front_line_stance_choices_exclude_retreat() -> None:
+    # The option's choices are what the settings window offers; RETREAT is not a
+    # sensible standing default and must not be selectable.
+    field = Settings.__dataclass_fields__["default_front_line_stance"]
+    description = field.metadata[SETTING_DESCRIPTION_KEY]
+    values = set(description.choices.values())
+    assert CombatStance.RETREAT not in values
+    assert values == {
+        CombatStance.AGGRESSIVE,
+        CombatStance.DEFENSIVE,
+        CombatStance.AMBUSH,
+        CombatStance.ELIMINATION,
+        CombatStance.BREAKTHROUGH,
+    }
+
+
+def test_default_front_line_stance_is_user_visible() -> None:
+    names = {
+        name
+        for page in Settings.pages()
+        for section in Settings.sections(page)
+        for name, _description in Settings.fields(page, section)
+    }
+    assert "default_front_line_stance" in names
+
+
+def test_default_front_line_stance_backfills_on_old_save() -> None:
+    # An old save lacks the field entirely; __setstate__ overlays saved state on a
+    # fresh Settings(), so the field must resolve to the AGGRESSIVE default.
+    settings = Settings.__new__(Settings)
+    settings.__setstate__({})
+    assert settings.default_front_line_stance is CombatStance.AGGRESSIVE
+
+
+def test_default_front_line_stance_enum_round_trips() -> None:
+    out = Settings.deserialize_state_dict(
+        {"default_front_line_stance": "CombatStance.BREAKTHROUGH"}
+    )
+    assert out["default_front_line_stance"] is CombatStance.BREAKTHROUGH
+
+
+def test_default_front_line_stance_stale_value_falls_back() -> None:
+    out = Settings.deserialize_state_dict({"default_front_line_stance": "nonsense"})
+    assert out["default_front_line_stance"] is CombatStance.AGGRESSIVE
+
+
+def test_default_front_line_stance_corrupt_value_falls_back() -> None:
+    # Empty/truncated saved strings raise SyntaxError in eval; must fall back,
+    # not crash campaign load.
+    out = Settings.deserialize_state_dict({"default_front_line_stance": ""})
+    assert out["default_front_line_stance"] is CombatStance.AGGRESSIVE
+
+
+def test_default_front_line_stance_non_enum_value_falls_back() -> None:
+    # A saved string that evals to a non-member (e.g. a bare int) raises no
+    # exception; it must still fall back to the default, not store a bad type.
+    out = Settings.deserialize_state_dict({"default_front_line_stance": "42"})
+    assert out["default_front_line_stance"] is CombatStance.AGGRESSIVE

--- a/tests/theater/test_default_front_line_stance.py
+++ b/tests/theater/test_default_front_line_stance.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from game.ground_forces.combat_stance import CombatStance
+from game.theater.controlpoint import Airfield, Player
+
+
+def _bare_airfield() -> Airfield:
+    # Bypass __init__ (which needs a real Airport/theater); these methods only
+    # touch self.stances, so a constructed instance with a stances dict suffices.
+    cp = Airfield.__new__(Airfield)
+    cp.stances = {uuid4(): CombatStance.DEFENSIVE, uuid4(): CombatStance.RETREAT}
+    return cp
+
+
+def _mock_game(automate: bool, stance: CombatStance) -> MagicMock:
+    game = MagicMock()
+    game.settings.automate_front_line_stance = automate
+    game.settings.default_front_line_stance = stance
+    return game
+
+
+def test_seed_front_line_stances_overwrites_every_entry() -> None:
+    cp = _bare_airfield()
+    cp.seed_front_line_stances(CombatStance.AGGRESSIVE)
+    assert set(cp.stances.values()) == {CombatStance.AGGRESSIVE}
+
+
+def test_capture_seeds_for_blue_with_auto_off() -> None:
+    cp = _bare_airfield()
+    game = _mock_game(automate=False, stance=CombatStance.AGGRESSIVE)
+    cp.apply_default_stance_on_capture(game, Player.BLUE)
+    assert set(cp.stances.values()) == {CombatStance.AGGRESSIVE}
+
+
+def test_capture_does_not_seed_when_auto_on() -> None:
+    cp = _bare_airfield()
+    before = dict(cp.stances)
+    game = _mock_game(automate=True, stance=CombatStance.AGGRESSIVE)
+    cp.apply_default_stance_on_capture(game, Player.BLUE)
+    assert cp.stances == before
+
+
+def test_capture_does_not_seed_for_red() -> None:
+    cp = _bare_airfield()
+    before = dict(cp.stances)
+    game = _mock_game(automate=False, stance=CombatStance.AGGRESSIVE)
+    cp.apply_default_stance_on_capture(game, Player.RED)
+    assert cp.stances == before

--- a/tests/theater/test_default_front_line_stance_generation.py
+++ b/tests/theater/test_default_front_line_stance_generation.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+
+from game.ground_forces.combat_stance import CombatStance
+from game.settings.settings import Settings
+from game.theater.player import Player
+from game.theater.start_generator import apply_default_player_stances
+
+
+def _settings(auto: bool) -> Settings:
+    settings = Settings()
+    settings.automate_front_line_stance = auto
+    return settings
+
+
+def _cp(captured: Player) -> MagicMock:
+    cp = MagicMock()
+    cp.captured = captured
+    return cp
+
+
+def test_generation_seeds_player_points_when_auto_off() -> None:
+    # Delegates coalition filtering to player_points() and seeds each result.
+    blue = _cp(Player.BLUE)
+    theater = MagicMock()
+    theater.player_points.return_value = [blue]
+
+    apply_default_player_stances(theater, _settings(auto=False))
+
+    theater.player_points.assert_called_once()
+    blue.seed_front_line_stances.assert_called_once_with(CombatStance.AGGRESSIVE)
+
+
+def test_generation_seeds_nothing_when_auto_on() -> None:
+    blue = _cp(Player.BLUE)
+    theater = MagicMock()
+    theater.player_points.return_value = [blue]
+
+    apply_default_player_stances(theater, _settings(auto=True))
+
+    blue.seed_front_line_stances.assert_not_called()


### PR DESCRIPTION
 ## Frontline overhaul: clustered composition + cohesive maneuver

  Reworks how AI frontline ground forces are composed and how they move, replacing
  single-type random placement with proportional mixed clusters that maneuver as a
  unit. Bundles two stacked features.

  Implements item 7 of #285 (that issue tracks multiple items so trying to prevent GH from changing its status automatically).
   Closes #82.

  ### What changed

  **Composition & spread (#285, item 7)**
  - Frontline forces deploy as a **proportional mixed selection** (largest-remainder
    allocation across the base's actual armor pool) instead of purchase-order
    single-type groups.
  - Units assemble into **evenly-spread combat clusters**: an armor wedge
    (TANK/IFV/APC, 5–7, type alternates between adjacent clusters) with embedded
    SHORAD behind it, an ATGM standoff pair behind that, and recon/infantry leading
    in front. Artillery and logistics stay to the rear.
  - Clusters spread across the front in even slots rather than bunching at one offset.

  **Cohesive maneuver & formation (#82, "mobilize like Inferno")**
  - A cluster now **maneuvers as a unit** anchored to its armor wedge: followers
    (SHORAD/ATGM/recon) advance the wedge's per-stance distance so the cluster keeps
    its shape — recon leads, SHORAD/ATGM trail.
  - Per-stance advance preserved: ~16 km AGGRESSIVE/ELIMINATION, ~35 km BREAKTHROUGH.
    DEFENSIVE/AMBUSH hold, RETREAT falls back via the existing universal fallback.
  - **APC-type wedges** now behave like TANK/IFV wedges (full advance + engage),
    fixing APC-led clusters splitting in BREAKTHROUGH under the old soft-follow cap.
  - **Formations**: armor wedge moves in a Vee, ATGM pair in a line; recon/SHORAD
    scatter off-road. (Formation applies at the move waypoint; DCS forms units up
    once they start moving.)
  - Stance *selection* logic is unchanged — this only affects composition and
    maneuver once a stance is chosen.

  ### Testing
  - New unit tests: cluster assembly, anchor links, even-spread placement, per-stance
    movement/formation, save backfill (`tests/ground_forces/`,
    `tests/missiongenerator/`).
  - CI gates green: black, mypy (game + tests), pytest.
  - In-sim acceptance on a live mission: mixed/alternating armor per cluster, embedded
    AD, blue BREAKTHROUGH advancing as cohesive clusters, red RETREAT falling back
    correctly per stance.