### PR TITLE
Improve F-4E-45MC loadouts and fix Maverick date-fallback

### DIFF
--- a/resources/customized_payloads/F-4E-45MC.lua
+++ b/resources/customized_payloads/F-4E-45MC.lua
@@ -6,84 +6,60 @@ local unitPayloads = {
 			["name"] = "Retribution CAS",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{AGM_62_I}",
+					["CLSID"] = "{DB769D48-67D7-42ED-A2BE-108D566C8B1E}",
 					["num"] = 13,
 				},
+				[2] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
+					["num"] = 7,
 				},
 				[5] = {
 					["CLSID"] = "{HB_PAVE_SPIKE_FAST_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{AGM_62_I}",
-					["num"] = 1,
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 5,
 				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
+				[7] = {
+					["CLSID"] = "{DB769D48-67D7-42ED-A2BE-108D566C8B1E}",
+					["num"] = 1,
 				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{HB_F4EAGM-65D_LAU88_3x_Right}",
+				[8] = {
+					["CLSID"] = "{HB_F4EAGM-65D_LAU88_2x_Right}",
 					["num"] = 11,
 				},
-				[14] = {
-					["CLSID"] = "{HB_F4EAGM-65D_LAU88_3x_Left}",
+				[9] = {
+					["CLSID"] = "{HB_F4EAGM-65D_LAU88_2x_Left}",
 					["num"] = 3,
+				},
+				[10] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[11] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 4,
+				},
+				[12] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
+				},
+				[13] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
+				},
+				[14] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 10,
 				},
 			},
 			["tasks"] = {
@@ -100,94 +76,54 @@ local unitPayloads = {
 				[2] = {
 					["CLSID"] = "{LAU_34_AGM_45A}",
 					["num"] = 13,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
 				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AGM-65A_LAU117_SWA}",
+					["num"] = 11,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
 				},
 				[5] = {
-					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
-					["num"] = 6,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 1,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7F}",
 					["num"] = 9,
 				},
-				[12] = {
+				[7] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 8,
+				},
+				[8] = {
 					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
 					["num"] = 7,
 				},
+				[9] = {
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
+				},
+				[12] = {
+					["CLSID"] = "{HB_F4E_AGM-65A_LAU117_SWA}",
+					["num"] = 3,
+				},
 				[13] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 11,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
 				},
 				[14] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 3,
+					["CLSID"] = "{LAU_34_AGM_45A}",
+					["num"] = 1,
 				},
 			},
 			["tasks"] = {
@@ -198,124 +134,60 @@ local unitPayloads = {
 			["name"] = "Retribution Strike",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}", --GBU-24A/B
+					["num"] = 13,
 				},
 				[2] = {
-					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
-					["num"] = 13,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
 				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
+					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
+					["num"] = 7,
 				},
 				[5] = {
 					["CLSID"] = "{HB_PAVE_SPIKE_FAST_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
-					["num"] = 1,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 5,
 				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
+				[7] = {
 					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
-					["num"] = 3,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
+					["num"] = 1,
 				},
-				[14] = {
+				[8] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[9] = {
 					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
 					["num"] = 11,
-					["settings"] = {
-						["NFP_PRESID"] = "Paveway_III",
-						["NFP_PRESVER"] = 1,
-						["NFP_fuze_type_tail"] = "FMU139CB_LD",
-						["arm_delay_ctrl_FMU139CB_LD"] = 4,
-						["function_delay_ctrl_FMU139CB_LD"] = 0,
-						["laser_code"] = 1688,
-					},
+				},
+				[10] = {
+					["CLSID"] = "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}",
+					["num"] = 3,
+				},
+				[11] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
+				},
+				[12] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 4,
+				},
+				[13] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 10,
+				},
+				[14] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
 				},
 			},
 			["tasks"] = {
@@ -326,99 +198,104 @@ local unitPayloads = {
 			["name"] = "Retribution Escort",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
-					["num"] = 13,
-				},
-				[3] = {
-					["CLSID"] = "{AIM-9M}",
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 12,
 				},
-				[4] = {
-					["CLSID"] = "{AIM-9M}",
+				[2] = {
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 10,
 				},
+				[3] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[5] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 2,
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 5,
 				},
 				[7] = {
-					["CLSID"] = "{AIM-9M}",
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 4,
 				},
 				[8] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
+				},
+				[9] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
+					["num"] = 13,
+				},
+				[10] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
 					["num"] = 1,
 				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
 				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
 				},
 			},
 			["tasks"] = {
 			},
 		},
 		[5] = {
+			["displayName"] = "Retribution BARCAP",
 			["name"] = "Retribution BARCAP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
+					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
+					["num"] = 12,
 				},
 				[2] = {
+					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
+					["num"] = 10,
+				},
+				[3] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 9,
+				},
+				[5] = {
+					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
+					["num"] = 7,
+				},
+				[6] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 5,
+				},
+				[8] = {
+					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
+					["num"] = 4,
+				},
+				[9] = {
+					["CLSID"] = "{9BFD8C90-F7AE-4e90-833B-BFD0CED0E536}",
+					["num"] = 2,
+				},
+				[10] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
 					["num"] = 13,
 				},
