### PR TITLE
Campaign doctrine: ignore non-combat (crash) air losses

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * **[Options]** New option to spawn TACAN beacons at captured airfields
 * **[UX]** Show an "End of Mission Detected, processing Mission Data" busy dialog while turn results are processed, so the wait is not mistaken for a missed detection
 * **[Map]** Hovering a SAM threat or detection ring highlights its emitter — and hovering an emitter highlights its ring — making it easy to tell which site a ring belongs to. Can be disabled from the map's layer control.
+* **[Options]** New Campaign Doctrine option so AI non-combat (crash) air losses don't count: only losses DCS attributes to a weapon or SAM deplete a squadron, and the debriefing shows how many were not counted. Applies to both coalitions.
 
 ## Fixes
 * **[Mission]** Reliably auto-detect end of mission, even when DCS wrote the final state.json before the wait dialog started watching

--- a/game/debriefing.py
+++ b/game/debriefing.py
@@ -122,6 +122,13 @@ class StateData:
     #: Mangled names of bases that were captured during the mission.
     base_capture_events: List[str]
 
+    #: Structured S_EVENT_KILL records ({target, initiator, initiator_type,
+    #: initiator_player, weapon}), used to attribute air losses in the UI feed.
+    kill_details: List[Dict[str, Any]] = field(default_factory=list)
+
+    #: DCS mission model time in seconds (timer.getTime()); None for older states.
+    model_time: Optional[float] = None
+
     @classmethod
     def from_json(cls, data: Dict[str, Any], unit_map: UnitMap) -> StateData:
         def clean_unit_list(unit_list: List[Any]) -> List[str]:
@@ -130,10 +137,10 @@ class StateData:
             #   is dropped on them when they've already dead.
             # - Normalise dead map objects (which are ints) to strings. The unit map
             #   only stores strings
-            units = set()
-            for unit in unit_list:
-                units.add(str(unit))
-            return list(units)
+            # dict.fromkeys dedups while preserving first-seen order, so the cumulative
+            # state re-parsed every poll yields a stable append-only prefix (consumers
+            # that diff by position, e.g. the mission panel event feed, rely on this).
+            return list(dict.fromkeys(str(unit) for unit in unit_list))
 
         killed_aircraft = []
         killed_ground_units = []
@@ -160,6 +167,8 @@ class StateData:
             killed_ground_units=killed_ground_units,
             destroyed_statics=data.get("destroyed_objects_positions", []),
             base_capture_events=data.get("base_capture_events", []),
+            kill_details=data.get("kill_details", []),
+            model_time=data.get("model_time"),
         )
 
 
@@ -177,13 +186,81 @@ class Debriefing:
         self.air_losses = self.dead_aircraft()
         self.ground_losses = self.dead_ground_units()
         self.base_captures = self.base_capture_events()
+        self.kill_info_by_unit_id = self._index_kill_details()
+        # ids of air losses injected by the Retribution sim (no DCS kill record);
+        # they are real combat losses, so is_non_combat_loss() must not refund them.
+        self._sim_loss_ids: set[int] = set()
+
+    def _index_kill_details(self) -> Dict[int, Dict[str, Any]]:
+        """Map id(loss object) -> its S_EVENT_KILL detail (killer + weapon), for both
+        air losses (FlyingUnit) and ground losses (FrontLineUnit/ConvoyUnit/...).
+
+        Keyed by id() (not the object itself) because FlyingUnit holds a Pilot, an
+        unhashable dataclass. The lookup side (the mission panel) keys by id(loss);
+        those loss objects are the same instances unit_map resolves a name to, so
+        identity matches. Wrapped defensively: this only feeds the UI feed, so a
+        problem here must never break turn processing/debriefing construction.
+        """
+        index: Dict[int, Dict[str, Any]] = {}
+        try:
+            for detail in self.state_data.kill_details:
+                if not isinstance(detail, dict):
+                    continue
+                name = detail.get("target")
+                if not name:
+                    continue
+                obj = self._resolve_killed_object(str(name))
+                if obj is not None:
+                    index[id(obj)] = detail
+        except Exception:
+            logging.exception("Failed to index kill details; killer attribution off")
+        return index
+
+    def _resolve_killed_object(self, name: str) -> Optional[Any]:
+        """Resolve a killed unit name to its loss object, mirroring how
+        dead_aircraft/dead_ground_units resolve names, so id() lines up."""
+        um = self.unit_map
+        obj = um.flight(name)
+        if obj is not None:
+            return obj
+        obj = um.front_line_unit(name) or um.front_line_unit_from_tic_clone(name)
+        if obj is not None:
+            return obj
+        for getter in (
+            um.convoy_unit,
+            um.cargo_ship,
+            um.theater_units,
+            um.scenery_object,
+        ):
+            obj = getter(name)
+            if obj is not None:
+                return obj
+        return None
 
     def merge_simulation_results(self, results: SimulationResults) -> None:
         for air_loss in results.air_losses:
