### PR TITLE
Starts Honoring squadron `mission_types` definitions.

### DIFF
--- a/game/campaignloader/defaultsquadronassigner.py
+++ b/game/campaignloader/defaultsquadronassigner.py
@@ -16,6 +16,30 @@ if TYPE_CHECKING:
     from game.coalition import Coalition
 
 
+def warn_if_primary_not_auto_assignable(
+    squadron: Squadron, primary: FlightType
+) -> None:
+    """Log if an assigned squadron lacks its campaign primary in its auto set.
+
+    Squadron selection already guarantees ``capable_of(primary)`` and the campaign
+    replace preserves the primary, so this should never fire today. It is a tripwire
+    for future changes (e.g. an intersect/ceiling model) that could silently leave a
+    randomized squadron unable to fly its assigned primary.
+    """
+    # Use can_auto_assign (the canonical gate: set membership AND airframe capability)
+    # rather than raw set membership, so a dirty set (e.g. an incapable primary written
+    # via deserialization or a UI edit) still trips the wire.
+    if not squadron.can_auto_assign(primary):
+        logging.warning(
+            "Squadron %s (%s) assigned primary task %s, but it is not in the "
+            "squadron's auto-assignable mission types. Selection should guarantee "
+            "capability; this indicates an upstream regression.",
+            squadron.name,
+            squadron.aircraft,
+            primary,
+        )
+
+
 class DefaultSquadronAssigner:
     def __init__(
         self, config: CampaignAirWingConfig, game: Game, coalition: Coalition
@@ -53,6 +77,7 @@ class DefaultSquadronAssigner:
                 squadron.set_auto_assignable_mission_types(
                     squadron_config.auto_assignable
                 )
+                warn_if_primary_not_auto_assignable(squadron, squadron_config.primary)
                 self.air_wing.add_squadron(squadron)
 
     def find_squadron_for(

--- a/game/dcs/aircrafttype.py
+++ b/game/dcs/aircrafttype.py
@@ -6,7 +6,16 @@ from collections import defaultdict
 from dataclasses import dataclass
 from functools import cache, cached_property
 from pathlib import Path
-from typing import Any, ClassVar, Dict, Iterator, Optional, TYPE_CHECKING, Type
+from typing import (
+    Any,
+    ClassVar,
+    Collection,
+    Dict,
+    Iterator,
+    Optional,
+    TYPE_CHECKING,
+    Type,
+)
 
 import yaml
 from dcs.helicopters import helicopter_map
@@ -186,6 +195,35 @@ class FuelConsumption:
         )
 
 
+# Auto-derived task types: holding one capability implies a sibling capability.
+# Single source of truth shared by AircraftType.__post_init__ (airframe caps) and
+# SquadronDef.from_yaml (squadron mission_types) so the two cannot drift.
+# Maps a derived task to its source tasks (first present source wins for priority copy).
+_DERIVED_TASK_SOURCES: dict[FlightType, tuple[FlightType, ...]] = {
+    FlightType.SEAD_SWEEP: (FlightType.SEAD, FlightType.SEAD_ESCORT),
+    FlightType.ARMED_RECON: (FlightType.CAS, FlightType.BAI),
+    FlightType.RECOVERY: (FlightType.REFUELING,),
+}
+
+
+def derived_task_types(
+    tasks: Collection[FlightType], carrier_capable: bool
+) -> set[FlightType]:
+    """Sibling task types implied by ``tasks`` via the auto-derivation rules.
+
+    RECOVERY is only implied when the airframe is carrier-capable, matching
+    AircraftType.__post_init__.
+    """
+    derived: set[FlightType] = set()
+    for derived_task, sources in _DERIVED_TASK_SOURCES.items():
+        # RECOVERY is gated on carrier capability; the others are unconditional.
+        if derived_task is FlightType.RECOVERY and not carrier_capable:
+            continue
+        if any(source in tasks for source in sources):
+            derived.add(derived_task)
+    return derived
+
+
 # TODO: Split into PlaneType and HelicopterType?
 @dataclass(frozen=True)
 class AircraftType(UnitType[Type[FlyingType]]):
@@ -263,25 +301,18 @@ class AircraftType(UnitType[Type[FlyingType]]):
         self.__dict__.update(updated.__dict__)
 
     def __post_init__(self) -> None:
-        enrich = {}
-        if FlightType.SEAD_SWEEP not in self.task_priorities:
-            if (value := self.task_priorities.get(FlightType.SEAD)) or (
-                value := self.task_priorities.get(FlightType.SEAD_ESCORT)
-            ):
-                enrich[FlightType.SEAD_SWEEP] = value
-
-        if FlightType.ARMED_RECON not in self.task_priorities:
-            if (value := self.task_priorities.get(FlightType.CAS)) or (
-                value := self.task_priorities.get(FlightType.BAI)
-            ):
-                enrich[FlightType.ARMED_RECON] = value
-
-        if FlightType.RECOVERY not in self.task_priorities:
-            if (
-                value := self.task_priorities.get(FlightType.REFUELING)
-            ) and self.carrier_capable is True:
-                enrich[FlightType.RECOVERY] = value
-
+        enrich: dict[FlightType, int] = {}
+        for derived_task in derived_task_types(
+            self.task_priorities, self.carrier_capable
+        ):
+            if derived_task in self.task_priorities:
+                continue
+            for source in _DERIVED_TASK_SOURCES[derived_task]:
+                # Truthiness (not `is not None`) preserves prior behavior: a 0/falsy
+                # source priority falls through to the next source, or is skipped.
+                if value := self.task_priorities.get(source):
+                    enrich[derived_task] = value
+                    break
         self.task_priorities.update(enrich)
 
     def __eq__(self, other: object) -> bool:

--- a/game/squadrons/squadron.py
+++ b/game/squadrons/squadron.py
@@ -346,7 +346,9 @@ class Squadron:
         return self.aircraft.capable_of(task)
 
     def can_auto_assign(self, task: FlightType) -> bool:
-        return task in self.auto_assignable_mission_types
+        # Intersect with airframe capability at read time: a saved/UI-added type the
+        # airframe cannot fly is never auto-assignable, even if present in the set.
+        return task in self.auto_assignable_mission_types and self.capable_of(task)
 
     def can_auto_assign_mission(
         self,

--- a/game/squadrons/squadrondef.py
+++ b/game/squadrons/squadrondef.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union
 
 import yaml
 from dcs.country import Country
 from dcs.task import Modulation
 
-from game.dcs.aircrafttype import AircraftType
+from game.ato.flighttype import FlightType
+from game.dcs.aircrafttype import AircraftType, derived_task_types
 from game.dcs.countries import country_with_name
 from game.radio.radios import RadioFrequency
 from game.squadrons.operatingbases import OperatingBases
 from game.squadrons.pilot import Pilot
 
 if TYPE_CHECKING:
-    from game.ato.flighttype import FlightType
     from game.theater import ControlPoint
 
 
@@ -48,11 +48,14 @@ class SquadronDef:
         return self.aircraft.capable_of(task)
 
     def can_auto_assign(self, task: FlightType) -> bool:
+        """Whether this def auto-assigns ``task``.
+
+        Mirrors Squadron.can_auto_assign: the task must be in the def's
+        auto-assignable set AND within the airframe's capabilities.
         """
-        A squadron may be capable of performing a task even if it will not be
-        automatically assigned to it.
-        """
-        return self.aircraft.capable_of(task)
+        return task in self.auto_assignable_mission_types and self.aircraft.capable_of(
+            task
+        )
 
     def operates_from(self, control_point: ControlPoint) -> bool:
         if not control_point.can_operate(self.aircraft):
@@ -63,6 +66,36 @@ class SquadronDef:
             return self.operating_bases.lha
         else:
             return self.operating_bases.shore
+
+    @staticmethod
+    def _auto_assignable_from_yaml(
+        data: dict[str, Any], unit_type: AircraftType
+    ) -> set[FlightType]:
+        raw = data.get("mission_types")
+        if raw is None:
+            # No restriction declared: default to the full airframe capability set.
+            return set(unit_type.iter_task_capabilities())
+        if isinstance(raw, str) or not isinstance(raw, (list, tuple)):
+            # A bare scalar (e.g. `mission_types: SEAD`) would otherwise be iterated
+            # character-by-character, yielding a confusing per-character error.
+            raise KeyError(
+                "mission_types must be a list of flight types, got "
+                f"{type(raw).__name__}: {raw!r}"
+            )
+        try:
+            declared = {FlightType(value) for value in raw}
+        except ValueError as ex:
+            # FlightType(...) raises ValueError on an unknown value; surface it as a
+            # KeyError with context, matching the unknown-aircraft handling above.
+            raise KeyError(f"Unknown mission type in squadron definition: {ex}") from ex
+        caps = set(unit_type.iter_task_capabilities())
+        # Clamp to caps BEFORE deriving so a listed-but-incapable task cannot grant a
+        # derived sibling (e.g. listing SEAD on an airframe that only has SEAD_ESCORT
+        # must not back-door SEAD_SWEEP). mission_types can only *subtract* from the
+        # cap, never add a capability. The trailing clamp keeps only capable siblings.
+        declared &= caps
+        declared |= derived_task_types(declared, unit_type.carrier_capable)
+        return declared & caps
 
     @classmethod
     def from_yaml(cls, path: Path) -> SquadronDef:
@@ -105,7 +138,9 @@ class SquadronDef:
             aircraft=unit_type,
             livery=data.get("livery"),
             livery_set=data.get("livery_set", []),
-            auto_assignable_mission_types=set(unit_type.iter_task_capabilities()),
+            auto_assignable_mission_types=cls._auto_assignable_from_yaml(
+                data, unit_type
+            ),
             radio_presets=radio_presets,
             operating_bases=OperatingBases.from_yaml(unit_type, data.get("bases", {})),
             female_pilot_percentage=female_pilot_percentage,

--- a/scripts/validate_dr_enex.py
+++ b/scripts/validate_dr_enex.py
@@ -1,0 +1,147 @@
+"""Validation for dr-enex: squadron mission_types auto-assignable limit.
+
+Run from the repo root:
+    PATH=".venv/bin:$PATH" PYTHONPATH=. python scripts/validate_dr_enex.py
+
+Exercises section B (load-path behavior) of
+docs/superpowers/validation/2026-06-29-dr-enex-squadron-mission-types-validation.md.
+No DCS install required.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+import game.persistency as persistency
+
+# Point persistency at a temp dir so aircraft loading works without a DCS install
+# (mirrors tests/conftest.py).
+persistency._dcs_saved_game_folder = tempfile.mkdtemp(prefix="dr_enex_validate_")
+
+from game.ato.flighttype import FlightType  # noqa: E402
+from game.dcs.aircrafttype import (  # noqa: E402
+    AircraftType,
+    derived_task_types,
+)
+from game.squadrons.squadron import Squadron  # noqa: E402
+from game.squadrons.squadrondef import SquadronDef  # noqa: E402
+
+_results: list[tuple[str, bool, str]] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    _results.append((name, bool(ok), detail))
+
+
+def _write(tmp: Path, aircraft: AircraftType, mission_types: Any = ...) -> Path:
+    data: dict[str, Any] = {
+        "name": "v",
+        "country": "USA",
+        "role": "t",
+        "aircraft": aircraft.variant_id,
+    }
+    if mission_types is not ...:
+        data["mission_types"] = mission_types
+    path = tmp / "s.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+def main() -> int:
+    tmp = Path(tempfile.mkdtemp())
+    cas = AircraftType.priority_list_for_task(FlightType.CAS)[0]
+    caps = set(cas.iter_task_capabilities())
+
+    # B1: absent key -> all caps
+    sd = SquadronDef.from_yaml(_write(tmp, cas))
+    check("absent -> all caps", sd.auto_assignable_mission_types == caps)
+
+    # B2a: real shipped YAML loads, restricted to caps, derives ARMED_RECON.
+    # (Its curated list may or may not be narrower than this airframe's caps, so we
+    # don't assert strict restriction here -- that's covered by B2b on a constructed
+    # narrower case.)
+    real = Path("resources/squadrons/A-10C Warthog I/81st FS.yaml")
+    sd = SquadronDef.from_yaml(real)
+    rcaps = set(sd.aircraft.iter_task_capabilities())
+    aset = sd.auto_assignable_mission_types
+    check("81st FS subset of caps", aset <= rcaps)
+    check("81st FS keeps listed CAS", FlightType.CAS in aset)
+    check("81st FS derives ARMED_RECON", FlightType.ARMED_RECON in aset)
+
+    # B2b: constructed restriction -- listing only CAS yields {CAS, ARMED_RECON}, a
+    # strict subset of a multi-capability airframe's caps.
+    check("test airframe is multi-capability", len(caps) > 2, f"{len(caps)} caps")
+    sd = SquadronDef.from_yaml(_write(tmp, cas, [FlightType.CAS.value]))
+    restricted = sd.auto_assignable_mission_types
+    check(
+        "list [CAS] -> {CAS, ARMED_RECON} strictly restricted",
+        restricted == {FlightType.CAS, FlightType.ARMED_RECON} and restricted < caps,
+        f"{sorted(t.value for t in restricted)}",
+    )
+
+    # B3: empty list -> empty set
+    sd = SquadronDef.from_yaml(_write(tmp, cas, []))
+    check("empty -> empty", sd.auto_assignable_mission_types == set())
+
+    # B4: unknown value -> KeyError
+    try:
+        SquadronDef.from_yaml(_write(tmp, cas, ["BogusType"]))
+        check("unknown -> KeyError", False, "no error raised")
+    except KeyError:
+        check("unknown -> KeyError", True)
+
+    # B5: scalar (non-list) -> KeyError
+    try:
+        SquadronDef.from_yaml(_write(tmp, cas, FlightType.CAS.value))
+        check("scalar -> KeyError", False, "no error raised")
+    except KeyError:
+        check("scalar -> KeyError", True)
+
+    # B6: subtract-only -- a listed non-capable task cannot grant a derived sibling
+    found: Optional[str] = None
+    for aircraft in AircraftType.iter_all():
+        cap_set = set(aircraft.iter_task_capabilities())
+        incapable = next(
+            (
+                f
+                for f in FlightType
+                if f not in cap_set
+                and derived_task_types({f}, aircraft.carrier_capable) & cap_set
+            ),
+            None,
+        )
+        if incapable is None:
+            continue
+        sd = SquadronDef.from_yaml(_write(tmp, aircraft, [incapable.value]))
+        check(
+            "subtract-only (no back-door sibling)",
+            sd.auto_assignable_mission_types == set(),
+            aircraft.variant_id,
+        )
+        found = aircraft.variant_id
+        break
+    if found is None:
+        check("subtract-only (no back-door sibling)", True, "no airframe exposes it")
+
+    # B7: read-time gate (set membership AND airframe capability)
+    sqn: Squadron = object.__new__(Squadron)
+    sqn.aircraft = cas
+    incap = next(f for f in FlightType if f not in caps)
+    sqn.auto_assignable_mission_types = {FlightType.CAS, incap}
+    check("read-time: in-set + capable -> True", sqn.can_auto_assign(FlightType.CAS))
+    check("read-time: in-set + incapable -> False", not sqn.can_auto_assign(incap))
+
+    passed = sum(1 for _, ok, _ in _results if ok)
+    for name, ok, detail in _results:
+        suffix = f" - {detail}" if detail else ""
+        print(f"[{'PASS' if ok else 'FAIL'}] {name}{suffix}")
+    print(f"\n{passed}/{len(_results)} checks passed")
+    return 0 if passed == len(_results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared pytest fixtures for the whole suite.
+
+Loading aircraft via ``AircraftType.iter_all()`` / ``priority_list_for_task()``
+(and therefore the squadron/aircraft tests) reaches ``_user_weapon_injections()``,
+which asserts ``persistency._dcs_saved_game_folder`` is set. Point it at a temp
+dir for the test session so those lookups don't abort without a real DCS install.
+"""
+
+import pytest
+
+import game.persistency as persistency
+
+
+@pytest.fixture(autouse=True, scope="session")
+def stub_dcs_saved_game_folder(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Point persistency at a temp dir so weapon-injection lookups don't abort."""
+    tmp = tmp_path_factory.mktemp("dcs_saved_game")
+    persistency._dcs_saved_game_folder = str(tmp)

--- a/tests/dcs/test_derived_task_types.py
+++ b/tests/dcs/test_derived_task_types.py
@@ -1,0 +1,50 @@
+from game.ato.flighttype import FlightType
+from game.dcs.aircrafttype import (
+    AircraftType,
+    _DERIVED_TASK_SOURCES,
+    derived_task_types,
+)
+
+
+def test_armed_recon_derived_from_cas() -> None:
+    assert derived_task_types({FlightType.CAS}, False) == {FlightType.ARMED_RECON}
+
+
+def test_armed_recon_derived_from_bai() -> None:
+    assert derived_task_types({FlightType.BAI}, False) == {FlightType.ARMED_RECON}
+
+
+def test_sead_sweep_derived_from_sead() -> None:
+    assert derived_task_types({FlightType.SEAD}, False) == {FlightType.SEAD_SWEEP}
+
+
+def test_sead_sweep_derived_from_sead_escort() -> None:
+    assert derived_task_types({FlightType.SEAD_ESCORT}, False) == {
+        FlightType.SEAD_SWEEP
+    }
+
+
+def test_recovery_requires_carrier() -> None:
+    assert derived_task_types({FlightType.REFUELING}, True) == {FlightType.RECOVERY}
+    assert derived_task_types({FlightType.REFUELING}, False) == set()
+
+
+def test_unrelated_task_derives_nothing() -> None:
+    assert derived_task_types({FlightType.STRIKE}, True) == set()
+
+
+def test_helper_agrees_with_airframe_derivation() -> None:
+    # Drift guard: the airframe's own derived capabilities must match the rules the
+    # shared helper encodes, for every loaded aircraft.
+    for aircraft in AircraftType.iter_all():
+        caps = set(aircraft.iter_task_capabilities())
+        assert derived_task_types(caps, aircraft.carrier_capable) <= caps
+        if FlightType.SEAD in caps or FlightType.SEAD_ESCORT in caps:
+            assert FlightType.SEAD_SWEEP in caps
+        if FlightType.CAS in caps or FlightType.BAI in caps:
+            assert FlightType.ARMED_RECON in caps
+    assert set(_DERIVED_TASK_SOURCES) == {
+        FlightType.SEAD_SWEEP,
+        FlightType.ARMED_RECON,
+        FlightType.RECOVERY,
+    }

--- a/tests/squadrons/test_can_auto_assign_intersect.py
+++ b/tests/squadrons/test_can_auto_assign_intersect.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import yaml
+
+from game.ato.flighttype import FlightType
+from game.dcs.aircrafttype import AircraftType
+from game.squadrons.squadron import Squadron
+from game.squadrons.squadrondef import SquadronDef
+
+
+def _cas_aircraft() -> AircraftType:
+    return AircraftType.priority_list_for_task(FlightType.CAS)[0]
+
+
+def _squadron(aircraft: AircraftType, auto_set: set[FlightType]) -> Squadron:
+    """Construct a minimal Squadron stub — only the attrs can_auto_assign reads."""
+    sqn: Squadron = object.__new__(Squadron)
+    sqn.aircraft = aircraft
+    sqn.auto_assignable_mission_types = set(auto_set)
+    return sqn
+
+
+def test_in_set_and_capable_is_true() -> None:
+    aircraft = _cas_aircraft()
+    sqn = _squadron(aircraft, {FlightType.CAS})
+    assert sqn.can_auto_assign(FlightType.CAS) is True
+
+
+def test_in_set_but_not_capable_is_false() -> None:
+    aircraft = _cas_aircraft()
+    caps = set(aircraft.iter_task_capabilities())
+    incapable = next((t for t in FlightType if t not in caps), None)
+    assert incapable is not None, "no FlightType outside this airframe's caps"
+    sqn = _squadron(aircraft, {FlightType.CAS, incapable})
+    assert sqn.can_auto_assign(incapable) is False
+
+
+def test_capable_but_not_in_set_is_false() -> None:
+    aircraft = _cas_aircraft()
+    caps = set(aircraft.iter_task_capabilities())
+    other_cap = next((t for t in caps if t != FlightType.CAS), None)
+    assert other_cap is not None, "test needs a CAS aircraft with caps beyond CAS"
+    sqn = _squadron(aircraft, {FlightType.CAS})
+    assert sqn.can_auto_assign(other_cap) is False
+
+
+def test_squadrondef_can_auto_assign_respects_set(tmp_path: Path) -> None:
+    aircraft = _cas_aircraft()
+    data: dict[str, object] = {
+        "name": "t",
+        "country": "USA",
+        "role": "t",
+        "aircraft": aircraft.variant_id,
+        "mission_types": [FlightType.CAS.value],
+    }
+    path = tmp_path / "sqn.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    sqn_def = SquadronDef.from_yaml(path)
+    others = [
+        t
+        for t in aircraft.iter_task_capabilities()
+        if t not in sqn_def.auto_assignable_mission_types
+    ]
+    assert others, "test needs a CAS aircraft with caps beyond its mission_types"
+    other_cap = others[0]
+    assert sqn_def.can_auto_assign(FlightType.CAS) is True
+    assert sqn_def.can_auto_assign(other_cap) is False

--- a/tests/squadrons/test_primary_invariant.py
+++ b/tests/squadrons/test_primary_invariant.py
@@ -1,0 +1,50 @@
+import logging
+
+import pytest
+
+from game.ato.flighttype import FlightType
+from game.campaignloader.defaultsquadronassigner import (
+    warn_if_primary_not_auto_assignable,
+)
+from game.dcs.aircrafttype import AircraftType
+from game.squadrons.squadron import Squadron
+
+
+def _squadron(
+    aircraft: AircraftType, auto_set: set[FlightType], name: str = "t"
+) -> Squadron:
+    """Minimal Squadron stub — only the attrs the guard / setter read."""
+    sqn: Squadron = object.__new__(Squadron)
+    sqn.aircraft = aircraft
+    sqn.auto_assignable_mission_types = set(auto_set)
+    sqn.name = name
+    return sqn
+
+
+def test_guard_warns_when_primary_missing(caplog: pytest.LogCaptureFixture) -> None:
+    aircraft = AircraftType.priority_list_for_task(FlightType.CAS)[0]
+    sqn = _squadron(aircraft, {FlightType.STRIKE})
+    with caplog.at_level(logging.WARNING):
+        warn_if_primary_not_auto_assignable(sqn, FlightType.CAS)
+    assert any("auto-assignable" in record.getMessage() for record in caplog.records)
+
+
+def test_guard_silent_when_primary_present(caplog: pytest.LogCaptureFixture) -> None:
+    aircraft = AircraftType.priority_list_for_task(FlightType.CAS)[0]
+    sqn = _squadron(aircraft, {FlightType.CAS})
+    with caplog.at_level(logging.WARNING):
+        warn_if_primary_not_auto_assignable(sqn, FlightType.CAS)
+    assert not caplog.records
+
+
+def test_replace_keeps_primary_over_def_limit() -> None:
+    # A squadron limited to a set excluding SEAD, then a campaign that makes SEAD the
+    # primary: replace (not intersect) must keep SEAD auto-assignable.
+    aircraft = AircraftType.priority_list_for_task(FlightType.SEAD)[0]
+    caps = set(aircraft.iter_task_capabilities())
+    limited = caps - {
+        FlightType.SEAD
+    }  # SEAD-capable airframe -> non-empty, excludes SEAD
+    sqn = _squadron(aircraft, limited)
+    sqn.set_auto_assignable_mission_types({FlightType.SEAD})
+    assert FlightType.SEAD in sqn.auto_assignable_mission_types

--- a/tests/squadrons/test_squadrondef_mission_types.py
+++ b/tests/squadrons/test_squadrondef_mission_types.py
@@ -1,0 +1,124 @@
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import yaml
+
+from game.ato.flighttype import FlightType
+from game.dcs.aircrafttype import AircraftType, derived_task_types
+from game.squadrons.squadrondef import SquadronDef
+
+
+def _write_squadron_yaml(
+    tmp_path: Path,
+    aircraft: AircraftType,
+    mission_types: Optional[list[str]] = None,
+) -> Path:
+    data: dict[str, object] = {
+        "name": "Test Sqn",
+        "country": "USA",
+        "role": "test",
+        "aircraft": aircraft.variant_id,
+    }
+    if mission_types is not None:
+        data["mission_types"] = mission_types
+    path = tmp_path / "sqn.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+def _cas_aircraft() -> AircraftType:
+    return AircraftType.priority_list_for_task(FlightType.CAS)[0]
+
+
+def test_absent_mission_types_is_all_caps(tmp_path: Path) -> None:
+    aircraft = _cas_aircraft()
+    sqn = SquadronDef.from_yaml(_write_squadron_yaml(tmp_path, aircraft))
+    assert sqn.auto_assignable_mission_types == set(aircraft.iter_task_capabilities())
+
+
+def test_mission_types_limits_to_listed_plus_derived(tmp_path: Path) -> None:
+    aircraft = _cas_aircraft()
+    caps = set(aircraft.iter_task_capabilities())
+    sqn = SquadronDef.from_yaml(
+        _write_squadron_yaml(tmp_path, aircraft, [FlightType.CAS.value])
+    )
+    # Concrete (not helper-recomputed) expectation: CAS plus its derived sibling
+    # ARMED_RECON, and nothing else. A CAS-capable airframe always has ARMED_RECON in
+    # caps (the airframe derives it), so listing CAS yields exactly these two.
+    expected = {FlightType.CAS, FlightType.ARMED_RECON}
+    assert sqn.auto_assignable_mission_types == expected
+    # Genuinely limited: capabilities outside the list are dropped.
+    excluded = caps - expected
+    assert excluded, "test needs a CAS aircraft with capabilities beyond CAS"
+    for task in excluded:
+        assert task not in sqn.auto_assignable_mission_types
+
+
+def test_types_outside_airframe_caps_are_dropped(tmp_path: Path) -> None:
+    aircraft = _cas_aircraft()
+    caps = set(aircraft.iter_task_capabilities())
+    outside = next(t for t in FlightType if t not in caps)
+    sqn = SquadronDef.from_yaml(
+        _write_squadron_yaml(tmp_path, aircraft, [FlightType.CAS.value, outside.value])
+    )
+    assert outside not in sqn.auto_assignable_mission_types
+    assert FlightType.CAS in sqn.auto_assignable_mission_types
+
+
+def test_unknown_mission_type_raises_keyerror(tmp_path: Path) -> None:
+    aircraft = _cas_aircraft()
+    path = _write_squadron_yaml(tmp_path, aircraft, ["NotARealMissionType"])
+    with pytest.raises(KeyError):
+        SquadronDef.from_yaml(path)
+
+
+def test_scalar_mission_types_raises_keyerror(tmp_path: Path) -> None:
+    # A bare scalar (not a list) must fail clearly, not iterate char-by-char.
+    aircraft = _cas_aircraft()
+    data: dict[str, object] = {
+        "name": "Test Sqn",
+        "country": "USA",
+        "role": "test",
+        "aircraft": aircraft.variant_id,
+        "mission_types": FlightType.CAS.value,  # scalar string, not a list
+    }
+    path = tmp_path / "sqn.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    with pytest.raises(KeyError):
+        SquadronDef.from_yaml(path)
+
+
+def test_empty_mission_types_yields_empty_set(tmp_path: Path) -> None:
+    # An explicit empty list means "auto-plan nothing" (distinct from an absent key,
+    # which means all caps). Locks the documented behavior.
+    aircraft = _cas_aircraft()
+    sqn = SquadronDef.from_yaml(_write_squadron_yaml(tmp_path, aircraft, []))
+    assert sqn.auto_assignable_mission_types == set()
+
+
+def test_listed_incapable_type_does_not_grant_derived_sibling(tmp_path: Path) -> None:
+    # Regression: derivation must run AFTER clamping to airframe caps, so listing a task
+    # the airframe cannot fly cannot back-door a derived sibling that IS in caps (e.g.
+    # listing SEAD on a SEAD_ESCORT-only airframe must not grant SEAD_SWEEP).
+    tested = 0
+    for aircraft in AircraftType.iter_all():
+        caps = set(aircraft.iter_task_capabilities())
+        incapable = next(
+            (
+                f
+                for f in FlightType
+                if f not in caps
+                and derived_task_types({f}, aircraft.carrier_capable) & caps
+            ),
+            None,
+        )
+        if incapable is None:
+            continue
+        sqn = SquadronDef.from_yaml(
+            _write_squadron_yaml(tmp_path, aircraft, [incapable.value])
+        )
+        assert sqn.auto_assignable_mission_types == set(), aircraft.variant_id
+        tested += 1
+    if tested == 0:
+        pytest.skip("no aircraft exposes the derive-from-incapable scenario")


### PR DESCRIPTION
Prior, squadron.yml `mission_types` was dropped completely. Now, it's loaded. If campaigns define the squadron and offer mission_types, those override the squadron's. After a campaign is generated, that gets saved to the campaign save file. Users can override it in the UI if they want to tweak things. Then when autoplanner runs, that set of mission types is intersected with those defined for the airframe.

I *think* the only change from current behaviors are:
- squadron yaml is actually used for mission_types
- if a user overrides the mission types for the squadron to one the airframe doesn't support, the autoplanner will ignore it (an F-14 doesn't make sense doing an air-assault mission even if someone configured it to try to)