-				[3] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 12,
-				},
-				[4] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 10,
-				},
-				[5] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 6,
-				},
-				[6] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 2,
-				},
-				[7] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 4,
-				},
-				[8] = {
+				[11] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
 					["num"] = 1,
 				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+				[12] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
 				},
 			},
 			["tasks"] = {
@@ -435,82 +312,54 @@ local unitPayloads = {
 				[2] = {
 					["CLSID"] = "{LAU_34_AGM_45A}",
 					["num"] = 13,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
 				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
+					["CLSID"] = "{LAU_34_AGM_45A_SWA}",
+					["num"] = 11,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
 				},
 				[5] = {
-					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
-					["num"] = 6,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-				},
-				[8] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 1,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7F}",
 					["num"] = 9,
 				},
-				[12] = {
+				[7] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 8,
+				},
+				[8] = {
 					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
 					["num"] = 7,
 				},
+				[9] = {
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
+				},
+				[12] = {
+					["CLSID"] = "{LAU_34_AGM_45A_SWA}",
+					["num"] = 3,
+				},
 				[13] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 11,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
 				},
 				[14] = {
 					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 3,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["num"] = 1,
 				},
 			},
 			["tasks"] = {
@@ -521,99 +370,100 @@ local unitPayloads = {
 			["name"] = "Retribution TARCAP",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
-					["num"] = 13,
-				},
-				[3] = {
-					["CLSID"] = "{AIM-9M}",
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 12,
 				},
-				[4] = {
-					["CLSID"] = "{AIM-9M}",
+				[2] = {
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 10,
 				},
+				[3] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
+				},
+				[4] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[5] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "{AIM-9M}",
-					["num"] = 2,
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 5,
 				},
 				[7] = {
-					["CLSID"] = "{AIM-9M}",
+					["CLSID"] = "{AIM-9L}",
 					["num"] = 4,
 				},
 				[8] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
+				},
+				[9] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
+					["num"] = 13,
+				},
+				[10] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
 					["num"] = 1,
 				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
 				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
 				},
 			},
 			["tasks"] = {
 			},
 		},
 		[8] = {
+			["displayName"] = "Retribution Anti-ship",
 			["name"] = "Retribution Anti-ship",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 13,
-				},
-				[3] = {
-					["CLSID"] = "{C40A1E3A-DD05-40D9-85A4-217729E37FAE}",
-					["num"] = 11,
-				},
-				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-				},
-				[5] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-				},
-				[6] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 9,
 				},
-				[7] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+				[2] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 8,
 				},
-				[8] = {
+				[3] = {
 					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+				[4] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 5,
 				},
-				[10] = {
+				[5] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
+					["num"] = 1,
+				},
+				[6] = {
+					["CLSID"] = "{C40A1E3A-DD05-40D9-85A4-217729E37FAE}",
+					["num"] = 11,
+				},
+				[7] = {
 					["CLSID"] = "{C40A1E3A-DD05-40D9-85A4-217729E37FAE}",
 					["num"] = 3,
 				},
+				[8] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[9] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
+					["num"] = 13,
+				},
+				[10] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
+				},
 				[11] = {
 					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
+					["num"] = 10,
 				},
 				[12] = {
 					["CLSID"] = "<CLEAN>",
@@ -621,11 +471,7 @@ local unitPayloads = {
 				},
 				[13] = {
 					["CLSID"] = "<CLEAN>",
-					["num"] = 1,
-				},
-				[14] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
+					["num"] = 2,
 				},
 			},
 			["tasks"] = {
@@ -636,84 +482,60 @@ local unitPayloads = {
 			["name"] = "Retribution BAI",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "<CLEAN>",
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
 					["num"] = 13,
 				},
+				[2] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_CBU-87_MER_4x}",
+					["num"] = 7,
 				},
 				[5] = {
 					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 1,
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 5,
 				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
+				[7] = {
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
+					["num"] = 1,
 				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
-				},
-				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{HB_F4EAGM-65D_LAU88_3x_Right}",
+				[8] = {
+					["CLSID"] = "{HB_F4E_CBU-87_2x_SWA}",
 					["num"] = 11,
 				},
-				[14] = {
-					["CLSID"] = "{HB_F4EAGM-65D_LAU88_3x_Left}",
+				[9] = {
+					["CLSID"] = "{HB_F4E_CBU-87_2x_SWA}",
 					["num"] = 3,
+				},
+				[10] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
+				},
+				[11] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
+				},
+				[12] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
+				},
+				[13] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
+				},
+				[14] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
 				},
 			},
 			["tasks"] = {
@@ -728,96 +550,52 @@ local unitPayloads = {
 					["num"] = 14,
 				},
 				[2] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
 					["num"] = 13,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
 				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{LAU_34_AGM_45A}",
+					["num"] = 11,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 9,
 				},
 				[5] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 8,