+            self._sim_loss_ids.add(id(air_loss))
             if air_loss.flight.squadron.player.is_blue:
                 self.air_losses.player.append(air_loss)
             else:
                 self.air_losses.enemy.append(air_loss)
+
+    def is_non_combat_loss(self, flying_unit: "FlyingUnit") -> bool:
+        """True if this air loss was a non-combat write-off: a crash, a collision,
+        or a death with no shooter credited by DCS — as opposed to being shot down
+        by a weapon or SAM. Retribution-sim combat losses (no DCS kill record) are
+        NOT treated as crashes."""
+        if id(flying_unit) in self._sim_loss_ids:
+            return False
+        detail = self.kill_info_by_unit_id.get(id(flying_unit))
+        if detail:
+            initiator_type = detail.get("initiator_type")
+            weapon = detail.get("weapon")
+            has_shooter = bool(detail.get("initiator_player") or initiator_type)
+            collision = bool(weapon and weapon == initiator_type)
+            if has_shooter and not collision:
+                return False  # shot down by a weapon / SAM
+        return True
 
     @property
     def front_line_losses(self) -> Iterator[FrontLineUnit]:
@@ -347,6 +424,12 @@ class Debriefing:
         untracked: List[str] = []
         for unit_name in self.state_data.killed_ground_units:
             front_line_unit = self.unit_map.front_line_unit(unit_name)
+            if front_line_unit is None:
+                # The TIC plugin respawns frontline units as renamed
+                # single-unit clones; map clone deaths back to their group.
+                front_line_unit = self.unit_map.front_line_unit_from_tic_clone(
+                    unit_name
+                )
             if front_line_unit is not None:
                 if front_line_unit.origin.captured.is_blue:
                     losses.player_front_line.append(front_line_unit)

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -193,6 +193,19 @@ class Settings:
     )
 
     # CAMPAIGN DOCTRINE
