### PR TITLE
Degrade Mavericks to Rockeye instead of Walleye

### DIFF
--- a/resources/weapons/standoff/AGM-65A.yaml
+++ b/resources/weapons/standoff/AGM-65A.yaml
@@ -1,6 +1,10 @@
 name: AGM-65A
 year: 1972
-fallback: AGM-62 Walleye II
+# Degrade Mavericks to an anti-armor cluster (Rockeye), not the AGM-62 Walleye.
+# A Maverick is a CAS/anti-armor PGM; the period substitute for that mission is
+# Rockeye, not a ~1100lb TV-guided standoff bomb. The whole AGM-65 family chains
+# down through this node, so this reroutes every Maverick's pre-1972 degrade.
+fallback: Mk-20 Rockeye
 clsids:
   - "{RB75}"   # Rb-75A (AGM-65A Maverick) (TV ASM)
   - "{HB_F4E_AGM-65A_LAU117}"   # AGM-65A - Maverick A (TV Guided) (LAU-117)


### PR DESCRIPTION
## Problem

With `restrict_weapons_by_date` on, every AGM-65 Maverick's date-fallback chain bottoms out at the **AGM-62 Walleye**:

> `AGM-65D` → `AGM-65B` → `AGM-65A` → **`AGM-62 Walleye II`**

A Maverick is a CAS/anti-armor PGM; degrading it to a ~1100 lb TV-guided standoff bomb is the wrong mission. It's most visible on the Heatblur F-4E in a Vietnam-era campaign, where CAS and DEAD flights end up carrying Walleyes on the inner-wing pylons.

## Fix

Reroute `AGM-65A`'s fallback to **Mk-20 Rockeye** (anti-armor cluster, 1968). The whole AGM-65 family chains down through `AGM-65A`, so this corrects every aircraft's Maverick degrade in one node:

> `AGM-65D` → `AGM-65B` → `AGM-65A` → `Mk-20 Rockeye` → `Mk 82`

Walleye remains available where it's deliberately loaded. One-line weapon-data change; verified the weapon DB loads and the chain no longer contains Walleye.