### PR TITLE
Improve F-4E-45MC (Heatblur) default loadouts

### DIFF
--- a/resources/customized_payloads/F-4E-45MC.lua
+++ b/resources/customized_payloads/F-4E-45MC.lua
@@ -6,84 +6,60 @@ local unitPayloads = {
 			["name"] = "Retribution CAS",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{AGM_62_I}",
+					["CLSID"] = "{DB769D48-67D7-42ED-A2BE-108D566C8B1E}",
 					["num"] = 13,
 				},
+				[2] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
+					["num"] = 7,
 				},
 				[5] = {
 					["CLSID"] = "{HB_PAVE_SPIKE_FAST_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{AGM_62_I}",
-					["num"] = 1,
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 5,
 				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
+				[7] = {
+					["CLSID"] = "{DB769D48-67D7-42ED-A2BE-108D566C8B1E}",
+					["num"] = 1,
 				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{HB_F4EAGM-65D_LAU88_3x_Right}",
+				[8] = {
+					["CLSID"] = "{HB_F4EAGM-65D_LAU88_2x_Right}",
 					["num"] = 11,
 				},
-				[14] = {
-					["CLSID"] = "{HB_F4EAGM-65D_LAU88_3x_Left}",
+				[9] = {
+					["CLSID"] = "{HB_F4EAGM-65D_LAU88_2x_Left}",
 					["num"] = 3,
+				},
+				[10] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[11] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 4,
+				},
+				[12] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
+				},
+				[13] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
+				},
+				[14] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 10,
 				},
 			},
 			["tasks"] = {
@@ -100,94 +76,54 @@ local unitPayloads = {
 				[2] = {
 					["CLSID"] = "{LAU_34_AGM_45A}",
 					["num"] = 13,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
 				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AGM-65A_LAU117_SWA}",
+					["num"] = 11,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
 				},
 				[5] = {
-					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
-					["num"] = 6,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 1,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7F}",
 					["num"] = 9,
 				},
-				[12] = {
+				[7] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 8,
+				},
+				[8] = {
 					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
 					["num"] = 7,
 				},
+				[9] = {
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
+				},
+				[12] = {
+					["CLSID"] = "{HB_F4E_AGM-65A_LAU117_SWA}",
+					["num"] = 3,
+				},
 				[13] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 11,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
 				},
 				[14] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 3,
+					["CLSID"] = "{LAU_34_AGM_45A}",
+					["num"] = 1,
 				},
 			},
 			["tasks"] = {
@@ -198,124 +134,60 @@ local unitPayloads = {
 			["name"] = "Retribution Strike",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}", --GBU-24A/B
+					["num"] = 13,
 				},
 				[2] = {
-					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
-					["num"] = 13,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
 				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
+					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
+					["num"] = 7,
 				},
 				[5] = {
 					["CLSID"] = "{HB_PAVE_SPIKE_FAST_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
-					["num"] = 1,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 5,
 				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
+				[7] = {
 					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
-					["num"] = 3,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
+					["num"] = 1,
 				},
-				[14] = {
+				[8] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[9] = {
 					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
 					["num"] = 11,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
+				},
+				[10] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 3,
+				},
+				[11] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
+				},
+				[12] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 4,
+				},
+				[13] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 10,
+				},
+				[14] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
 				},
 			},
 			["tasks"] = {
@@ -326,99 +198,104 @@ local unitPayloads = {
 			["name"] = "Retribution Escort",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
-					["num"] = 13,
-				},
-				[3] = {
-					["CLSID"] = "{AIM-9M}",
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 12,
 				},
-				[4] = {
-					["CLSID"] = "{AIM-9M}",
+				[2] = {
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 10,
 				},
+				[3] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[5] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 2,
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 5,
 				},
 				[7] = {
-					["CLSID"] = "{AIM-9M}",
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 4,
 				},
 				[8] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
+				},
+				[9] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
+					["num"] = 13,
+				},
+				[10] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
 					["num"] = 1,
 				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
 				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
 				},
 			},
 			["tasks"] = {
 			},
 		},
 		[5] = {
+			["displayName"] = "Retribution BARCAP",
 			["name"] = "Retribution BARCAP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
+					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
+					["num"] = 12,
 				},
 				[2] = {
+					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
+					["num"] = 10,
+				},
+				[3] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 9,
+				},
+				[5] = {
+					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
+					["num"] = 7,
+				},
+				[6] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 5,
+				},
+				[8] = {
+					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
+					["num"] = 4,
+				},
+				[9] = {
+					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
+					["num"] = 2,
+				},
+				[10] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
 					["num"] = 13,
 				},