+    ignore_non_combat_air_losses: bool = boolean_option(
+        "Non-combat (crash) aircraft losses don't count",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=False,
+        detail=(
+            "The AI has too high a tendency to crash into terrain or buildings. "
+            "This setting makes those losses not count as real ones: the aircraft "
+            "is not removed from the squadron and its pilot survives. Only losses "
+            "DCS attributes to a weapon or a SAM count as real in the campaign. "
+            "Applies to both coalitions."
+        ),
+    )
     desired_barcap_mission_duration: timedelta = minutes_option(
         "Desired BARCAP on-station time",
         page=CAMPAIGN_DOCTRINE_PAGE,

--- a/game/sim/missionresultsprocessor.py
+++ b/game/sim/missionresultsprocessor.py
@@ -55,6 +55,16 @@ class MissionResultsProcessor:
 
     def commit_air_losses(self, debriefing: Debriefing) -> None:
         for loss in debriefing.air_losses.losses:
+            if self.game.settings.ignore_non_combat_air_losses and (
+                debriefing.is_non_combat_loss(loss)
+            ):
+                # Campaign doctrine: a non-combat write-off (crash/collision/no
+                # credited shooter) does not deplete the squadron or kill the pilot.
+                logging.info(
+                    f"Ignoring non-combat loss of {loss.flight.unit_type} from "
+                    f"{loss.flight.squadron}"
+                )
+                continue
             if loss.pilot is not None and (
                 not loss.pilot.player
                 or not self.game.settings.invulnerable_player_pilots

--- a/game/unitmap.py
+++ b/game/unitmap.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import itertools
 import math
+import re
 from dataclasses import dataclass
 from typing import Dict, Optional, Any, TYPE_CHECKING
 
@@ -57,11 +58,21 @@ class AirliftUnits:
     transfer: TransferOrder
 
 
+# Unit name of a clone spawned by the TIC (Troops In Contact) script. TIC
+# despawns each late-activated original group and respawns every unit as its
+# own single-unit group via MOOSE SPAWN, which renames units to
+# "<original group name>-<index>#<spawn:03d>-<unit:02d>" (the "-<index>#<NNN>"
+# segment repeats when TIC respawns dismounting infantry). The original group
+# name is recovered by stripping those suffixes.
+TIC_CLONE_NAME = re.compile(r"^(?P<group>.+?)(?:-\d+#\d{3})+-\d{2}$")
+
+
 class UnitMap:
     def __init__(self) -> None:
         self.aircraft: Dict[str, FlyingUnit] = {}
         self.airfields: Dict[str, Airfield] = {}
         self.front_line_units: Dict[str, FrontLineUnit] = {}
+        self.front_line_groups: Dict[str, FrontLineUnit] = {}
         self.theater_objects: Dict[str, TheaterUnitMapping] = {}
         self.scenery_objects: Dict[str, SceneryObjectMapping] = {}
         self.convoys: Dict[str, ConvoyUnit] = {}
@@ -93,6 +104,10 @@ class UnitMap:
     def add_front_line_units(
         self, group: VehicleGroup, origin: ControlPoint, unit_type: GroundUnitType
     ) -> None:
+        group_name = str(group.name)
+        if group_name in self.front_line_groups:
+            raise RuntimeError(f"Duplicate front line group: {group_name}")
+        self.front_line_groups[group_name] = FrontLineUnit(unit_type, origin)
         for unit in group.units:
             # The actual name is a String (the pydcs translatable string), which
             # doesn't define __eq__.
@@ -103,6 +118,23 @@ class UnitMap:
 
     def front_line_unit(self, name: str) -> Optional[FrontLineUnit]:
         return self.front_line_units.get(name, None)
+
+    def front_line_unit_from_tic_clone(self, name: str) -> Optional[FrontLineUnit]:
+        """Maps a dead TIC clone unit back to its original frontline group.
+
+        Each clone is a single-unit group, so every clone death corresponds to
+        exactly one original unit loss. Clones share their group's unit type
+        and origin, which is all the debriefing needs.
+        """
+        match = TIC_CLONE_NAME.match(name)
+        if match is None:
+            return None
+        # getattr for save compat: a UnitMap pickled by an older build has no
+        # front_line_groups attribute.
+        groups = getattr(self, "front_line_groups", None)
+        if not groups:
+            return None
+        return groups.get(match.group("group"))
 
     def add_theater_unit_mapping(
         self, theater_unit: TheaterUnit, dcs_unit: Unit

--- a/qt_ui/windows/QDebriefingWindow.py
+++ b/qt_ui/windows/QDebriefingWindow.py
@@ -24,9 +24,7 @@ class LossGrid(QGridLayout):
     def __init__(self, debriefing: Debriefing, player: Player) -> None:
         super().__init__()
 
-        self.add_loss_rows(
-            debriefing.air_losses.by_type(player), lambda u: u.display_name
-        )
+        self.add_air_loss_rows(debriefing, player)
         self.add_loss_rows(
             debriefing.front_line_losses_by_type(player), lambda u: str(u)
         )
@@ -55,6 +53,41 @@ class LossGrid(QGridLayout):
                 name = unit_type.id
             self.addWidget(QLabel(name), row, 0)
             self.addWidget(QLabel(str(count)), row, 1)
+
+    def add_air_loss_rows(self, debriefing: Debriefing, player: Player) -> None:
+        # Air losses, flagging how many didn't count when the "crashes don't
+        # count" doctrine is on, so the debrief matches what the campaign applied.
+        doctrine_on = bool(
+            getattr(debriefing.game.settings, "ignore_non_combat_air_losses", False)
+        )
+        losses = (
+            debriefing.air_losses.player
+            if player.is_blue
+            else debriefing.air_losses.enemy
+        )
+        not_counted: Dict[object, int] = {}
+        if doctrine_on:
+            for loss in losses:
+                if debriefing.is_non_combat_loss(loss):
+                    unit_type = loss.flight.unit_type
+                    not_counted[unit_type] = not_counted.get(unit_type, 0) + 1
+        for unit_type, count in debriefing.air_losses.by_type(player).items():
+            row = self.rowCount()
+            try:
+                name = unit_type.display_name
+            except AttributeError:
+                name = unit_type.id
+            self.addWidget(QLabel(name), row, 0)
+            self.addWidget(QLabel(str(count)), row, 1)
+            nc = not_counted.get(unit_type, 0)
+            if nc:
+                self.addWidget(
+                    QLabel(
+                        f"({nc} not counted because of crashed-do-not-count setting)"
+                    ),
+                    row,
+                    2,
+                )
 
 
 class ScrollingCasualtyReportContainer(QGroupBox):


### PR DESCRIPTION
Adds a **Campaign Doctrine → General** option *"Non-combat (crash) aircraft losses don't count"* (default off). When enabled, air losses DCS does not credit to a weapon or SAM — AI crashes, collisions, terrain/fuel — no longer deplete the squadron and the pilot survives; only real combat kills count. Applies to both coalitions.

Implemented on top of new per-loss **kill attribution** in `Debriefing`: each `S_EVENT_KILL` is indexed by killed unit and resolved to its loss object (including TIC-respawned front-line clones), so a loss can be classified as non-combat by elimination. The debriefing window now shows, per aircraft type, how many losses were not counted.