### PR TITLE
Fix escort leash never running (DCS has no Group.getByID)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 
 
 ## Fixes
+* **[Plugins]** Fix the escort leash never running (DCS has no `Group.getByID`; look the group up by name via mist), so escorts are actually held to their engagement range.
 * **[Mission Planning]** Carrier/LHA targets now offer SEAD in the flight-task list and no longer list SEAD Escort twice (their escorts are SAM platforms, so they can be suppressed directly like any other naval group).
 * **[App]** Retribution no longer stays alive in the background after its window is closed: the API server's graceful shutdown is now bounded (uvicorn otherwise waited forever on the long-lived event-stream websocket and the join hung).
 * **[App]** Relaunching the executable while it is already running no longer spawns orphaned, windowless duplicate processes; a second instance detects the first via an OS file lock and exits immediately.

--- a/resources/plugins/base/dcs_retribution.lua
+++ b/resources/plugins/base/dcs_retribution.lua
@@ -225,7 +225,9 @@ local function escort_leash_get_group(id)
     if not group_id or group_id <= 0 then
         return nil
     end
-    return Group.getByID(group_id)
+    -- DCS has no Group.getByID; resolve the mission group id to a name via mist.
+    local data = mist.DBs.groupsById and mist.DBs.groupsById[group_id]
+    return data and Group.getByName(data.groupName) or nil
 end
 
 local function escort_leash_set_roe(group, roe)


### PR DESCRIPTION
`escort_leash_get_group` calls `Group.getByID(group_id)`, which is not a function in the DCS scripting API (only `Group.getByName` exists). The leash timer errored every tick, so escorts were never held to their engagement range.

Fix: resolve the mission group id to its name via `mist.DBs.groupsById` and use `Group.getByName`.