-				[3] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 12,
-				},
-				[4] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 10,
-				},
-				[5] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 6,
-				},
-				[6] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 2,
-				},
-				[7] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 4,
-				},
-				[8] = {
+				[11] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
 					["num"] = 1,
 				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+				[12] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
 				},
 			},
 			["tasks"] = {
@@ -435,82 +312,54 @@ local unitPayloads = {
 				[2] = {
 					["CLSID"] = "{LAU_34_AGM_45A}",
 					["num"] = 13,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
 				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
+					["CLSID"] = "{LAU_34_AGM_45A_SWA}",
+					["num"] = 11,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
 				},
 				[5] = {
-					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
-					["num"] = 6,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-				},
-				[8] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 1,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7F}",
 					["num"] = 9,
 				},
-				[12] = {
+				[7] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 8,
+				},
+				[8] = {
 					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
 					["num"] = 7,
 				},
+				[9] = {
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
+				},
+				[12] = {
+					["CLSID"] = "{LAU_34_AGM_45A_SWA}",
+					["num"] = 3,
+				},
 				[13] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 11,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
 				},
 				[14] = {
 					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 3,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["num"] = 1,
 				},
 			},
 			["tasks"] = {
@@ -521,99 +370,100 @@ local unitPayloads = {
 			["name"] = "Retribution TARCAP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
-					["num"] = 13,
-				},
-				[3] = {
-					["CLSID"] = "{AIM-9M}",
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 12,
 				},
-				[4] = {
-					["CLSID"] = "{AIM-9M}",
+				[2] = {
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 10,
 				},
+				[3] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[5] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 2,
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 5,
 				},
 				[7] = {
-					["CLSID"] = "{AIM-9M}",
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 4,
 				},
 				[8] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
+				},
+				[9] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
+					["num"] = 13,
+				},
+				[10] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
 					["num"] = 1,
 				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
 				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
 				},
 			},
 			["tasks"] = {
 			},
 		},
 		[8] = {
+			["displayName"] = "Retribution Anti-ship",
 			["name"] = "Retribution Anti-ship",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 13,
-				},
-				[3] = {
-					["CLSID"] = "{C40A1E3A-DD05-40D9-85A4-217729E37FAE}",
-					["num"] = 11,
-				},
-				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-				},
-				[5] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-				},
-				[6] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 9,
 				},
-				[7] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+				[2] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 8,
 				},
-				[8] = {
+				[3] = {
 					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+				[4] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 5,
 				},
-				[10] = {
+				[5] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
+					["num"] = 1,
+				},
+				[6] = {
+					["CLSID"] = "{C40A1E3A-DD05-40D9-85A4-217729E37FAE}",
+					["num"] = 11,
+				},
+				[7] = {
 					["CLSID"] = "{C40A1E3A-DD05-40D9-85A4-217729E37FAE}",
 					["num"] = 3,
 				},
+				[8] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[9] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
+					["num"] = 13,
+				},
+				[10] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
+				},
 				[11] = {
 					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
+					["num"] = 10,
 				},
 				[12] = {
 					["CLSID"] = "<CLEAN>",
@@ -621,11 +471,7 @@ local unitPayloads = {
 				},
 				[13] = {
 					["CLSID"] = "<CLEAN>",
-					["num"] = 1,
-				},
-				[14] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
+					["num"] = 2,
 				},
 			},
 			["tasks"] = {
@@ -636,84 +482,60 @@ local unitPayloads = {
 			["name"] = "Retribution BAI",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "<CLEAN>",
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
 					["num"] = 13,
 				},
+				[2] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_CBU-87_MER_4x}",
+					["num"] = 7,
 				},
 				[5] = {
 					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 1,
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 5,
 				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
+				[7] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
+					["num"] = 1,
 				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{HB_F4EAGM-65D_LAU88_3x_Right}",
+				[8] = {
+					["CLSID"] = "{HB_F4E_CBU-87_2x_SWA}",
 					["num"] = 11,
 				},
-				[14] = {
-					["CLSID"] = "{HB_F4EAGM-65D_LAU88_3x_Left}",
+				[9] = {
+					["CLSID"] = "{HB_F4E_CBU-87_2x_SWA}",
 					["num"] = 3,
+				},
+				[10] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
+				},
+				[11] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
+				},
+				[12] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
+				},
+				[13] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
+				},
+				[14] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
 				},
 			},
 			["tasks"] = {
@@ -728,96 +550,52 @@ local unitPayloads = {
 					["num"] = 14,
 				},
 				[2] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
 					["num"] = 13,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
 				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{LAU_34_AGM_45A}",
+					["num"] = 11,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 9,
 				},
 				[5] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 8,
+				},
+				[6] = {
 					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
 				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 5,
 				},
 				[8] = {
 					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 1,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["num"] = 3,
 				},
 				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
+					["num"] = 1,
 				},
 				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
 				},
 				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+					["CLSID"] = "<CLEAN>",
+					["num"] = 10,
 				},
 				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
+					["CLSID"] = "<CLEAN>",
+					["num"] = 4,
 				},
 				[13] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 11,
