### PR TITLE
Mission Planning: carrier/LHA targets offer SEAD instead of a duplicate SEAD Escort

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 * **[Options]** Add new option to fast forward until player is at the IP.
 
 ## Fixes
+* **[Mission Planning]** Carrier/LHA targets now offer SEAD in the flight-task list and no longer list SEAD Escort twice (their escorts are SAM platforms, so they can be suppressed directly like any other naval group).
 * **[App]** Retribution no longer stays alive in the background after its window is closed: the API server's graceful shutdown is now bounded (uvicorn otherwise waited forever on the long-lived event-stream websocket and the join hung).
 * **[App]** Relaunching the executable while it is already running no longer spawns orphaned, windowless duplicate processes; a second instance detects the first via an OS file lock and exits immediately.
 * **[Mission]** Reliably auto-detect end of mission, even when DCS wrote the final state.json before the wait dialog started watching

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1409,7 +1409,7 @@ class NavalControlPoint(
         else:
             yield from [
                 FlightType.ANTISHIP,
-                FlightType.SEAD_ESCORT,
+                FlightType.SEAD,
             ]
         yield from super().mission_types(for_player)
         if self.is_friendly(for_player):

--- a/tests/theater/test_mission_types_no_duplicates.py
+++ b/tests/theater/test_mission_types_no_duplicates.py
@@ -1,0 +1,48 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Importing these registers every concrete MissionTarget subclass (control
+# points, theater ground objects, transfers, front lines) so the
+# parametrization below discovers them all.
+import game.theater.controlpoint  # noqa: F401
+import game.theater.theatergroundobject  # noqa: F401
+from game.theater.missiontarget import MissionTarget
+
+
+def _concrete_mission_targets() -> list[type[MissionTarget]]:
+    found: set[type[MissionTarget]] = set()
+
+    def walk(cls: type[MissionTarget]) -> None:
+        for sub in cls.__subclasses__():
+            walk(sub)
+            if not getattr(sub, "__abstractmethods__", frozenset()):
+                found.add(sub)
+
+    walk(MissionTarget)
+    return sorted(found, key=lambda c: c.__name__)
+
+
+@pytest.mark.parametrize("cls", _concrete_mission_targets())
+@pytest.mark.parametrize("friendly", [True, False])
+def test_mission_types_have_no_duplicates(
+    cls: "type[MissionTarget]", friendly: bool
+) -> None:
+    """No mission target may offer the same FlightType twice.
+
+    mission_types() chains a subclass's own entries with the base mission
+    types; listing one the base already provides (as happened with
+    SEAD_ESCORT on carriers) produces a duplicate in the "Create flight" task
+    menu. Covers every concrete mission target, for either coalition.
+    """
+    # Built without running __init__ (it needs a full game); typed as Any so
+    # the mocks can stand in for the real, strongly-typed attributes. Only
+    # mission_types() and the two collaborators it consults are exercised.
+    target: Any = object.__new__(cls)
+    target.is_friendly = MagicMock(return_value=friendly)
+    target.total_aircraft_parking = MagicMock(return_value=1)
+
+    types = list(target.mission_types(MagicMock()))
+
+    assert len(types) == len(set(types)), f"{cls.__name__}: duplicates in {types}"


### PR DESCRIPTION
Carrier and LHA targets listed **SEAD Escort twice** in the "Create flight" task menu: `NavalControlPoint.mission_types()` yielded `SEAD_ESCORT` explicitly, but the base `MissionTarget.mission_types()` already yields it. This changes the explicit yield to **SEAD**, so carrier groups offer SEAD (their escorts are SAM platforms and can be suppressed directly, like any other naval group) with no duplicate — `SEAD_ESCORT` is still available via the base class.

A new parametrized test (`tests/theater/test_mission_types_no_duplicates.py`) asserts that no concrete `MissionTarget` offers a duplicate `FlightType`, for either coalition.

Verified: the new test passes (40 cases); reverting only the one-line fix makes it fail for exactly `Carrier`, `EssexCarrier` and `Lha`; the full `tests/theater` suite passes with no regressions.