### PR TITLE
Kneeboard: light-grey daytime background to avoid HDR glare

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.
 * **[UX]** Avoid having escorts from wondering off too far while chasing a target.

--- a/game/missiongenerator/kneeboard.py
+++ b/game/missiongenerator/kneeboard.py
@@ -68,7 +68,9 @@ class KneeboardPageWriter:
             self.background_fill = (10, 5, 5)
         else:
             self.foreground_fill = (15, 15, 15)
-            self.background_fill = (255, 252, 252)
+            # Light grey rather than near-white: avoids glare under HDR / Auto-HDR
+            # while staying perfectly readable in daylight.
+            self.background_fill = (210, 210, 210)
         self.image_size = (960, 1080)
         self.image = Image.new("RGB", self.image_size, self.background_fill)
         # These font sizes create a relatively full page for current sorties. If


### PR DESCRIPTION
The daytime kneeboard background was near-white (255, 252, 252), which is dazzling under HDR / Nvidia Auto-HDR even in daylight. This uses a light grey (210, 210, 210) instead — clearly readable in daylight but well off peak white. Night theme and text colours are unchanged.

![Kneeboard with the light-grey daytime background](https://raw.githubusercontent.com/juanjux/dcs-retribution/assets-screenshots/screenshots/kneeboard-grey-bg.png)