### PR TITLE
Fix app lingering in the background on exit + add a single-instance guard

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@
 * **[Options]** Add new option to fast forward until player is at the IP.
 
 ## Fixes
+* **[App]** Retribution no longer stays alive in the background after its window is closed: the API server's graceful shutdown is now bounded (uvicorn otherwise waited forever on the long-lived event-stream websocket and the join hung).
+* **[App]** Relaunching the executable while it is already running no longer spawns orphaned, windowless duplicate processes; a second instance detects the first via an OS file lock and exits immediately.
 * **[Mission]** Reliably auto-detect end of mission, even when DCS wrote the final state.json before the wait dialog started watching
 * **[Performance]** Faster post-mission turn processing
 * **[AirWing]** Track per-squadron campaign aircraft stats (initial/destroyed/purchased, save-compatible) and expose pilot experience level and living/dead pilot views for the UI

--- a/game/server/server.py
+++ b/game/server/server.py
@@ -12,6 +12,10 @@ from game.server.app import app
 from game.server.settings import ServerSettings
 from game.sim import GameUpdateEvents
 
+# Upper bound (seconds) on uvicorn's graceful shutdown; without it, it can wait
+# forever for the long-lived /eventstream websocket task to drain on exit.
+GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = 3
+
 
 class Server(uvicorn.Server):
     def __init__(self, port: Optional[int]) -> None:
@@ -23,6 +27,7 @@ class Server(uvicorn.Server):
                 port=settings.server_port,
                 # Configured explicitly with default_logging.yaml or logging.yaml.
                 log_config=None,
+                timeout_graceful_shutdown=GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS,
             )
         )
 
@@ -39,4 +44,9 @@ class Server(uvicorn.Server):
         finally:
             self.should_exit = True
             EventStream.put_nowait(GameUpdateEvents().shut_down())
-            thread.join()
+            thread.join(timeout=GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS + 2)
+            if thread.is_alive():
+                # Graceful shutdown stalled anyway; force uvicorn to stop waiting
+                # so the process can exit instead of hanging on join() forever.
+                self.force_exit = True
+                thread.join(timeout=GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS)

--- a/qt_ui/main.py
+++ b/qt_ui/main.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import ntpath
 import sys
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -410,8 +411,47 @@ def dump_task_priorities() -> None:
         yaml.dump(data, output, sort_keys=False, allow_unicode=True)
 
 
+_single_instance_lock = None  # held lock-file handle; the OS frees it on exit
+
+
+def _acquire_single_instance_lock() -> bool:
+    """Become the only running instance; return False if another one holds the lock.
+
+    Uses an OS advisory lock on a temp file that the OS releases automatically when
+    this process exits, even on a crash. Without it, relaunching the executable
+    starts a second process that cannot bind the already-used web-server port, hangs
+    without ever showing a window, and is left orphaned when the first window closes.
+    """
+    global _single_instance_lock
+    lock_path = Path(tempfile.gettempdir()) / "dcs_retribution.lock"
+    try:
+        handle = open(lock_path, "w")
+    except OSError:
+        return True  # never block startup on a lock-file problem
+    try:
+        if sys.platform == "win32":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.close()
+        return False
+    _single_instance_lock = handle  # keep open for the lifetime of the process
+    return True
+
+
 def main():
     logging_config.init_logging(VERSION)
+
+    if not _acquire_single_instance_lock():
+        logging.warning(
+            "DCS Retribution is already running; exiting this duplicate instance."
+        )
+        sys.exit(0)
 
     logging.debug("Python version %s", sys.version)
 


### PR DESCRIPTION
Two related app process-lifecycle fixes.

### 1. App lingers in the background after the window is closed
Closing Retribution sometimes left `retribution_main.exe` running (hundreds of MB). The API server (uvicorn) runs in a background thread; on shutdown `Server.run_in_thread()` joins it, but `timeout_graceful_shutdown` was never set, so uvicorn waited forever for the long-lived `/eventstream` websocket task to drain — it never does once the web view is torn down — and the join hung.

Fix: set `timeout_graceful_shutdown=3` on the uvicorn config, plus a `force_exit` + bounded-join backstop, so the server thread always stops and the process exits. (This is the change from the now-closed #795.)

### 2. Relaunching the exe spawns orphaned duplicate processes
Launching the executable while an instance is already running started a second process that couldn't bind the already-in-use web-server port, hung without ever showing a window, and was left orphaned when the first window was closed (each extra launch left another orphan).

Fix: acquire an OS advisory lock on a temp file at startup (`msvcrt` on Windows, `fcntl` elsewhere). If another instance already holds it, exit immediately. The OS releases the lock when the process exits — even on a crash — so no stale lock blocks a later launch. (A duplicate launch currently just exits with a log line; raising/focusing the existing window would need IPC and can be added if preferred.)

Draft — opening for early feedback; happy to split into two commits if that's preferred.
