### PR TITLE
Add optional descriptionInUI field for plugin options

### DIFF
--- a/game/plugins/luaplugin.py
+++ b/game/plugins/luaplugin.py
@@ -72,6 +72,7 @@ class LuaPluginOption(PluginSettings):
 class LuaPluginDefinition:
     identifier: str
     name: str
+    description: str
     present_in_ui: bool
     enabled_by_default: bool
     options: List[LuaPluginOption]
@@ -120,6 +121,7 @@ class LuaPluginDefinition:
         return cls(
             identifier=name,
             name=data["nameInUI"],
+            description=data.get("descriptionInUI", ""),
             present_in_ui=not data.get("skipUI", False),
             enabled_by_default=data.get("defaultValue", False),
             options=options,
@@ -137,6 +139,10 @@ class LuaPlugin(PluginSettings):
     @property
     def name(self) -> str:
         return self.definition.name
+
+    @property
+    def description(self) -> str:
+        return self.definition.description
 
     @property
     def show_in_ui(self) -> bool:

--- a/qt_ui/windows/settings/plugins.py
+++ b/qt_ui/windows/settings/plugins.py
@@ -72,7 +72,20 @@ class PluginOptionsBox(QGroupBox):
 
         self.widgets: Dict[str, QWidget] = {}
 
-        for row, option in enumerate(plugin.options):
+        row = 0
+        if plugin.description:
+            description = QLabel(plugin.description)
+            description.setWordWrap(True)
+            font = description.font()
+            font.setItalic(True)
+            description.setFont(font)
+            description.setTextInteractionFlags(
+                Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+            layout.addWidget(description, row, 0, 1, 2)
+            row += 1
+
+        for option in plugin.options:
             label = QLabel(option.name)
             label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
             layout.addWidget(label, row, 0)
@@ -97,6 +110,8 @@ class PluginOptionsBox(QGroupBox):
                 spinbox.valueChanged.connect(option.set_value)
                 layout.addWidget(spinbox, row, 1)
                 self.widgets[option.identifier] = spinbox
+
+            row += 1
 
     def update_from_settings(self, settings: Settings) -> None:
         for identifier in self.widgets:

--- a/resources/plugins/MooseSoundhandler/plugin.json
+++ b/resources/plugins/MooseSoundhandler/plugin.json
@@ -1,5 +1,6 @@
 {
     "nameInUI": "Moose Soundhandler",
+    "descriptionInUI": "Plays radio-call and combat sound effects (weapon launch calls, kill confirmations, SAM warnings) in response to in-game events for added immersion.",
     "defaultValue": false,
     "specificOptions": [
         {

--- a/resources/plugins/airboss/plugin.json
+++ b/resources/plugins/airboss/plugin.json
@@ -1,5 +1,6 @@
 {
     "nameInUI": "Moose Airboss",
+    "descriptionInUI": "Carrier air-traffic control: LSO and Marshal voice comms, the recovery window schedule, and an optional rescue helo / recovery tanker for carrier operations.",
     "defaultValue": false,
     "specificOptions": [        
         {

--- a/resources/plugins/arty/plugin.json
+++ b/resources/plugins/arty/plugin.json
@@ -1,5 +1,6 @@
 {
     "nameInUI": "Carsten's Arty Spotter",
+    "descriptionInUI": "Lets players call in friendly artillery fire missions on map-marked positions, with control over salvo size, dispersion, and how far away targets can be spotted.",
     "defaultValue": false,
     "specificOptions": [
         {

--- a/resources/plugins/artymbot/plugin.json
+++ b/resources/plugins/artymbot/plugin.json
@@ -1,5 +1,6 @@
 {
     "nameInUI": "Mbot Call Artillery Script",
+    "descriptionInUI": "Alternative artillery fire-support engine that lets players direct land (and optionally ship) gunfire onto targets.",
     "defaultValue": false,
     "specificOptions": [
         {

--- a/resources/plugins/bigeye/plugin.json
+++ b/resources/plugins/bigeye/plugin.json
@@ -1,5 +1,6 @@
 {
     "nameInUI": "BigEye EWR",
+    "descriptionInUI": "Early-warning radar that broadcasts text threat reports to pilots, prioritised by how dangerous each contact is and tuned per coalition by available sensors (datalink, RWR, IRST).",
     "defaultValue": false,
     "specificOptions": [
         {

--- a/resources/plugins/ctld/plugin.json
+++ b/resources/plugins/ctld/plugin.json
@@ -1,5 +1,6 @@
 {
     "nameInUI": "CTLD",
+    "descriptionInUI": "Helicopter and transport logistics: sling-loading crates, deploying troops and vehicles, and JTAC autolasing for laser-guided strikes.",
     "defaultValue": true,
     "specificOptions": [
         {

--- a/resources/plugins/lotatc/plugin.json
+++ b/resources/plugins/lotatc/plugin.json
@@ -1,5 +1,6 @@
 {
     "nameInUI": "LotATC Export",
+    "descriptionInUI": "Exports anti-air sites to LotATC so GCI controllers can see the SAM/AAA picture on the LotATC radar scope.",
     "defaultValue": false,
     "specificOptions": [
         {

--- a/resources/plugins/skynetiads/plugin.json
+++ b/resources/plugins/skynetiads/plugin.json
@@ -1,5 +1,6 @@
 {
     "nameInUI": "Skynet IADS",
+    "descriptionInUI": "Networks each coalition's SAMs and EWRs into an Integrated Air Defense System, coordinating detection and engagement and letting mobile SAMs shoot-and-scoot instead of fighting as isolated sites.",
     "defaultValue": true,
     "specificOptions": [
         {


### PR DESCRIPTION
## What

Adds an optional `descriptionInUI` string to the plugin manifest schema. When present, it renders as an italic, word-wrapped line at the top of that plugin's options box in the settings dialog — a one-line "what does this plugin do?" for players.

## Why

The plugins list shows a name and a checkbox but no explanation of what each plugin actually does, so enabling them is guesswork unless you read the source. A short per-plugin description in the UI is pure discoverability.

## Details

- `game/plugins/luaplugin.py` — `LuaPluginDefinition` gains a `description` field, read from `descriptionInUI` in `from_json` (defaults to `""`), exposed via a `LuaPlugin.description` property.
- `qt_ui/windows/settings/plugins.py` — `PluginOptionsBox` renders the description above the options when non-empty.
- Populated `descriptionInUI` for the bundled plugins whose purpose is unambiguous (airboss, arty, artymbot, bigeye, ctld, lotatc, skynetiads, MooseSoundhandler) so the field is demonstrated rather than dormant.

## Compatibility

Fully backward-compatible: the field is optional and defaults to empty, so any plugin (bundled or third-party) without `descriptionInUI` renders exactly as before. No settings/save changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)