### PR TITLE
fix(carcass): dedup respawned-static carcasses by type+position

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -33,6 +33,7 @@ from .infos.information import Information
 from .lasercodes.lasercoderegistry import LaserCodeRegistry
 from .profiling import logged_duration
 from .settings import Settings
+from .spatialindex import LiveUnitIndex
 from .theater import ConflictTheater, Player
 from .theater.bullseye import Bullseye
 from .theater.theatergroundobject import (
@@ -659,6 +660,28 @@ class Game:
                 seen.add(key)
                 deduped.append(d)
         self.__destroyed_units = deduped
+
+    def prune_destroyed_units(self, index: LiveUnitIndex) -> None:
+        # Drop any carcass a live unit now occupies: once something alive stands at
+        # a cell, its old wreck-history there is stale (the list is cosmetic-only).
+        # Deleting (vs keeping-hidden) avoids two-husk stacking when a site is
+        # rebuilt as a different type and re-killed. Garbled-coord entries can't be
+        # matched, so they're kept — consistent with _safe_carcass_key.
+        kept: list[dict[str, Union[float, str]]] = []
+        for d in self.__destroyed_units:
+            try:
+                x = cast(float, d["x"])
+                z = cast(float, d["z"])
+                occupied = index.occupied(float(x), float(z))
+            except (KeyError, TypeError, ValueError):
+                # Missing x/z (KeyError) or a non-numeric coord (TypeError/
+                # ValueError) -> unmatchable, keep the entry. Non-finite coords
+                # don't reach here: LiveUnitIndex.occupied is total over floats.
+                kept.append(d)
+                continue
+            if not occupied:
+                kept.append(d)
+        self.__destroyed_units = kept
 
     def position_culled(self, pos: Point) -> bool:
         """

--- a/game/game.py
+++ b/game/game.py
@@ -169,6 +169,11 @@ class Game:
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
+        # Heal carcass lists bloated by old saves. Guarded like laser_code_registry
+        # below: __destroyed_units postdates the oldest saves, so a pre-2020 save
+        # arrives without it and must not AttributeError here.
+        if hasattr(self, "_Game__destroyed_units"):
+            self._dedup_destroyed_units()
         if not hasattr(self, "laser_code_registry"):
             self.laser_code_registry = LaserCodeRegistry()
             for front_line in self.theater.conflicts():
@@ -587,15 +592,73 @@ class Game:
         self.__culling_zones = zones
         events.update_unculled_zones(zones)
 
+    @staticmethod
+    def _carcass_key(data: dict[str, Union[float, str]]) -> tuple[str, int, int]:
+        # (type, x, z) quantized to 1 m identifies one carcass. Statics that
+        # Retribution respawns ALIVE each mission (FARP fuel/ammo depots,
+        # motorpool Garage_A) fire a fresh S_EVENT_DEAD at the same deterministic
+        # spot every time they are bombed; keying on this collapses them to a
+        # single wreck. Type is in the key so adjacent different-type statics
+        # (FARP fuel vs ammo) never merge; 1 m rounding absorbs Lua->JSON float
+        # jitter (distinct same-type statics are always spaced well over a metre).
+        # Precondition: data must carry "x" and "z" (raises KeyError otherwise).
+        # For entries of unknown provenance use _safe_carcass_key instead.
+        return (
+            str(data.get("type", "")),
+            round(cast(float, data["x"])),
+            round(cast(float, data["z"])),
+        )
+
+    @staticmethod
+    def _safe_carcass_key(
+        data: dict[str, Union[float, str]],
+    ) -> tuple[str, int, int] | None:
+        # None for an unkeyable legacy entry (missing/garbled coords). Callers
+        # treat None as "no match", so such entries are never merged nor crash
+        # the dedup scan — matching _dedup's keep-them-untouched behaviour.
+        # OverflowError: round(±inf); ValueError: round(nan); KeyError: no x/z;
+        # TypeError: non-float coord.
+        try:
+            return Game._carcass_key(data)
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return None
+
     def add_destroyed_units(self, data: dict[str, Union[float, str]]) -> None:
         pos = Point(
             cast(float, data["x"]), cast(float, data["z"]), self.theater.terrain
         )
-        if self.theater.is_on_land(pos):
-            self.__destroyed_units.append(data)
+        if not self.theater.is_on_land(pos):
+            return
+        # Bound to one carcass per (type, cell): a respawned-alive static bombed
+        # every mission would otherwise stack a new hidden wreck each turn.
+        # _safe_carcass_key throughout so a garbled coord (missing/inf/nan) never
+        # crashes turn commit; an unkeyable entry (key None) can't be deduped, so
+        # it's just recorded — mirroring _dedup's keep-them-untouched behaviour.
+        key = self._safe_carcass_key(data)
+        if key is not None and any(
+            self._safe_carcass_key(d) == key for d in self.__destroyed_units
+        ):
+            return
+        self.__destroyed_units.append(data)
 
     def get_destroyed_units(self) -> list[dict[str, Union[float, str]]]:
         return self.__destroyed_units
+
+    def _dedup_destroyed_units(self) -> None:
+        # Heal saves written before the insert-path dedup existed: collapse
+        # stacked carcasses to one per (type, cell). First occurrence wins,
+        # order preserved.
+        seen: set[tuple[str, int, int]] = set()
+        deduped: list[dict[str, Union[float, str]]] = []
+        for d in self.__destroyed_units:
+            key = self._safe_carcass_key(d)
+            if key is None:
+                deduped.append(d)  # unkeyable legacy entry: keep it, never dedup
+                continue
+            if key not in seen:
+                seen.add(key)
+                deduped.append(d)
+        self.__destroyed_units = deduped
 
     def position_culled(self, pos: Point) -> bool:
         """

--- a/game/missiongenerator/missiongenerator.py
+++ b/game/missiongenerator/missiongenerator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import dcs.lua
 from dcs import Mission, Point
@@ -13,6 +13,7 @@ from dcs.point import MovingPoint
 from dcs.task import OptReactOnThreat
 from dcs.terrain import Airport
 from dcs.unit import Static
+from dcs.unitgroup import Group
 
 from game.atcdata import AtcData
 from game.dcs.beacons import Beacons
@@ -21,6 +22,7 @@ from game.missiongenerator.aircraft.aircraftgenerator import (
     AircraftGenerator,
 )
 from game.naming import namegen
+from game.spatialindex import LiveUnitIndex
 from game.radio.radios import RadioFrequency, RadioRegistry, MHz
 from game.radio.tacan import TacanRegistry
 from game.theater import Airfield
@@ -46,6 +48,8 @@ from ..radio.datalink import DataLinkRegistry
 
 if TYPE_CHECKING:
     from game import Game
+
+CARCASS_SUPPRESS_RADIUS_M = 5.0
 
 
 class MissionGenerator:
@@ -308,8 +312,33 @@ class MissionGenerator:
         if self.game.settings.plugins.get("ewrj"):
             self._configure_react_to_threat_for_ew_jamming_packages(aircraft_generator)
 
+    def _live_unit_positions(self) -> list[tuple[float, float]]:
+        # World (x, z) of every live unit already spawned (TGO SAM/BAI, FARP depots,
+        # motorpool, convoys, cargo). pydcs Point.y is world z. Dead groups excluded
+        # so a wreck doesn't suppress itself. Frontline units aren't spawned yet.
+        positions: list[tuple[float, float]] = []
+        for coalition in self.mission.coalition.values():
+            for country in coalition.countries.values():
+                groups: list[Group[Any, Any]] = [
+                    *country.vehicle_group,
+                    *country.static_group,
+                ]
+                for group in groups:
+                    # Only StaticGroup carries a 'dead' flag; VehicleGroups have no
+                    # such attribute and are always live at prune time.
+                    if getattr(group, "dead", False):
+                        continue
+                    for unit in group.units:
+                        positions.append((unit.position.x, unit.position.y))
+        return positions
+
     def generate_destroyed_units(self) -> None:
         """Add destroyed units to the Mission"""
+        # Prune before the perf gate so stale carcasses are cleaned even when wreck
+        # spawning is disabled.
+        self.game.prune_destroyed_units(
+            LiveUnitIndex(self._live_unit_positions(), CARCASS_SUPPRESS_RADIUS_M)
+        )
         if not self.game.settings.perf_destroyed_units:
             return
 

--- a/game/spatialindex.py
+++ b/game/spatialindex.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import math
+
+
+class LiveUnitIndex:
+    """Point-proximity test over a fixed set of 2-D positions.
+
+    Buckets positions on an R-size grid; a query scans its own bucket plus the
+    eight neighbours (a point within R is at most one R-size bucket away on each
+    axis) and confirms with an exact distance check.
+    """
+
+    def __init__(self, positions: list[tuple[float, float]], radius: float) -> None:
+        self._radius = radius
+        self._buckets: dict[tuple[int, int], list[tuple[float, float]]] = {}
+        for x, z in positions:
+            # A non-finite position (inf/nan) isn't anywhere; skip it rather than
+            # let math.floor(x / radius) raise (OverflowError on inf, ValueError on
+            # nan) and abort construction.
+            if not (math.isfinite(x) and math.isfinite(z)):
+                continue
+            self._buckets.setdefault(self._cell(x, z), []).append((x, z))
+
+    def _cell(self, x: float, z: float) -> tuple[int, int]:
+        return (math.floor(x / self._radius), math.floor(z / self._radius))
+
+    def occupied(self, x: float, z: float) -> bool:
+        if not (math.isfinite(x) and math.isfinite(z)):
+            return False
+        cx, cz = self._cell(x, z)
+        for dx in (-1, 0, 1):
+            for dz in (-1, 0, 1):
+                for px, pz in self._buckets.get((cx + dx, cz + dz), ()):
+                    if math.hypot(px - x, pz - z) <= self._radius:
+                        return True
+        return False

--- a/tests/missiongenerator/test_live_unit_positions.py
+++ b/tests/missiongenerator/test_live_unit_positions.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+from typing import Any
+
+from game.missiongenerator.missiongenerator import MissionGenerator
+
+
+def _unit(x: float, y: float) -> Any:
+    return SimpleNamespace(position=SimpleNamespace(x=x, y=y))
+
+
+def _group(units: list[Any], dead: bool = False) -> Any:
+    return SimpleNamespace(units=units, dead=dead)
+
+
+def _mission(vehicle_groups: list[Any], static_groups: list[Any]) -> Any:
+    country = SimpleNamespace(vehicle_group=vehicle_groups, static_group=static_groups)
+    coalition = SimpleNamespace(countries={"c": country})
+    return SimpleNamespace(coalition={"blue": coalition})
+
+
+def _group_no_dead_attr(units: list[Any]) -> Any:
+    # pydcs VehicleGroup has NO 'dead' attribute (only StaticGroup does); the
+    # walker must tolerate its absence rather than AttributeError.
+    return SimpleNamespace(units=units)
+
+
+def test_collects_live_units_skips_dead_groups() -> None:
+    gen = MissionGenerator.__new__(MissionGenerator)
+    gen.mission = _mission(
+        vehicle_groups=[
+            _group([_unit(1.0, 2.0)]),
+            _group([_unit(9.0, 9.0)], dead=True),
+        ],
+        static_groups=[_group([_unit(3.0, 4.0)])],
+    )
+    assert sorted(gen._live_unit_positions()) == [(1.0, 2.0), (3.0, 4.0)]
+
+
+def test_group_without_dead_attr_is_live() -> None:
+    # A VehicleGroup lacks a 'dead' attribute entirely -> treated as live.
+    gen = MissionGenerator.__new__(MissionGenerator)
+    gen.mission = _mission(
+        vehicle_groups=[_group_no_dead_attr([_unit(7.0, 8.0)])],
+        static_groups=[],
+    )
+    assert gen._live_unit_positions() == [(7.0, 8.0)]

--- a/tests/test_game_carcass_dedup.py
+++ b/tests/test_game_carcass_dedup.py
@@ -2,6 +2,7 @@ from typing import Union
 from unittest.mock import MagicMock
 
 from game.game import Game
+from game.spatialindex import LiveUnitIndex
 
 
 def _carcass(type_name: str, x: float, z: float) -> dict[str, Union[float, str]]:
@@ -109,3 +110,38 @@ def test_add_destroyed_units_survives_inf_coord_incoming() -> None:
     game = _bare_game()
     game.add_destroyed_units(_carcass("Garage_A", float("inf"), 0.0))  # no crash
     assert len(game.get_destroyed_units()) == 1
+
+
+def test_prune_removes_carcass_under_live_unit() -> None:
+    game = _bare_game()
+    on = _carcass("Garage_A", 100.0, 200.0)
+    off = _carcass("Garage_A", 100.0, 400.0)
+    game._Game__destroyed_units = [on, off]  # type: ignore[attr-defined]
+    game.prune_destroyed_units(LiveUnitIndex([(101.0, 201.0)], 5.0))
+    assert game.get_destroyed_units() == [off]  # 'on' pruned, 'off' kept
+
+
+def test_prune_empty_index_keeps_all() -> None:
+    game = _bare_game()
+    items = [_carcass("Garage_A", 100.0, 200.0)]
+    game._Game__destroyed_units = list(items)  # type: ignore[attr-defined]
+    game.prune_destroyed_units(LiveUnitIndex([], 5.0))
+    assert game.get_destroyed_units() == items
+
+
+def test_prune_keeps_garbled_coord_carcass() -> None:
+    game = _bare_game()
+    bad: dict[str, Union[float, str]] = {"y": 0.0, "type": "Garage_A"}  # no x/z
+    game._Game__destroyed_units = [bad]  # type: ignore[attr-defined]
+    game.prune_destroyed_units(LiveUnitIndex([(0.0, 0.0)], 5.0))
+    assert game.get_destroyed_units() == [bad]  # unmatchable -> kept
+
+
+def test_prune_survives_inf_coord_carcass() -> None:
+    # math.floor(inf / radius) raises OverflowError (not ValueError): must be
+    # caught so an inf-coord carcass is kept, not crashing mission generation.
+    game = _bare_game()
+    inf_entry = _carcass("Garage_A", float("inf"), 0.0)
+    game._Game__destroyed_units = [inf_entry]  # type: ignore[attr-defined]
+    game.prune_destroyed_units(LiveUnitIndex([(0.0, 0.0)], 5.0))  # must not raise
+    assert game.get_destroyed_units() == [inf_entry]  # unmatchable -> kept

--- a/tests/test_game_carcass_dedup.py
+++ b/tests/test_game_carcass_dedup.py
@@ -1,0 +1,111 @@
+from typing import Union
+from unittest.mock import MagicMock
+
+from game.game import Game
+
+
+def _carcass(type_name: str, x: float, z: float) -> dict[str, Union[float, str]]:
+    return {"x": x, "y": 0.0, "z": z, "type": type_name, "orientation": 0.0}
+
+
+def _bare_game(on_land: bool = True) -> Game:
+    # Game.__new__ skips heavy __init__; we only exercise the carcass paths.
+    game = Game.__new__(Game)
+    game._Game__destroyed_units = []  # type: ignore[attr-defined]
+    theater = MagicMock()
+    theater.is_on_land.return_value = on_land
+    game.theater = theater
+    return game
+
+
+def test_carcass_key_same_type_and_position_are_equal() -> None:
+    a = Game._carcass_key(_carcass("Garage_A", 100.0, 200.0))
+    b = Game._carcass_key(_carcass("Garage_A", 100.0, 200.0))
+    assert a == b
+
+
+def test_carcass_key_distinct_position_differs() -> None:
+    a = Game._carcass_key(_carcass("Garage_A", 100.0, 200.0))
+    b = Game._carcass_key(_carcass("Garage_A", 100.0, 260.0))
+    assert a != b
+
+
+def test_carcass_key_distinct_type_differs() -> None:
+    # FARP fuel vs ammo can sit within metres of each other — must not merge.
+    a = Game._carcass_key(_carcass("FARP_Fuel_Depot", 100.0, 200.0))
+    b = Game._carcass_key(_carcass("FARP_Ammo_Dump_Coating", 100.0, 200.0))
+    assert a != b
+
+
+def test_carcass_key_quantizes_submetre_jitter() -> None:
+    a = Game._carcass_key(_carcass("Garage_A", 100.0, 200.0))
+    b = Game._carcass_key(_carcass("Garage_A", 100.4, 199.6))
+    assert a == b
+
+
+def test_add_destroyed_units_dedups_same_type_position() -> None:
+    game = _bare_game()
+    game.add_destroyed_units(_carcass("Garage_A", 100.0, 200.0))
+    game.add_destroyed_units(_carcass("Garage_A", 100.0, 200.0))
+    assert len(game.get_destroyed_units()) == 1
+
+
+def test_add_destroyed_units_keeps_distinct_positions() -> None:
+    game = _bare_game()
+    game.add_destroyed_units(_carcass("Garage_A", 100.0, 200.0))
+    game.add_destroyed_units(_carcass("Garage_A", 100.0, 260.0))
+    assert len(game.get_destroyed_units()) == 2
+
+
+def test_add_destroyed_units_skips_offland() -> None:
+    game = _bare_game(on_land=False)
+    game.add_destroyed_units(_carcass("Garage_A", 100.0, 200.0))
+    assert len(game.get_destroyed_units()) == 0
+
+
+def test_dedup_destroyed_units_collapses_and_keeps_first() -> None:
+    game = _bare_game()
+    first = _carcass("Garage_A", 100.0, 200.0)
+    dup = _carcass("Garage_A", 100.3, 200.2)  # same 1 m cell
+    other = _carcass("FARP_Fuel_Depot", 500.0, 600.0)
+    game._Game__destroyed_units = [first, dup, other]  # type: ignore[attr-defined]
+    game._dedup_destroyed_units()
+    result = game.get_destroyed_units()
+    assert result == [first, other]  # first occurrence kept, order preserved
+
+
+def test_dedup_destroyed_units_keeps_unkeyable_entries() -> None:
+    game = _bare_game()
+    bad: dict[str, Union[float, str]] = {"y": 0.0, "type": "Garage_A"}  # no x/z
+    game._Game__destroyed_units = [bad]  # type: ignore[attr-defined]
+    game._dedup_destroyed_units()
+    assert game.get_destroyed_units() == [bad]
+
+
+def test_add_destroyed_units_survives_unkeyable_entry_in_list() -> None:
+    # An unkeyable legacy entry (no x/z) that _dedup preserves must not make the
+    # next insert's dedup scan raise KeyError.
+    game = _bare_game()
+    bad: dict[str, Union[float, str]] = {"y": 0.0, "type": "Garage_A"}  # no x/z
+    game._Game__destroyed_units = [bad]  # type: ignore[attr-defined]
+    game.add_destroyed_units(_carcass("Garage_A", 100.0, 200.0))
+    assert len(game.get_destroyed_units()) == 2  # bad kept, new one appended
+
+
+def test_safe_carcass_key_none_on_inf_coord() -> None:
+    # round(inf) raises OverflowError (not ValueError): must be caught -> None.
+    assert Game._safe_carcass_key(_carcass("Garage_A", float("inf"), 0.0)) is None
+
+
+def test_dedup_destroyed_units_survives_inf_coord() -> None:
+    game = _bare_game()
+    inf_entry = _carcass("Garage_A", float("inf"), 0.0)
+    game._Game__destroyed_units = [inf_entry]  # type: ignore[attr-defined]
+    game._dedup_destroyed_units()  # must not raise OverflowError
+    assert game.get_destroyed_units() == [inf_entry]  # kept as unkeyable
+
+
+def test_add_destroyed_units_survives_inf_coord_incoming() -> None:
+    game = _bare_game()
+    game.add_destroyed_units(_carcass("Garage_A", float("inf"), 0.0))  # no crash
+    assert len(game.get_destroyed_units()) == 1

--- a/tests/test_spatialindex.py
+++ b/tests/test_spatialindex.py
@@ -1,0 +1,37 @@
+from game.spatialindex import LiveUnitIndex
+
+
+def test_empty_index_never_occupied() -> None:
+    assert LiveUnitIndex([], 5.0).occupied(0.0, 0.0) is False
+
+
+def test_occupied_within_radius() -> None:
+    idx = LiveUnitIndex([(100.0, 200.0)], 5.0)
+    assert idx.occupied(100.0, 200.0) is True
+    assert idx.occupied(103.0, 203.0) is True  # ~4.24 m
+
+
+def test_not_occupied_beyond_radius() -> None:
+    idx = LiveUnitIndex([(100.0, 200.0)], 5.0)
+    assert idx.occupied(110.0, 200.0) is False  # 10 m
+
+
+def test_boundary_just_inside_and_outside() -> None:
+    idx = LiveUnitIndex([(0.0, 0.0)], 5.0)
+    assert idx.occupied(4.9, 0.0) is True
+    assert idx.occupied(5.1, 0.0) is False
+
+
+def test_match_found_in_neighbouring_bucket() -> None:
+    # Query and point sit in different R-size buckets but within R.
+    idx = LiveUnitIndex([(4.9, 0.0)], 5.0)  # bucket (0,0)
+    assert idx.occupied(5.1, 0.0) is True  # bucket (1,0), dist 0.2 m
+
+
+def test_non_finite_positions_skipped_at_construction() -> None:
+    # A degenerate unit position (inf/nan) must not crash __init__
+    # (math.floor(inf/r) -> OverflowError, math.floor(nan/r) -> ValueError);
+    # such a unit isn't anywhere, so it occupies nothing. Finite points still work.
+    idx = LiveUnitIndex([(float("inf"), 0.0), (0.0, float("nan")), (100.0, 200.0)], 5.0)
+    assert idx.occupied(100.0, 200.0) is True
+    assert idx.occupied(float("inf"), 0.0) is False


### PR DESCRIPTION
    Game.add_destroyed_units appended every destroyed-static position from the debrief with no dedup. Statics that Retribution respawns alive every mission at a fixed spot — FARP fuel/ammo depots (FARP_Fuel_Depot, FARP_Ammo_Dump_Coating), the motorpool Garage_A depot — therefore stacked a new hidden dead carcass at that spot each time they were bombed, and a live respawned unit z-fought the old wreck. Growth is unbounded over a campaign; generate_destroyed_units re-spawns every entry each mission (gated by perf_destroyed_units). Perf/cosmetic — no economy or front-line effect.

##    Steps to reproduce

    1. Enable perf_destroyed_units. Play a campaign with a FARP (fuel/ammo depots present).
    2. Bomb the FARP fuel/ammo depot; end the mission.
    3. Repeat over several turns (the depot respawns alive each mission).
    4. Inspect the save: game.get_destroyed_units() holds N entries at the same (type, x, z) — one per mission bombed — and each generated .miz spawns N coincident hidden dead statics, one of them clipping the live respawned depot.

## Fix

    1. Dedup carcasses by position — game/game.py
    2. Suppress carcasses under respawned live units

      Layering stays clean: LiveUnitIndex is a leaf; game.py and missiongenerator.py both depend on it, with no new game → missiongenerator import.

      Behavior for genuinely one-time destroyed statics is unchanged (they were already exactly one wreck, and no live unit stands on them). 22 new tests; full suite green.