### PR TITLE
Anti-ship: expend=All so the AI fires its whole anti-ship load

### DIFF
--- a/game/missiongenerator/aircraft/waypoints/antishipingress.py
+++ b/game/missiongenerator/aircraft/waypoints/antishipingress.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 
 from dcs.point import MovingPoint
-from dcs.task import AttackGroup, OptFormation, WeaponType
+from dcs.task import AttackGroup, Expend, OptFormation, WeaponType
 
 from game.theater import NavalControlPoint, TheaterGroundObject
 from .pydcswaypointbuilder import PydcsWaypointBuilder
@@ -70,7 +70,15 @@ class AntiShipIngressBuilder(PydcsWaypointBuilder):
                 )
                 continue
 
-            task = AttackGroup(miz_group.id, group_attack=True, weapon_type=ordnance)
+            # expend=All so the AI empties its anti-ship load on the target instead of
+            # DCS's default Auto salvo (which fires ~2 and RTBs with the rest). Matches
+            # what DEAD does. weapon_type scopes it to the anti-ship ordnance only.
+            task = AttackGroup(
+                miz_group.id,
+                group_attack=True,
+                weapon_type=ordnance,
+                expend=Expend.All,
+            )
             waypoint.tasks.append(task)
             added += 1
         return added


### PR DESCRIPTION
The AntiShip `AttackGroup` task sets no `expend`, so DCS falls back to `Auto` — the AI fires a partial salvo (~2 missiles) and RTBs with the rest. In one debrief most F/A-18Cs fired 2 of 4 LRASM and left the ships barely damaged.

This sets `expend=Expend.All` (scoped to the anti-ship ordnance via `weapon_type`, so only the anti-ship missiles are affected), matching what the DEAD ingress task already does, so an anti-ship flight empties its anti-ship load on the target.

One file changed; no behaviour change for any other task.
