### PR TITLE
perf(theater): use the prepared landmap index in is_on_land/is_in_sea

### DIFF
--- a/game/theater/conflicttheater.py
+++ b/game/theater/conflicttheater.py
@@ -114,13 +114,17 @@ class ConflictTheater:
         if self.is_on_land(point):
             return False
 
-        for exclusion_zone in self.landmap.exclusion_zones.geoms:
-            if poly_contains(point.x, point.y, exclusion_zone):
-                return False
+        # Test the prepared MultiPolygons as a whole rather than looping their
+        # .geoms: shp.prepare() builds a spatial index on the MultiPolygon, so a
+        # single .contains() is indexed instead of a Python loop over every
+        # polygon (which also rebuilt a shapely Point per geom). On large theaters
+        # with thousands of exclusion zones this is the difference between minutes
+        # and seconds in the ground-conflict phase.
+        if poly_contains(point.x, point.y, self.landmap.exclusion_zones):
+            return False
 
-        for sea in self.landmap.sea_zones.geoms:
-            if poly_contains(point.x, point.y, sea):
-                return True
+        if poly_contains(point.x, point.y, self.landmap.sea_zones):
+            return True
 
         return False
 
@@ -136,9 +140,11 @@ class ConflictTheater:
             return False
 
         if not ignore_exclusion:
-            for exclusion_zone in self.landmap.exclusion_zones.geoms:
-                if poly_contains(point.x, point.y, exclusion_zone):
-                    return False
+            # Single indexed contains on the prepared MultiPolygon (see is_in_sea)
+            # rather than a per-polygon loop — this is a hot path during ground
+            # generation.
+            if poly_contains(point.x, point.y, self.landmap.exclusion_zones):
+                return False
 
         return True
 

--- a/game/theater/landmap.py
+++ b/game/theater/landmap.py
@@ -29,7 +29,15 @@ class Landmap:
         if not self.sea_zones.is_valid:
             raise RuntimeError("Sea zones not valid")
 
-        # Generate Spatial Index using `prepare` to improve performance
+        self.prepare()
+
+    def prepare(self) -> None:
+        """Build the GEOS spatial index on each zone MultiPolygon so point-in-
+        polygon queries are indexed instead of linear. ``shp.prepare`` is
+        idempotent. It runs from ``__post_init__`` for freshly built landmaps,
+        but pickle (``load_landmap``) bypasses ``__post_init__``, so the load
+        path calls this explicitly — otherwise the index is missing and
+        ``is_on_land``/``is_in_sea`` degrade to a full scan of every polygon."""
         shp.prepare(self.inclusion_zones)
         shp.prepare(self.exclusion_zones)
         shp.prepare(self.sea_zones)
@@ -46,7 +54,11 @@ class Landmap:
 def load_landmap(filename: Path) -> Optional[Landmap]:
     try:
         with open(filename, "rb") as f:
-            return pickle.load(f)
+            landmap = pickle.load(f)
+        # Pickle bypasses __post_init__, so the prepared spatial index isn't
+        # rebuilt; do it now (see Landmap.prepare).
+        landmap.prepare()
+        return landmap
     except:
         logging.exception(f"Failed to load landmap {filename}")
         return None


### PR DESCRIPTION
## What

Makes the `is_on_land` / `is_in_sea` landmap queries actually use the GEOS spatial index that `Landmap` already builds, removing a multi-minute stall during ground generation on large theaters.

## The problem

`Landmap.__post_init__` calls `shp.prepare()` on each zone `MultiPolygon` to build a spatial index — but two things meant the index never helped at runtime:

1. **The queries bypassed it.** `is_on_land` / `is_in_sea` looped over `MultiPolygon.geoms` and ran `poly_contains` against each child `Polygon` individually. That sidesteps the prepared index entirely and rebuilds a shapely `Point` for every geom. On a theater with thousands of exclusion zones this is millions of `contains()`/`Point` calls.
2. **The index was never built on loaded landmaps.** Landmaps ship as pickles (`landmap.p`) and are loaded via `load_landmap` / `__setstate__`. `pickle` bypasses `__post_init__`, so `shp.prepare()` was never called on the object that's actually used.

## The fix

- `is_on_land` / `is_in_sea` now test the whole prepared `MultiPolygon` with a single indexed `contains()` instead of looping `.geoms`.
- `shp.prepare()` is factored into `Landmap.prepare()`, called from `__post_init__` (unchanged for fresh landmaps) **and** from `load_landmap` after the pickle load so the loaded object gets its index.

## Compatibility

No behaviour change — the boolean results are identical, the queries are just indexed. No save-format change. `shp.prepare()` is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)