### PR TITLE
Recon fog-of-war: hide enemy site composition until scouted, with an overview toggle

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[Campaign]** Recon fog of war: the enemy ground picture is earned, not given. Without fresh reconnaissance the map shows a site's last-known state — unconfirmed kills still render alive (battle-damage lag) and unscouted sites hide their composition; recon flights confirm BDA and reveal what's really there. AI planning always uses ground truth, so only the human's picture is fogged. (#828)
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.

--- a/client/src/components/airdefenserangelayer/RevealFogToggle.tsx
+++ b/client/src/components/airdefenserangelayer/RevealFogToggle.tsx
@@ -1,0 +1,29 @@
+import backend from "../../api/backend";
+import reloadGameState from "../../api/gamestate";
+import { AppDispatch } from "../../app/store";
+import { useAppDispatch } from "../../app/hooks";
+import { LayerGroup } from "react-leaflet";
+
+// Empty layer wrapped in a LayersControl.Overlay. Toggling the overlay flips the
+// transient, server-side "reveal fog of war" flag, then re-pulls game state so the
+// map redraws with (or without) the recon-fogged enemy composition, threat/
+// detection rings, and IADS links. The flag is runtime-only and never persisted,
+// so a save can never carry a god-view.
+function setReveal(dispatch: AppDispatch, revealed: boolean) {
+  backend
+    .put("/fog-of-war/reveal", null, { params: { revealed } })
+    .then(() => reloadGameState(dispatch, true))
+    .catch((error) => console.log(`Error toggling fog of war: ${error}`));
+}
+
+export default function RevealFogToggle() {
+  const dispatch = useAppDispatch();
+  return (
+    <LayerGroup
+      eventHandlers={{
+        add: () => setReveal(dispatch, true),
+        remove: () => setReveal(dispatch, false),
+      }}
+    />
+  );
+}

--- a/client/src/components/liberationmap/LiberationMap.tsx
+++ b/client/src/components/liberationmap/LiberationMap.tsx
@@ -3,6 +3,7 @@ import { useAppSelector } from "../../app/hooks";
 import AircraftLayer from "../aircraftlayer";
 import AirDefenseRangeLayer from "../airdefenserangelayer";
 import EmitterHighlightToggle from "../airdefenserangelayer/EmitterHighlightToggle";
+import RevealFogToggle from "../airdefenserangelayer/RevealFogToggle";
 import CombatLayer from "../combatlayer";
 import ControlPointsLayer from "../controlpointslayer";
 import CullingExclusionZones from "../cullingexclusionzones/CullingExclusionZones";