+				},
+				[6] = {
 					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
-				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
 				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 5,
 				},
 				[8] = {
 					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 1,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["num"] = 3,
 				},
 				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
+					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
+					["num"] = 1,
 				},
 				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
+					["CLSID"] = "<CLEAN>",
+					["num"] = 12,
 				},
 				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+					["CLSID"] = "<CLEAN>",
+					["num"] = 10,
 				},
 				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
+					["CLSID"] = "<CLEAN>",
+					["num"] = 4,
 				},
 				[13] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 11,
-				},
-				[14] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 3,
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
 				},
 			},
 			["tasks"] = {
@@ -828,84 +606,52 @@ local unitPayloads = {
 			["name"] = "Retribution OCA/Aircraft",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
-					["CLSID"] = "{GBU_8_B}",
+					["CLSID"] = "{HB_F4E_CBU-87_MER_3x_Right}",
 					["num"] = 13,
 				},
+				[2] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_CBU-87_MER_4x}",
+					["num"] = 7,
 				},
 				[5] = {
-					["CLSID"] = "{HB_PAVE_SPIKE_FAST_ON_ADAPTER_IN_AERO7}",
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{GBU_8_B}",
-					["num"] = 1,
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
 					["num"] = 5,
 				},
+				[7] = {
+					["CLSID"] = "{HB_F4E_CBU-87_MER_3x_Left}",
+					["num"] = 1,
+				},
+				[8] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
+				},
+				[9] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
+				},
 				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
 				},
 				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
 				},
 				[12] = {
-					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
-					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{GBU_8_B}",
-					["num"] = 11,
-				},
-				[14] = {
-					["CLSID"] = "{GBU_8_B}",
-					["num"] = 3,
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
 				},
 			},
 			["tasks"] = {
@@ -916,84 +662,52 @@ local unitPayloads = {
 			["name"] = "Retribution OCA/Runway",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{HB_ALE_40_30_60}",
-					["num"] = 14,
-				},
-				[2] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL_R}",
 					["num"] = 13,
 				},
+				[2] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 9,
+				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 8,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[5] = {
 					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
 					["num"] = 6,
 				},
+				[5] = {
+					["CLSID"] = "{HB_F4E_AIM-7E-2}",
+					["num"] = 5,
+				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
 					["CLSID"] = "{F4_SARGENT_TANK_370_GAL}",
 					["num"] = 1,
 				},
+				[7] = {
+					["CLSID"] = "{HB_ALE_40_30_60}",
+					["num"] = 14,
+				},
+				[8] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
+				},
 				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
 				},
 				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
 				},
 				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 9,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
 				},
 				[12] = {
 					["CLSID"] = "{HB_F4E_BLU-107B_6x}",
 					["num"] = 7,
-				},
-				[13] = {
-					["CLSID"] = "{HB_F4E_BLU-107B_3x}",
-					["num"] = 11,
-				},
-				[14] = {
-					["CLSID"] = "{HB_F4E_BLU-107B_3x}",
-					["num"] = 3,
 				},
 			},
 			["tasks"] = {
@@ -1010,94 +724,54 @@ local unitPayloads = {
 				[2] = {
 					["CLSID"] = "{LAU_34_AGM_45A}",
 					["num"] = 13,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
 				},
 				[3] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 12,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{LAU_34_AGM_45A_SWA}",
+					["num"] = 11,
 				},
 				[4] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 10,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 12,
 				},
 				[5] = {
-					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
-					["num"] = 6,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 10,
 				},
 				[6] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 2,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[7] = {
-					["CLSID"] = "<CLEAN>",
-					["num"] = 4,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[8] = {
-					["CLSID"] = "{LAU_34_AGM_45A}",
-					["num"] = 1,
-					["settings"] = {
-						["EAS_bypass_ctrl"] = 1,
-						["NFP_PRESID"] = "AGM_45",
-						["NFP_PRESVER"] = 1,
-						["NFP_rfgu_type"] = 1,
-						["rf_lower_limit_ctrl_Mk22Mod2"] = 4800000000,
-						["rf_upper_limit_ctrl_Mk22Mod2"] = 5200000000,
-					},
-				},
-				[9] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 5,
-				},
-				[10] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
-					["num"] = 8,
-				},
-				[11] = {
-					["CLSID"] = "{HB_F4E_AIM-7M}",
+					["CLSID"] = "{HB_F4E_AIM-7F}",
 					["num"] = 9,
 				},
