### PR TITLE
Air assault: keep the drop-off zone out of the water

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 * **[Flight Plans]** Stabilized waypoint solver debug GeoJSON coordinate precision to avoid platform-specific floating point drift in debug output.
 * **[Mission Generation]** Assign plane-specific laser codes to LGB weapons when building the mission
 * **[Engine]** Fixed a bug where squadrons could transfer to enemy owned control points
+* **[Mission Generation]** Air assault drop-off zones are kept on land, so coastal objectives no longer drop the troops into the sea.
 
 # Retribution v1.5.0
 

--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -154,9 +154,7 @@ class Builder(FormationAttackBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
         else:
             heading = tgt.position.heading_between_point(ingress.position)
             drop_pos = tgt.position.point_from_heading(heading, 1200)
-            # Keep the drop-off out of the water: for coastal objectives the
-            # 1200 m offset toward the ingress can land offshore. Predefined CTLD
-            # drop-off zones are placed by the campaign designer, so leave them as-is.
+            # Keep the drop-off out of the water
             drop_pos = self.flight.coalition.game.theater.nearest_land_pos(drop_pos)
         drop_off_zone = MissionTarget("Dropoff zone", drop_pos)
         dz = builder.dropoff_zone(drop_off_zone) if self.flight.is_helo else None

--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -154,6 +154,9 @@ class Builder(FormationAttackBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
         else:
             heading = tgt.position.heading_between_point(ingress.position)
             drop_pos = tgt.position.point_from_heading(heading, 1200)
+        # Keep the drop-off out of the water: for coastal objectives the CTLD
+        # random point or the 1200 m offset toward the ingress can land offshore.
+        drop_pos = self.flight.coalition.game.theater.nearest_land_pos(drop_pos)
         drop_off_zone = MissionTarget("Dropoff zone", drop_pos)
         dz = builder.dropoff_zone(drop_off_zone) if self.flight.is_helo else None
 

--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -154,8 +154,7 @@ class Builder(FormationAttackBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
         else:
             heading = tgt.position.heading_between_point(ingress.position)
             drop_pos = tgt.position.point_from_heading(heading, 1200)
-        # Keep the drop-off out of the water: for coastal objectives the CTLD
-        # random point or the 1200 m offset toward the ingress can land offshore.
+
         drop_pos = self.flight.coalition.game.theater.nearest_land_pos(drop_pos)
         drop_off_zone = MissionTarget("Dropoff zone", drop_pos)
         dz = builder.dropoff_zone(drop_off_zone) if self.flight.is_helo else None

--- a/game/ato/flightplans/airassault.py
+++ b/game/ato/flightplans/airassault.py
@@ -154,8 +154,10 @@ class Builder(FormationAttackBuilder[AirAssaultFlightPlan, AirAssaultLayout]):
         else:
             heading = tgt.position.heading_between_point(ingress.position)
             drop_pos = tgt.position.point_from_heading(heading, 1200)
-
-        drop_pos = self.flight.coalition.game.theater.nearest_land_pos(drop_pos)
+            # Keep the drop-off out of the water: for coastal objectives the
+            # 1200 m offset toward the ingress can land offshore. Predefined CTLD
+            # drop-off zones are placed by the campaign designer, so leave them as-is.
+            drop_pos = self.flight.coalition.game.theater.nearest_land_pos(drop_pos)
         drop_off_zone = MissionTarget("Dropoff zone", drop_pos)
         dz = builder.dropoff_zone(drop_off_zone) if self.flight.is_helo else None
 


### PR DESCRIPTION
For coastal objectives the air-assault drop-off position was computed without a land check: the CTLD random point (`random_point_within`) or the 1200 m offset toward the ingress could land offshore, dropping the troops into the sea (where they die, DCS soldiers doesn't swim very well).

Snap the drop-off to the nearest land with `theater.nearest_land_pos` — a no-op when the point is already on land, and on theaters that ship no landmap.