-				},
-				[14] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 3,
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
 				},
 			},
 			["tasks"] = {
@@ -828,84 +606,52 @@ local unitPayloads = {
 			["name"] = "Retribution OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{GBU_8_B}",
+					["CLSID"] = "{HB_F4E_CBU-87_MER_3x_Right}",
 					["num"] = 13,
 				},
+				[2] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_CBU-87_MER_4x}",
+					["num"] = 7,
 				},
 				[5] = {
-					["CLSID"] = "{HB_PAVE_SPIKE_FAST_ON_ADAPTER_IN_AERO7}",
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{GBU_8_B}",
-					["num"] = 1,
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 5,
 				},
+				[7] = {
+					["CLSID"] = "{HB_F4E_CBU-87_MER_3x_Left}",
+					["num"] = 1,
+				},
+				[8] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
+				},
+				[9] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
+				},
 				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
 				},
 				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
 				},
 				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{GBU_8_B}",
-					["num"] = 11,
-				},
-				[14] = {
-					["CLSID"] = "{GBU_8_B}",
-					["num"] = 3,
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
 				},
 			},
 			["tasks"] = {
@@ -916,84 +662,52 @@ local unitPayloads = {
 			["name"] = "Retribution OCA/Runway",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
 					["num"] = 13,
 				},
+				[2] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[5] = {
 					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
+				[5] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 5,
+				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
 					["num"] = 1,
 				},
+				[7] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[8] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
+				},
 				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
 				},
 				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
 				},
 				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
 				},
 				[12] = {
 					["CLSID"] = "{HB_F4E_BLU-107B_6x}",
 					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{HB_F4E_BLU-107B_3x}",
-					["num"] = 11,
-				},
-				[14] = {
-					["CLSID"] = "{HB_F4E_BLU-107B_3x}",
-					["num"] = 3,
 				},
 			},
 			["tasks"] = {
@@ -1010,94 +724,54 @@ local unitPayloads = {
 				[2] = {
 					["CLSID"] = "{LAU_34_AGM_45A}",
 					["num"] = 13,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
 				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{LAU_34_AGM_45A_SWA}",
+					["num"] = 11,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
 				},
 				[5] = {
-					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
-					["num"] = 6,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 1,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7F}",
 					["num"] = 9,
 				},
-				[12] = {
+				[7] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 8,
+				},
+				[8] = {
 					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
 					["num"] = 7,
 				},
+				[9] = {
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
+				},
+				[12] = {
+					["CLSID"] = "{LAU_34_AGM_45A_SWA}",
+					["num"] = 3,
+				},
 				[13] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 11,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
 				},
 				[14] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 3,
+					["CLSID"] = "{LAU_34_AGM_45A}",
+					["num"] = 1,
 				},
 			},
 			["tasks"] = {


### PR DESCRIPTION
## What

The `F-4E-45MC` (Heatblur Phantom) Retribution loadout presets in `resources/customized_payloads/F-4E-45MC.lua` were a grab-bag of odd single-weapon fits (and weapon picks that read as nonsensical in the payload editor). This rebuilds **all 13** presets by sourcing them directly from the **module's own built-in loadouts**, mapped to the matching `Retribution <task>` names.

| Task | Loadout |
|---|---|
| CAS | AGM-65D ×4 + GBU-12 ×2 + Pave Spike |
| BAI | CBU-87 ×8 cluster |
| Strike | GBU-24 ×4 (2000lb LGB) + Pave Spike |
| DEAD | AGM-45 Shrike ×2 + AGM-65A ×2 (hunter-killer) |
| SEAD / SEAD Sweep | AGM-45 Shrike ×4 |
| SEAD Escort | AGM-45 Shrike ×2 + endurance tanks |
| Escort / TARCAP | 4× AIM-7E2 + 4× AIM-9L |
| BARCAP | 4× AIM-7F + 4× AIM-9P, 3 tanks |
| Anti-ship | AGM-62 Walleye II ×2 |
| OCA/Aircraft | CBU-87 ×10 |
| OCA/Runway | BLU-107 Durandal ×6 |

## Why

The previous presets used modern air-to-air across the board (AIM-7M everywhere) and several picks (e.g. a lone Walleye, mostly-empty stations) that triggered the editor's "incompatible loadout" skip → the planner fell back to a clean jet, which is what made them look broken. The rebuilt set uses a **period-correct AIM-7E2 / AIM-9L** A2A baseline (AIM-7F/9P on BARCAP) so `restrict_weapons_by_date` degrades to best-available across both early and modern eras, and each preset is a coherent, role-appropriate fit.

## Validation

Headless against this tree (`pydcs` + `f4e_expanded_weapons`):
- Every CLSID resolves (`Loadout.valid_payload`) — no skipped presets.
- Every weapon is legal on its assigned pylon station.
- Every F-4E combat task resolves to its `Retribution` preset — no clean-jet fallback.

Data-only change to one `customized_payloads` file; no Python touched.