### PR TITLE
Plugins: support drop-down (choice) options in plugin settings

### DIFF
--- a/game/plugins/luaplugin.py
+++ b/game/plugins/luaplugin.py
@@ -58,10 +58,19 @@ class PluginSettings:
 
 class LuaPluginOption(PluginSettings):
     def __init__(
-        self, identifier: str, name: str, min: Any, max: Any, value: Any
+        self,
+        identifier: str,
+        name: str,
+        min: Any,
+        max: Any,
+        value: Any,
+        choices: Optional[List[str]] = None,
     ) -> None:
         super().__init__(identifier, value)
         self.name = name
+        # A "choice" option picks its value from a fixed list (rendered as a
+        # drop-down). Numeric options keep min/max (spin box); bools are checkboxes.
+        self.choices = choices
         if type(value) == int or type(value) == float:
             self.min, self.max = min, max
         else:
@@ -93,6 +102,7 @@ class LuaPluginDefinition:
                     min=option.get("minimumValue", 0),
                     max=option.get("maximumValue", 10000),
                     value=option.get("defaultValue"),
+                    choices=option.get("choices"),
                 )
             )
 
@@ -169,12 +179,24 @@ class LuaPlugin(PluginSettings):
         for work_order in self.definition.work_orders:
             work_order.work(lua_generator)
 
+    @staticmethod
+    def _lua_literal(value: Any) -> str:
+        # Render a plugin-option value as a Lua literal: bool -> true/false,
+        # numbers verbatim, strings quoted (so `choices` options inject safely
+        # instead of becoming an undefined Lua identifier).
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return str(value)
+        escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+
     def inject_configuration(self, lua_generator: LuaGenerator) -> None:
         # inject the plugin options
         if self.options:
             option_decls = []
             for option in self.options:
-                value = str(option.get_value).lower()
+                value = self._lua_literal(option.get_value)
                 name = option.identifier
                 option_decls.append(f"    dcsRetribution.plugins.{name} = {value}")
 

--- a/qt_ui/windows/settings/plugins.py
+++ b/qt_ui/windows/settings/plugins.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 from PySide6.QtCore import Qt, QLocale
 from PySide6.QtWidgets import (
     QCheckBox,
+    QComboBox,
     QGridLayout,
     QGroupBox,
     QLabel,
@@ -78,7 +79,14 @@ class PluginOptionsBox(QGroupBox):
             layout.addWidget(label, row, 0)
 
             val = option.get_value
-            if type(val) == bool:
+            if option.choices:
+                combo = QComboBox()
+                combo.addItems(option.choices)
+                combo.setCurrentText(str(val))
+                combo.currentTextChanged.connect(option.set_value)
+                layout.addWidget(combo, row, 1)
+                self.widgets[option.identifier] = combo
+            elif type(val) == bool:
                 checkbox = QCheckBox()
                 checkbox.setChecked(val)
                 checkbox.toggled.connect(option.set_value)
@@ -104,6 +112,8 @@ class PluginOptionsBox(QGroupBox):
             w = self.widgets[identifier]
             if isinstance(w, QCheckBox):
                 w.setChecked(value)
+            elif isinstance(w, QComboBox):
+                w.setCurrentText(str(value))
             elif isinstance(w, QDoubleSpinBox) or isinstance(w, QSpinBox):
                 w.setValue(value)
 


### PR DESCRIPTION
Plugin `specificOptions` could only be booleans (checkbox) or numbers (spin box). This adds a third type: an option that declares a `"choices"` list of strings renders as a **drop-down (`QComboBox`)** in the plugin settings.

- `game/plugins/luaplugin.py`: `LuaPluginOption` now carries `choices`, and `from_json` reads the optional `"choices"` key. Plugin-option values are injected into the mission Lua via a small `_lua_literal` helper that **quotes strings** — previously a non-bool/number value was written unquoted (`... = foo`), which Lua reads as an undefined identifier. `bool` (`true`/`false`) and number injection are unchanged.
- `qt_ui/windows/settings/plugins.py`: renders a `QComboBox` for choice options and restores its value in `update_from_settings`.

No behaviour change for existing plugins (none declare `choices`). `black` clean.

Example option:
```json
{ "nameInUI": "Message audience", "mnemonic": "SCOPE", "choices": ["A", "B", "C"], "defaultValue": "B" }
```

(Note: This is used in a branch I am testing and will publish soon using the EW script for more features).