-				[12] = {
+				[7] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 8,
+				},
+				[8] = {
 					["CLSID"] = "{F4_SARGENT_TANK_600_GAL}",
 					["num"] = 7,
 				},
+				[9] = {
+					["CLSID"] = "{HB_ALQ-131_ON_ADAPTER_IN_AERO7}",
+					["num"] = 6,
+				},
+				[10] = {
+					["CLSID"] = "{HB_F4E_AIM-7F}",
+					["num"] = 5,
+				},
+				[11] = {
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 4,
+				},
+				[12] = {
+					["CLSID"] = "{LAU_34_AGM_45A_SWA}",
+					["num"] = 3,
+				},
 				[13] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 11,
+					["CLSID"] = "{AIM-9L}",
+					["num"] = 2,
 				},
 				[14] = {
-					["CLSID"] = "{HB_F4E_AGM-65G_LAU117}",
-					["num"] = 3,
+					["CLSID"] = "{LAU_34_AGM_45A}",
+					["num"] = 1,
 				},
 			},
 			["tasks"] = {

--- a/resources/weapons/standoff/AGM-65A.yaml
+++ b/resources/weapons/standoff/AGM-65A.yaml
@@ -1,6 +1,10 @@
 name: AGM-65A
 year: 1972
-fallback: AGM-62 Walleye II
+# Degrade Mavericks to an anti-armor cluster (Rockeye), not the AGM-62 Walleye.
+# A Maverick is a CAS/anti-armor PGM; the period substitute for that mission is
+# Rockeye, not a ~1100lb TV-guided standoff bomb. The whole AGM-65 family chains
+# down through this node, so this reroutes every Maverick's pre-1972 degrade.
+fallback: Mk-20 Rockeye
 clsids:
   - "{RB75}"   # Rb-75A (AGM-65A Maverick) (TV ASM)
   - "{HB_F4E_AGM-65A_LAU117}"   # AGM-65A - Maverick A (TV Guided) (LAU-117)

--- a/resources/weapons/standoff/AGM-65A.yaml
+++ b/resources/weapons/standoff/AGM-65A.yaml
@@ -1,10 +1,6 @@
 name: AGM-65A
 year: 1972
-# Degrade Mavericks to an anti-armor cluster (Rockeye), not the AGM-62 Walleye.
-# A Maverick is a CAS/anti-armor PGM; the period substitute for that mission is
-# Rockeye, not a ~1100lb TV-guided standoff bomb. The whole AGM-65 family chains
-# down through this node, so this reroutes every Maverick's pre-1972 degrade.
-fallback: Mk-20 Rockeye
+fallback: AGM-62 Walleye II
 clsids:
   - "{RB75}"   # Rb-75A (AGM-65A Maverick) (TV ASM)
   - "{HB_F4E_AGM-65A_LAU117}"   # AGM-65A - Maverick A (TV Guided) (LAU-117)


### PR DESCRIPTION
Two related fixes for the Heatblur F-4E (and Mavericks generally).

## 1. F-4E-45MC default loadouts

The `F-4E-45MC` Retribution presets were a grab-bag of odd single-weapon fits that read as nonsensical in the payload editor. Rebuild all 13 from the module's own built-in loadouts, mapped to the matching `Retribution <task>` names, with a period-correct **AIM-7E2 / AIM-9L** air-to-air baseline (AIM-7F/9P on BARCAP) instead of the previous all-modern AIM-7M — so `restrict_weapons_by_date` degrades to best-available across both early and modern eras.

## 2. Maverick date-fallback → Rockeye, not Walleye

With date restriction on, every AGM-65 Maverick's fallback chain bottomed out at the **AGM-62 Walleye** (`AGM-65D → AGM-65B → AGM-65A → AGM-62 Walleye`). A Maverick is a CAS/anti-armor PGM; degrading it to a ~1100 lb TV-guided standoff bomb is the wrong mission — and it made the F-4E's CAS/DEAD presets carry Walleyes on pre-1972 campaigns. Reroute `AGM-65A`'s fallback to **Mk-20 Rockeye** (anti-armor cluster, 1968); the whole AGM-65 family chains through that node, so it fixes every aircraft's Maverick degrade:

> `AGM-65D → AGM-65B → AGM-65A → Mk-20 Rockeye → Mk 82`

## Validation

Headless against this tree: all 13 F-4E presets resolve, are station-legal, and map to their tasks (no clean-jet fallback); the weapon DB loads and the Maverick chain no longer contains Walleye. Data-only change to two files.