### PR TITLE
Mirage F1EQ loadout and yaml update

### DIFF
--- a/resources/customized_payloads/Mirage-F1EQ.lua
+++ b/resources/customized_payloads/Mirage-F1EQ.lua
@@ -1,44 +1,50 @@
 local unitPayloads = {
 	["name"] = "Mirage-F1EQ",
 	["payloads"] = {
-		[1] = {
-			["displayName"] = "Retribution CAS",
-			["name"] = "Retribution CAS",
+		[0] = {
+			["displayName"] = "Clean",
+			["name"] = "Clean",
 			["pylons"] = {
 				[1] = {
-					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
-					["num"] = 7,
-				},
-				[2] = {
-					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
+					["CLSID"] = "<CLEAN>",
 					["num"] = 1,
 				},
-				[3] = {
-					["CLSID"] = "BR_500",
-					["num"] = 5,
+				[2] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
 				},
-				[4] = {
-					["CLSID"] = "BR_500",
+				[3] = {
+					["CLSID"] = "<CLEAN>",
 					["num"] = 3,
 				},
-				[5] = {
-					["CLSID"] = "PTB-1200-F1",
+				[4] = {
+					["CLSID"] = "<CLEAN>",
 					["num"] = 4,
 				},
+				[5] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 5,
+				},
 				[6] = {
-					["CLSID"] = "BR_500",
+					["CLSID"] = "<CLEAN>",
 					["num"] = 6,
 				},
 				[7] = {
-					["CLSID"] = "BR_500",
-					["num"] = 2,
+					["CLSID"] = "<CLEAN>",
+					["num"] = 7,
 				},
 			},
 			["tasks"] = {
-				[1] = 11,
+				[1] = 10,
+				[2] = 11,
+				[3] = 18,
+				[4] = 19,
+				[5] = 31,
+				[6] = 32,
+				[7] = 34,
 			},
 		},
-		[2] = {
+		[1] = {
 			["displayName"] = "Retribution OCA/Runway",
 			["name"] = "Retribution OCA/Runway",
 			["pylons"] = {
@@ -73,12 +79,91 @@ local unitPayloads = {
 			},
 			["tasks"] = {
 				[1] = 11,
-				[2] = 34,
+			},
+		},
+		[2] = {
+			["displayName"] = "Retribution Strike",
+			["name"] = "Retribution Strike",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
+					["num"] = 7,
+				},
+				[2] = {
+					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{7A44FF09-527C-4B7E-B42B-3F111CFE50FB}",
+					["num"] = 5,
+					["settings"] = {
+						["00_prfx_arm_delay_ctrl_M904E4"] = 4,
+						["00_prfx_function_delay_ctrl_M904E4"] = 0,
+						["01_prfx_arm_delay_ctrl_M905"] = 4,
+						["01_prfx_function_delay_ctrl_M905"] = 0,
+						["NFP_PRESID"] = "MDRN_B_A_GPLD",
+						["NFP_PRESVER"] = 2,
+						["NFP_VIS_DrawArgNo_57"] = 0,
+						["NFP_fuze_type_nose"] = "M904E4",
+						["NFP_fuze_type_tail"] = "M905",
+					},
+				},
+				[4] = {
+					["CLSID"] = "{7A44FF09-527C-4B7E-B42B-3F111CFE50FB}",
+					["num"] = 3,
+					["settings"] = {
+						["00_prfx_arm_delay_ctrl_M904E4"] = 4,
+						["00_prfx_function_delay_ctrl_M904E4"] = 0,
+						["01_prfx_arm_delay_ctrl_M905"] = 4,
+						["01_prfx_function_delay_ctrl_M905"] = 0,
+						["NFP_PRESID"] = "MDRN_B_A_GPLD",
+						["NFP_PRESVER"] = 2,
+						["NFP_VIS_DrawArgNo_57"] = 0,
+						["NFP_fuze_type_nose"] = "M904E4",
+						["NFP_fuze_type_tail"] = "M905",
+					},
+				},
+				[5] = {
+					["CLSID"] = "PTB-1200-F1",
+					["num"] = 4,
+				},
+				[6] = {
+					["CLSID"] = "{7A44FF09-527C-4B7E-B42B-3F111CFE50FB}",
+					["num"] = 6,
+					["settings"] = {
+						["00_prfx_arm_delay_ctrl_M904E4"] = 4,
+						["00_prfx_function_delay_ctrl_M904E4"] = 0,
+						["01_prfx_arm_delay_ctrl_M905"] = 4,
+						["01_prfx_function_delay_ctrl_M905"] = 0,
+						["NFP_PRESID"] = "MDRN_B_A_GPLD",
+						["NFP_PRESVER"] = 2,
+						["NFP_VIS_DrawArgNo_57"] = 0,
+						["NFP_fuze_type_nose"] = "M904E4",
+						["NFP_fuze_type_tail"] = "M905",
+					},
+				},
+				[7] = {
+					["CLSID"] = "{7A44FF09-527C-4B7E-B42B-3F111CFE50FB}",
+					["num"] = 2,
+					["settings"] = {
+						["00_prfx_arm_delay_ctrl_M904E4"] = 4,
+						["00_prfx_function_delay_ctrl_M904E4"] = 0,
+						["01_prfx_arm_delay_ctrl_M905"] = 4,
+						["01_prfx_function_delay_ctrl_M905"] = 0,
+						["NFP_PRESID"] = "MDRN_B_A_GPLD",
+						["NFP_PRESVER"] = 2,
+						["NFP_VIS_DrawArgNo_57"] = 0,
+						["NFP_fuze_type_nose"] = "M904E4",
+						["NFP_fuze_type_tail"] = "M905",
+					},
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
 			},
 		},
 		[3] = {
-			["displayName"] = "Retribution Strike",
-			["name"] = "Retribution Strike",
+			["name"] = "Retribution BAI",
 			["pylons"] = {
 				[1] = {
 					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
@@ -137,12 +222,130 @@ local unitPayloads = {
 					["CLSID"] = "PTB-1200-F1",
 					["num"] = 4,
 				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
+				},
+				[7] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 6,
+				},
 			},
 			["tasks"] = {
 				[1] = 11,
 			},
 		},
 		[5] = {
+			["displayName"] = "Retribution OCA/Aircraft",
+			["name"] = "Retribution OCA/Aircraft",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
+					["num"] = 7,
+				},
+				[2] = {
+					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{MATRA_F1_SNEBT257}",
+					["num"] = 5,
+				},
+				[4] = {
+					["CLSID"] = "{MATRA_F1_SNEBT257}",
+					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "PTB-1200-F1",
+					["num"] = 4,
+				},
+				[6] = {
+					["CLSID"] = "{MATRA_F1_SNEBT257}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{MATRA_F1_SNEBT257}",
+					["num"] = 2,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[6] = {
+			["name"] = "Retribution BARCAP",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
+					["num"] = 7,
+				},
+				[2] = {
+					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{S530F}",
+					["num"] = 5,
+				},
+				[4] = {
+					["CLSID"] = "{S530F}",
+					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "PTB-1200-F1",
+					["num"] = 4,
+				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[7] = {
+			["displayName"] = "Retribution CAS",
+			["name"] = "Retribution CAS",
+			["pylons"] = {
+				[1] = {
+					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
+					["num"] = 7,
+				},
+				[2] = {
+					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
+					["num"] = 1,
+				},
+				[3] = {
+					["CLSID"] = "{BLG66_AC}",
+					["num"] = 5,
+				},
+				[4] = {
+					["CLSID"] = "{BLG66_AC}",
+					["num"] = 3,
+				},
+				[5] = {
+					["CLSID"] = "PTB-1200-F1",
+					["num"] = 4,
+				},
+				[6] = {
+					["CLSID"] = "{BLG66_AC}",
+					["num"] = 6,
+				},
+				[7] = {
+					["CLSID"] = "{BLG66_AC}",
+					["num"] = 2,
+				},
+			},
+			["tasks"] = {
+				[1] = 11,
+			},
+		},
+		[8] = {
 			["displayName"] = "Retribution Escort",
 			["name"] = "Retribution Escort",
 			["pylons"] = {
@@ -166,12 +369,20 @@ local unitPayloads = {
 					["CLSID"] = "PTB-1200-F1",
 					["num"] = 4,
 				},
+				[6] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 2,
+				},
+				[7] = {
+					["CLSID"] = "<CLEAN>",
+					["num"] = 6,
+				},
 			},
 			["tasks"] = {
 				[1] = 11,
 			},
 		},
-		[6] = {
+		[9] = {
 			["displayName"] = "Retribution DEAD",
 			["name"] = "Retribution DEAD",
 			["pylons"] = {
@@ -184,11 +395,11 @@ local unitPayloads = {
 					["num"] = 1,
 				},
 				[3] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
+					["CLSID"] = "{X-29T}",
 					["num"] = 5,
 				},
 				[4] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
+					["CLSID"] = "{X-29T}",
 					["num"] = 3,
 				},
 				[5] = {
@@ -196,11 +407,11 @@ local unitPayloads = {
 					["num"] = 4,
 				},
 				[6] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
+					["CLSID"] = "<CLEAN>",
 					["num"] = 6,
 				},
 				[7] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
+					["CLSID"] = "<CLEAN>",
 					["num"] = 2,
 				},
 			},
@@ -208,44 +419,7 @@ local unitPayloads = {
 				[1] = 11,
 			},
 		},
-		[7] = {
-			["displayName"] = "Retribution OCA/Aircraft",
-			["name"] = "Retribution OCA/Aircraft",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
-					["num"] = 7,
-				},
-				[2] = {
-					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
-					["num"] = 1,
-				},
-				[3] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
-					["num"] = 5,
-				},
-				[4] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
-					["num"] = 3,
-				},
-				[5] = {
-					["CLSID"] = "PTB-1200-F1",
-					["num"] = 4,
-				},
-				[6] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
-					["num"] = 6,
-				},
-				[7] = {
-					["CLSID"] = "{BLG66_BELOUGA}",
-					["num"] = 2,
-				},
-			},
-			["tasks"] = {
-				[1] = 11,
-			},
-		},
-		[8] = {
+		[10] = {
 			["displayName"] = "Retribution TARCAP",
 			["name"] = "Retribution TARCAP",
 			["pylons"] = {
@@ -269,69 +443,13 @@ local unitPayloads = {
 					["CLSID"] = "PTB-1200-F1",
 					["num"] = 4,
 				},
-			},
-			["tasks"] = {
-				[1] = 11,
-			},
-		},
-		[9] = {
-			["name"] = "Retribution BAI",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
-					["num"] = 7,
-				},
-				[2] = {
-					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
-					["num"] = 1,
-				},
-				[3] = {
-					["CLSID"] = "BR_500",
-					["num"] = 5,
-				},
-				[4] = {
-					["CLSID"] = "BR_500",
-					["num"] = 3,
-				},
-				[5] = {
-					["CLSID"] = "PTB-1200-F1",
-					["num"] = 4,
-				},
 				[6] = {
-					["CLSID"] = "BR_500",
+					["CLSID"] = "<CLEAN>",
 					["num"] = 6,
 				},
 				[7] = {
-					["CLSID"] = "BR_500",
+					["CLSID"] = "<CLEAN>",
 					["num"] = 2,
-				},
-			},
-			["tasks"] = {
-				[1] = 11,
-			},
-		},
-		[10] = {
-			["name"] = "Retribution BARCAP",
-			["pylons"] = {
-				[1] = {
-					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
-					["num"] = 7,
-				},
-				[2] = {
-					["CLSID"] = "{FC23864E-3B80-48E3-9C03-4DA8B1D7497B}",
-					["num"] = 1,
-				},
-				[3] = {
-					["CLSID"] = "{S530F}",
-					["num"] = 5,
-				},
-				[4] = {
-					["CLSID"] = "{S530F}",
-					["num"] = 3,
-				},
-				[5] = {
-					["CLSID"] = "PTB-1200-F1",
-					["num"] = 4,
 				},
 			},
 			["tasks"] = {

--- a/resources/units/aircraft/Mirage-F1EQ.yaml
+++ b/resources/units/aircraft/Mirage-F1EQ.yaml
@@ -15,6 +15,7 @@ tasks:
   BAI: 300
   BARCAP: 290
   CAS: 300
+  DEAD: 300
   Escort: 290
   Fighter sweep: 290
   Intercept: 290


### PR DESCRIPTION
Add DEAD mission type to F1EQ, and update its loadout to fix empty pylons and remove missile type it cannot carry.