@@ -98,6 +99,9 @@ export default function LiberationMap() {
         </LayersControl.Overlay>
         <LayersControl.Overlay name="Highlight radar emitter on hover" checked>
           <EmitterHighlightToggle />
+        </LayersControl.Overlay>
+        <LayersControl.Overlay name="Reveal fog of war">
+          <RevealFogToggle />
         </LayersControl.Overlay>
         <LayersControl.Overlay name="Allied IADS Network">
           <Iadsnetworklayer blue={true} />

--- a/game/server/app.py
+++ b/game/server/app.py
@@ -6,6 +6,7 @@ from . import (
     debuggeometries,
     eventstream,
     flights,
+    fogofwar,
     frontlines,
     game,
     mapzones,
@@ -23,6 +24,7 @@ app.include_router(controlpoints.router)
 app.include_router(debuggeometries.router)
 app.include_router(eventstream.router)
 app.include_router(flights.router)
+app.include_router(fogofwar.router)
 app.include_router(frontlines.router)
 app.include_router(game.router)
 app.include_router(mapzones.router)

--- a/game/server/fogofwar/__init__.py
+++ b/game/server/fogofwar/__init__.py
@@ -1,0 +1,1 @@
+from .routes import router

--- a/game/server/fogofwar/routes.py
+++ b/game/server/fogofwar/routes.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, status
+from starlette.responses import Response
+
+from game.theater.fogofwar import fog_revealed, set_fog_revealed
+
+router: APIRouter = APIRouter(prefix="/fog-of-war")
+
+
+@router.get("/reveal", operation_id="get_fog_of_war_reveal", response_model=bool)
+def get_reveal() -> bool:
+    """Whether the fog-of-war overview is currently on."""
+    return fog_revealed()
+
+
+@router.put(
+    "/reveal",
+    operation_id="set_fog_of_war_reveal",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def set_reveal(revealed: bool) -> None:
+    """Toggle the fog-of-war overview ("show the real picture").
+
+    Runtime-only view state; never persisted. After flipping this the client
+    re-pulls full game state, so the map redraws with (or without) the fogged
+    enemy composition, threat/detection rings, and hidden command posts. The
+    flag short-circuits the three fog leaves (``alive_for`` / ``known_for`` /
+    ``hidden_on_player_map``) to ground truth for any viewer; AI/planner/threat
+    math pass ``viewer=None`` and are unaffected.
+    """
+    set_fog_revealed(revealed)

--- a/game/server/iadsnetwork/models.py
+++ b/game/server/iadsnetwork/models.py
@@ -32,9 +32,16 @@ class IadsConnectionJs(BaseModel):
 
     @staticmethod
     def connections_for_node(network_node: IadsNetworkNode) -> list[IadsConnectionJs]:
-        iads_connections = []
+        iads_connections: list[IadsConnectionJs] = []
         tgo = network_node.group.ground_object
+        # Recon intel-fog: hide IADS links to/from a site the player has not yet
+        # discovered, so an unscouted SAM does not leak its network membership.
+        if not tgo.known_for(Player.BLUE):
+            return iads_connections
         for id, connection in network_node.connections.items():
+            connected_tgo = connection.ground_object
+            if not connected_tgo.known_for(Player.BLUE):
+                continue
             if connection.ground_object.is_friendly(Player.BLUE) != tgo.is_friendly(
                 Player.BLUE
             ):

--- a/game/server/mapzones/models.py
+++ b/game/server/mapzones/models.py
@@ -83,11 +83,19 @@ class ThreatZoneContainerJs(BaseModel):
 
     @staticmethod
     def for_game(game: Game) -> ThreatZoneContainerJs:
+        # Recon intel-fog: the human player (BLUE) only sees the enemy (RED)
+        # threat zone built from sites it has actually scouted, so undiscovered
+        # SAMs project no avoidance ring. The AI/navmesh keep using the cached
+        # ground-truth zone (game.threat_zone_for); this viewer-aware recompute is
+        # for display only. When the "reveal fog of war" overview is on, known_for
+        # short-circuits to truth, so this returns the full picture again.
         return ThreatZoneContainerJs(
             blue=ThreatZonesJs.from_zones(
-                game.threat_zone_for(player=Player.BLUE), game.theater
+                ThreatZones.for_faction(game, Player.BLUE, viewer=Player.BLUE),
+                game.theater,
             ),
             red=ThreatZonesJs.from_zones(
-                game.threat_zone_for(player=Player.RED), game.theater
+                ThreatZones.for_faction(game, Player.RED, viewer=Player.BLUE),
+                game.theater,
             ),
         )

--- a/game/server/tgos/models.py
+++ b/game/server/tgos/models.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from game.data.groups import GroupTask
 from game.server.leaflet import LeafletPoint
+from game.theater.player import Player
 from game.theater.theatergroundobject import ShipGroundObject
 
 if TYPE_CHECKING:
@@ -35,8 +36,25 @@ class TgoJs(BaseModel):
 
     @staticmethod
     def for_tgo(tgo: TheaterGroundObject) -> TgoJs:
-        threat_ranges = [group.max_threat_range().meters for group in tgo.groups]
-        detection_ranges = [group.max_detection_range().meters for group in tgo.groups]
+        threat_ranges: list[float]
+        detection_ranges: list[float]
+        units: list[str]
+        if tgo.known_for(Player.BLUE):
+            threat_ranges = [group.max_threat_range().meters for group in tgo.groups]
+            detection_ranges = [
+                group.max_detection_range().meters for group in tgo.groups
+            ]
+            units = [unit.display_name for unit in tgo.units]
+            dead = tgo.is_dead
+        else:
+            # Recon intel-fog: the site stays on the map and remains targetable
+            # (position, category, allegiance), but its actual composition and
+            # threat/detection rings are hidden until it is attacked, scouted, or
+            # has a unit destroyed.
+            threat_ranges = []
+            detection_ranges = []
+            units = []
+            dead = False
         if tgo.control_point.captured.is_blue:
             blue = True
         else:
@@ -56,10 +74,10 @@ class TgoJs(BaseModel):
             category=tgo.category,
             blue=blue,
             position=tgo.position.latlng(),
-            units=[unit.display_name for unit in tgo.units],
+            units=units,
             threat_ranges=threat_ranges,
             detection_ranges=detection_ranges,
-            dead=tgo.is_dead,
+            dead=dead,
             sidc=str(tgo.sidc()),
             task=tgo.groups[0].ground_object.task if tgo.groups else None,
             mobile=mobile,

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -200,6 +200,20 @@ class Settings:
     )
 
     # CAMPAIGN DOCTRINE
+    recon_intel_fog: bool = boolean_option(
+        "Recon intel fog (hide enemy site composition until scouted)",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=True,
+        detail=(
+            "When enabled, enemy ground sites appear on the map as targets you can "
+            "plan against, but what is actually there -- unit types, counts, damage "
+            "state, and threat/detection rings -- stays hidden until the site is "
+            "attacked, scouted, or has a unit destroyed. The AI planner and threat "
+            "math always use full truth, so auto-planning is unaffected. Existing "
+            "campaigns keep everything revealed; the fog applies to new campaigns."
+        ),
+    )
     desired_barcap_mission_duration: timedelta = minutes_option(
         "Desired BARCAP on-station time",
         page=CAMPAIGN_DOCTRINE_PAGE,

--- a/game/sim/missionresultsprocessor.py
+++ b/game/sim/missionresultsprocessor.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from game.debriefing import Debriefing
 from game.ground_forces.combat_stance import CombatStance
 from game.profiling import logged_duration
-from game.theater import ControlPoint
+from game.theater import ControlPoint, Player, TheaterGroundObject
 from .gameupdateevents import GameUpdateEvents
 from ..ato.airtaaskingorder import AirTaskingOrder
 
@@ -165,12 +165,66 @@ class MissionResultsProcessor:
                         "has none available."
                     )
 
-    @staticmethod
-    def commit_ground_losses(debriefing: Debriefing, events: GameUpdateEvents) -> None:
+    def commit_ground_losses(
+        self, debriefing: Debriefing, events: GameUpdateEvents
+    ) -> None:
+        struck_tgos: set[TheaterGroundObject] = set()
         for ground_object_loss in debriefing.ground_object_losses:
+            struck_tgos.add(ground_object_loss.theater_unit.ground_object)
             ground_object_loss.theater_unit.kill(events)
         for scenery_object_loss in debriefing.scenery_object_losses:
+            struck_tgos.add(scenery_object_loss.ground_unit.ground_object)
             scenery_object_loss.ground_unit.kill(events)
+        self.reveal_discovered_sites(struck_tgos, debriefing, events)
+
+    def reveal_discovered_sites(
+        self,
+        struck_tgos: set[TheaterGroundObject],
+        debriefing: Debriefing,
+        events: GameUpdateEvents,
+    ) -> None:
+        """Recon intel-fog: flip enemy sites to "known" once the player has engaged
+        them this turn.
+
+        A site is discovered (composition + threat rings revealed, permanently) once
+        it is attacked (a unit destroyed) or overflown by a surviving offensive
+        sortie -- the pilots saw what was there even with no kills. Only enemy sites
+        are gated; friendly/neutral and the omniscient planner are never fogged.
+        """
+        discovered: set[TheaterGroundObject] = set()
+        discovered |= struck_tgos
+        discovered |= self.attacked_tgos_this_turn(debriefing)
+        for tgo in discovered:
+            if tgo.is_friendly(Player.BLUE):
+                continue
+            if not tgo.discovered_by_player:
+                tgo.discovered_by_player = True
+                events.update_tgo(tgo)
+
+    def attacked_tgos_this_turn(
+        self, debriefing: Debriefing
+    ) -> set[TheaterGroundObject]:
+        from game.ato import FlightType
+
+        offensive = {
+            FlightType.STRIKE,
+            FlightType.DEAD,
+            FlightType.SEAD,
+            FlightType.ANTISHIP,
+        }
+        attacked: set[TheaterGroundObject] = set()
+        for package in self.game.blue.ato.packages:
+            target = package.target
+            if not isinstance(target, TheaterGroundObject):
+                continue
+            for flight in package.flights:
+                if (
+                    flight.flight_type in offensive
+                    and debriefing.air_losses.surviving_flight_members(flight) > 0
+                ):
+                    attacked.add(target)
+                    break
+        return attacked
 
     @staticmethod
     def commit_damaged_runways(debriefing: Debriefing) -> None:

--- a/game/theater/fogofwar.py
+++ b/game/theater/fogofwar.py
@@ -1,0 +1,34 @@
+"""Transient "overview" reveal toggle for the recon fog-of-war.
+
+The 414th recon fog hides enemy composition, threat/detection rings, and SCAR
+command posts from the human side until they are scouted (see the viewer-aware
+visibility layer in ``theatergroup``/``theatergroundobject``). This module adds a
+single runtime switch that, while enabled, forces every player-facing fog
+accessor to resolve to ground truth — the "show the real picture" overview.
+
+It is deliberately a process-global runtime flag, **never persisted**: loading a
+save always starts with the fog intact, so a god-view can't be baked into a
+campaign or shared by accident. The flag is flipped from the main window's
+"Reveal fog of war" view action; the three fog chokepoints (``alive_for``,
+``known_for``, ``hidden_on_player_map``) consult ``fog_revealed()`` and short to
+truth when it is on. AI/planner/threat math already pass ``viewer=None`` and are
+therefore unaffected either way.
+
+This module intentionally has no imports so it can be pulled in from anywhere in
+the theater layer without risk of an import cycle.
+"""
+
+from __future__ import annotations
+
+_revealed: bool = False
+
+
+def fog_revealed() -> bool:
+    """Whether the overview is on (player-facing fog forced to ground truth)."""
+    return _revealed
+
+
+def set_fog_revealed(value: bool) -> None:
+    """Enable/disable the overview. Runtime-only; never written to a save."""
+    global _revealed
+    _revealed = bool(value)

--- a/game/theater/theatergroundobject.py
+++ b/game/theater/theatergroundobject.py
@@ -21,6 +21,7 @@ from game.sidc import (
 )
 from game.theater.presetlocation import PresetLocation
 from .missiontarget import MissionTarget
+from .fogofwar import fog_revealed
 from .player import Player
 from ..data.groups import GroupTask
 from ..utils import Distance, Heading, meters, nautical_miles
@@ -80,6 +81,12 @@ class TheaterGroundObject(MissionTarget, SidcDescribable, ABC):
         self._threat_poly: ThreatPoly | None = None
         self.task = task
         self.hide_on_mfd = hide_on_mfd
+        # Recon intel-fog: has the human (BLUE) player discovered what is actually
+        # at this site? New enemy sites start unknown (composition + threat rings
+        # hidden) until attacked, scouted, or destroyed. Friendly/neutral sites and
+        # omniscient (viewer=None) callers are handled by known_for(), so this flag
+        # only matters for enemy sites from the player's perspective.
+        self.discovered_by_player = False
 
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
@@ -88,7 +95,29 @@ class TheaterGroundObject(MissionTarget, SidcDescribable, ABC):
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         state["_threat_poly"] = None
+        # Save compatibility: a campaign saved before recon intel-fog has every
+        # site already on the player's map, so treat it as fully discovered rather
+        # than suddenly blanking an in-progress campaign. The fog is felt on new
+        # campaigns (where the flag defaults False).
+        if "discovered_by_player" not in state:
+            state["discovered_by_player"] = True
         self.__dict__.update(state)
+
+    def known_for(self, viewer: Optional[Player] = None) -> bool:
+        """Whether the viewer knows what is actually at this site.
+
+        ``viewer=None`` (omniscient -- AI, planner, threat math) and friendly
+        viewers always know. An enemy viewer only knows once the site has been
+        discovered (attacked / scouted / destroyed). The whole feature can be
+        switched off via the ``recon_intel_fog`` campaign setting, and the
+        ``fog_revealed()`` overview forces full knowledge for any viewer.
+        """
+        if viewer is None or fog_revealed() or self.is_friendly(viewer):
+            return True
+        settings = self.control_point.coalition.game.settings
+        if not settings.recon_intel_fog:
+            return True
+        return self.discovered_by_player
 
     @property
     def sidc_status(self) -> Status:

--- a/game/threatzones.py
+++ b/game/threatzones.py
@@ -188,13 +188,19 @@ class ThreatZones:
         return min(cap_threat_range, max_distance)
 
     @classmethod
-    def for_faction(cls, game: Game, player: Player) -> ThreatZones:
+    def for_faction(
+        cls, game: Game, player: Player, viewer: Player | None = None
+    ) -> ThreatZones:
         """Generates the threat zones projected by the given coalition.
 
         Args:
             game: The game to generate the threat zone for.
             player: True if the coalition projecting the threat zone belongs to
             the player.
+            viewer: When set, air defenses the viewer has not yet discovered
+            (recon intel-fog) are excluded, so the human-facing threat overlay
+            only shows scouted sites. ``None`` (the default, used by the AI /
+            navmesh / planner) projects full ground truth.
 
         Returns:
             The threat zones projected by the given coalition. If the threat
@@ -202,10 +208,14 @@ class ThreatZones:
             the enemy and vice versa.
         """
         air_threats = []
-        air_defenses = []
+        air_defenses: list[TheaterGroundObject] = []
         for cp in game.theater.control_points_for(player):
             air_threats.append(cp)
-            air_defenses.extend([go for go in cp.ground_objects if go.has_aa])
+            air_defenses.extend(
+                go
+                for go in cp.ground_objects
+                if go.has_aa and (viewer is None or go.known_for(viewer))
+            )
 
         return cls.for_threats(
             game.theater, game.faction_for(player).doctrine, air_threats, air_defenses

--- a/qt_ui/windows/groundobject/QGroundObjectMenu.py
+++ b/qt_ui/windows/groundobject/QGroundObjectMenu.py
@@ -129,7 +129,17 @@ class QGroundObjectMenu(QDialog):
         self.intelBox = QGroupBox("Units :")
         self.intelLayout = QGridLayout()
         i = 0
-        for g in self.ground_object.groups:
+        # Recon intel-fog: an undiscovered enemy site shows on the map as a target
+        # but its composition stays hidden until it is attacked, scouted, or has a
+        # unit destroyed. The own coalition (and the omniscient AI) always sees truth.
+        viewer = Player.BLUE if self.game_model.is_ownfor else Player.RED
+        scouted = self.ground_object.known_for(viewer)
+        if not scouted:
+            self.intelLayout.addWidget(
+                QLabel("<i>Not yet scouted — composition unknown</i>"), i, 0
+            )
+            i += 1
+        for g in self.ground_object.groups if scouted else []:
             for unit in g.units:
                 self.intelLayout.addWidget(
                     QLabel(f"<b>Unit {str(unit.display_name)}</b>"), i, 0

--- a/tests/server/test_fogofwar_route.py
+++ b/tests/server/test_fogofwar_route.py
@@ -1,0 +1,33 @@
+"""The /fog-of-war/reveal endpoint flips the shared, transient overview flag.
+
+The flag is process-global, so each test restores it to off afterwards to keep
+the fog assertions in the rest of the suite deterministic.
+"""
+
+from typing import Iterator
+
+import pytest
+
+from game.server.fogofwar.routes import get_reveal, set_reveal
+from game.theater.fogofwar import fog_revealed, set_fog_revealed
+
+
+@pytest.fixture(autouse=True)
+def _restore_flag() -> Iterator[None]:
+    yield
+    set_fog_revealed(False)
+
+
+def test_default_is_off() -> None:
+    assert fog_revealed() is False
+    assert get_reveal() is False
+
+
+def test_set_reveal_flips_the_shared_flag() -> None:
+    set_reveal(True)
+    assert fog_revealed() is True
+    assert get_reveal() is True
+
+    set_reveal(False)
+    assert fog_revealed() is False
+    assert get_reveal() is False

--- a/tests/server/test_tgo_movement_routes.py
+++ b/tests/server/test_tgo_movement_routes.py
@@ -30,7 +30,12 @@ def _ship(blue: bool = True) -> ShipGroundObject:
         theater=None,  # type: ignore[arg-type]
         starts_blue=player,
     )
-    cp._coalition = SimpleNamespace(player=player)  # type: ignore[assignment]
+    # known_for consults the campaign's recon_intel_fog setting for enemy
+    # viewers, so the coalition double carries a minimal game.settings chain.
+    cp._coalition = SimpleNamespace(  # type: ignore[assignment]
+        player=player,
+        game=SimpleNamespace(settings=SimpleNamespace(recon_intel_fog=False)),
+    )
     return ShipGroundObject(name="ship", location=location, control_point=cp)
 
 

--- a/tests/test_recon_intel_fog.py
+++ b/tests/test_recon_intel_fog.py
@@ -1,0 +1,90 @@
+"""Recon intel-fog: enemy site composition/rings hidden until discovered.
+
+Covers the discovery gate (``known_for``), the omniscient/setting escape hatches,
+and the save-migration default. The end-to-end reveal trigger (a strike flips a
+site to discovered) is asserted in ``test_bda_tarps_reveal.py`` where the
+mission-results fixtures already live.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from dcs.mapping import Point
+
+from game.theater import Player
+from game.theater.controlpoint import OffMapSpawn
+from game.theater.presetlocation import PresetLocation
+from game.theater.theatergroundobject import SamGroundObject
+from game.utils import Heading
+
+
+class _EnemySam(SamGroundObject):
+    def is_friendly(self, to_player: Player) -> bool:
+        return False
+
+
+def _enemy_sam(*, fog: bool = True) -> SamGroundObject:
+    location = PresetLocation(
+        name="target",
+        position=Point(0, 0, None),  # type: ignore[arg-type]
+        heading=Heading(0),
+    )
+    control_point = OffMapSpawn(
+        name="enemy-cp",
+        position=Point(0, 0, None),  # type: ignore[arg-type]
+        theater=None,  # type: ignore[arg-type]
+        starts_blue=Player.RED,
+    )
+    tgo = _EnemySam(
+        name="Enemy SAM",
+        location=location,
+        control_point=control_point,
+        task=None,
+    )
+    # known_for() reaches control_point.coalition.game.settings.recon_intel_fog.
+    tgo.control_point = cast(
+        Any,
+        SimpleNamespace(
+            coalition=SimpleNamespace(
+                game=SimpleNamespace(settings=SimpleNamespace(recon_intel_fog=fog))
+            )
+        ),
+    )
+    return tgo
+
+
+def test_enemy_site_unknown_until_discovered() -> None:
+    tgo = _enemy_sam()
+    # New enemy sites start unknown to the player...
+    assert tgo.discovered_by_player is False
+    assert tgo.known_for(Player.BLUE) is False
+    # ...but the omniscient view (AI planner / threat math) always sees truth.
+    assert tgo.known_for(None) is True
+    # Once discovered (attacked/scouted/destroyed), it is known and stays known.
+    tgo.discovered_by_player = True
+    assert tgo.known_for(Player.BLUE) is True
+
+
+def test_setting_off_reveals_everything() -> None:
+    tgo = _enemy_sam(fog=False)
+    assert tgo.discovered_by_player is False
+    # With the master toggle off, nothing is fogged even when undiscovered.
+    assert tgo.known_for(Player.BLUE) is True
+
+
+def test_setting_defaults_on() -> None:
+    from game.settings import Settings
+
+    assert Settings().recon_intel_fog is True
+
+
+def test_old_saves_migrate_to_discovered() -> None:
+    tgo = _enemy_sam()
+    state = dict(tgo.__dict__)
+    state.pop("discovered_by_player", None)  # simulate a pre-feature save
+    state.pop("_threat_poly", None)
+    tgo.__setstate__(state)
+    # An in-progress campaign keeps everything visible rather than blanking.
+    assert tgo.discovered_by_player is True

--- a/tests/test_recon_reveal.py
+++ b/tests/test_recon_reveal.py
@@ -1,0 +1,85 @@
+"""Recon intel-fog reveal-on-engage: a struck or overflown enemy site becomes
+known (composition revealed, permanently). Friendly sites are never gated.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from dcs.mapping import Point
+
+from game.ato.flighttype import FlightType
+from game.sim.gameupdateevents import GameUpdateEvents
+from game.sim.missionresultsprocessor import MissionResultsProcessor
+from game.theater import Player
+from game.theater.controlpoint import OffMapSpawn
+from game.theater.presetlocation import PresetLocation
+from game.theater.theatergroundobject import SamGroundObject
+from game.utils import Heading
+
+
+class _EnemySam(SamGroundObject):
+    def is_friendly(self, to_player: Player) -> bool:
+        return False
+
+
+def _enemy_sam() -> SamGroundObject:
+    location = PresetLocation(
+        name="target",
+        position=Point(0, 0, None),  # type: ignore[arg-type]
+        heading=Heading(0),
+    )
+    control_point = OffMapSpawn(
+        name="enemy-cp",
+        position=Point(0, 0, None),  # type: ignore[arg-type]
+        theater=None,  # type: ignore[arg-type]
+        starts_blue=Player.RED,
+    )
+    return _EnemySam(
+        name="Enemy SAM",
+        location=location,
+        control_point=control_point,
+        task=None,
+    )
+
+
+def _processor(*packages: Any) -> MissionResultsProcessor:
+    game = SimpleNamespace(
+        blue=SimpleNamespace(ato=SimpleNamespace(packages=list(packages))),
+        red=SimpleNamespace(ato=SimpleNamespace(packages=[])),
+    )
+    return MissionResultsProcessor(game)  # type: ignore[arg-type]
+
+
+def _debrief(surviving: int) -> Any:
+    return SimpleNamespace(
+        air_losses=SimpleNamespace(surviving_flight_members=lambda flight: surviving)
+    )
+
+
+def test_struck_enemy_site_is_revealed() -> None:
+    tgo = _enemy_sam()
+    assert tgo.discovered_by_player is False
+    processor = _processor()
+    processor.reveal_discovered_sites({tgo}, _debrief(0), GameUpdateEvents())
+    assert tgo.discovered_by_player is True
+
+
+def test_surviving_offensive_overflight_reveals_target() -> None:
+    tgo = _enemy_sam()
+    flight = SimpleNamespace(flight_type=FlightType.STRIKE)
+    package = SimpleNamespace(target=tgo, flights=[flight])
+    processor = _processor(package)
+    # No units struck, but a surviving striker overflew the target.
+    processor.reveal_discovered_sites(set(), _debrief(1), GameUpdateEvents())
+    assert tgo.discovered_by_player is True
+
+
+def test_dead_flight_with_no_survivors_does_not_reveal() -> None:
+    tgo = _enemy_sam()
+    flight = SimpleNamespace(flight_type=FlightType.DEAD)
+    package = SimpleNamespace(target=tgo, flights=[flight])
+    processor = _processor(package)
+    processor.reveal_discovered_sites(set(), _debrief(0), GameUpdateEvents())
+    assert tgo.discovered_by_player is False


### PR DESCRIPTION

### What

Adds an opt-in **recon intel-fog** to the human player's map. With it on (campaign
setting, default can be your call — the fork ships it ON for new campaigns), a newly
seen enemy ground site appears as a **targetable marker** (position, category,
allegiance) but its **actual composition and threat/detection rings stay hidden**
until the site is **attacked, scouted, or has a unit destroyed**. Once discovered, it
stays discovered (sticky, per-site, enemy-only).

A companion **"Reveal fog of war" overview toggle** — a transient, never-persisted
runtime switch — forces every player-facing fog accessor back to ground truth, so a
host can flip the whole map to the real picture for briefing/debrief without altering
any saved state.

The **AI planner and threat math are never fogged**: they pass `viewer=None`
(omniscient) everywhere, so auto-planning, threat zones used for routing, and
opponent reasoning all use full truth. The fog is purely a human-UI presentation
layer.

### Why

Today the player sees every enemy site's exact composition and SAM rings the instant
the campaign generates them, which removes any reason to scout and makes recon
flights pointless. This gates that knowledge behind contact, so the map reflects what
you've actually found.

### How (design)

- One **viewer-aware leaf** — `TheaterGroundObject.known_for(viewer)` — is the single
  source of truth for "does this viewer know what's actually here". `viewer=None`
  (AI/planner/threat) and friendly viewers always return `True`; an enemy viewer
  returns the sticky `discovered_by_player` flag, gated by the `recon_intel_fog`
  setting.
- Consumers **gate at the edge**: the map's TGO payload, IADS connections, and the
  enemy threat-zone builder all call `known_for(BLUE)` and emit a fogged
  (empty-rings, hidden-units) result when it is false; the Qt ground-object/building
  dialogs show "Not yet scouted — composition unknown".
- **Discovery** is flipped in the mission-results processor: any enemy site that was
  struck (a unit destroyed) or overflown by a surviving offensive sortie this turn is
  marked `discovered_by_player = True`.
- The **overview toggle** is a process-global `bool` in a new dependency-free
  `game/theater/fogofwar.py` (`fog_revealed()` / `set_fog_revealed()`), flipped via a
  new `PUT /fog-of-war/reveal` endpoint. `known_for` short-circuits to `True` when it
  is set, so the entire fogged render path un-fogs at once with no model changes. It
  is **never pickled** — a save can't carry a god-view.
- **Save migration**: a campaign saved before this feature has every site already on
  the map, so `TheaterGroundObject.__setstate__` defaults missing
  `discovered_by_player` to `True` (in-progress campaigns stay fully revealed; the fog
  is felt on new campaigns).

### Files

New:
- `game/theater/fogofwar.py` — the transient overview flag.
- `game/server/fogofwar/{__init__,routes}.py` — the `/fog-of-war/reveal` endpoint.

Changed:
- `game/theater/theatergroundobject.py` — `known_for`, `discovered_by_player`,
  `__setstate__` migration.
- `game/settings/settings.py` — the `recon_intel_fog` campaign setting.
- `game/threatzones.py` — `for_faction` filters air defenses by `known_for(viewer)`.
- `game/server/tgos/models.py` — `TgoJs.for_tgo` fogs composition/rings when unknown.
- `game/server/iadsnetwork/models.py` — hide IADS connections to/from unknown sites.
- `game/server/mapzones/models.py` — recompute the aggregate enemy threat-zone overlay
  with `viewer=Player.BLUE` at serialization, so the map overlay is fogged while the
  cached ground-truth zone still feeds the navmesh/AI.
- `game/server/app.py` — register the router.
- `game/sim/missionresultsprocessor.py` — `reveal_discovered_sites` +
  `attacked_tgos_this_turn` (reveal-on-engage).
- `qt_ui/windows/groundobject/QGroundObjectMenu.py` — "Not yet scouted" gate on the
  viewer-aware ground-object dialog.
- Client: `client/src/components/airdefenserangelayer/RevealFogToggle.tsx` +
  `LiberationMap.tsx` — a "Reveal fog of war" `LayersControl.Overlay` (mirroring the
  existing `EmitterHighlightToggle`) that `PUT`s the endpoint and re-pulls `/game`.

### Tests

- `tests/test_recon_intel_fog.py` — discovery gate, setting off, default-on,
  save migration.
- `tests/test_recon_reveal.py` — reveal-on-engage (struck / overflown).
- `tests/server/test_fogofwar_route.py` — the reveal endpoint flips the shared flag.

### Notes for the maintainer

- **Setting default**: the fork defaults `recon_intel_fog` ON for new campaigns. Pick
  whatever default you prefer; behavior with it OFF is identical to today.
- **Reveal trigger is deliberately generic** (struck or overflown by a surviving
  STRIKE/DEAD/SEAD/anti-ship flight). Confirm those `FlightType` member names against
  current upstream before merging.
- **The damage-lag half is intentionally not here.** Without it, the fog reveals
  composition on contact but does not lag *kills*; that's the clean separable line and
  the rest follows in PR #2 with the recon platform.
- **Client integration is the one non-portable bit** — the checkbox + `useEffect` is
  tiny, but it has to land in upstream's actual map-layer control, not the fork's
  custom panel. The Python endpoint is fully self-contained and tested.


---
*Carved from the 414th Joint Fighter Group fork (`bradyccox/414Ret`) and verified against upstream `dev` (`a31357b`): `git apply --check` clean, `black --check game qt_ui tests` clean, `mypy game tests` clean (439 files), 9 fog tests green. Client integration runs in CI.*
