### PR TITLE
Naval: fleets actively defend (RED alarm + weapon-free ROE), not passive

### DIFF
--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -40,6 +40,7 @@ from dcs.task import (
     EPLRS,
     FireAtPoint,
     OptAlarmState,
+    OptROE,
 )
 from dcs.terrain import Airport
 from dcs.translation import String
@@ -377,7 +378,8 @@ class GroundObjectGenerator:
                 if frequency:
                     ship_group.set_frequency(frequency.hertz)
                 ship_group.units[0].name = unit.unit_name
-                self.set_alarm_state(ship_group)
+                self.set_alarm_state(ship_group, force_red=True)
+                self.set_ship_engagement(ship_group)
                 NavalForcePainter(faction, ship_group.units[0]).apply_livery()
             else:
                 ship_unit = self.m.ship(unit.unit_name, unit.type)
@@ -422,11 +424,24 @@ class GroundObjectGenerator:
         if eplrs_enabled and unit_type.eplrs:
             group.points[0].tasks.append(EPLRS(group.id))
 
-    def set_alarm_state(self, group: MovingGroup[Any]) -> None:
-        if self.game.settings.perf_red_alert_state:
+    def set_alarm_state(self, group: MovingGroup[Any], force_red: bool = False) -> None:
+        # Ships pass force_red so they always defend; the perf toggle only exists
+        # to let ground SAMs start "dark" for Skynet IADS, not to disarm fleets.
+        if force_red or self.game.settings.perf_red_alert_state:
             group.points[0].tasks.append(OptAlarmState(2))
         else:
             group.points[0].tasks.append(OptAlarmState(1))
+
+    def set_ship_engagement(self, group: ShipGroup) -> None:
+        # Make fleets fight rather than sit passive. Ship weapons engagement in DCS is
+        # OPTION-driven, not task-driven: weapon-free ROE plus the RED alarm state set in
+        # set_alarm_state make a ship fire autonomously on any target that enters weapon
+        # range — SAMs on aircraft, anti-ship missiles/guns/torpedoes on enemy ships.
+        # Do NOT add an EngageTargets task here: it is an air-only enroute task, invalid
+        # for a ship controller (DCS me_action_db offers ships only NoTask), and feeding
+        # it to the naval AI crashed DCS (ACCESS_VIOLATION in AI::ControllerStack::start).
+        # Upstream ships likewise engage on ROE/alarm alone.
+        group.points[0].tasks.append(OptROE(OptROE.Values.WeaponFree))
 
     def _register_theater_unit(
         self,


### PR DESCRIPTION
Enemy (and friendly) ship groups were generated with only the default alarm state, so when the performance **red alert state** setting is off they sit passive — radars off, not firing — even when the enemy flies right over them.

This forces **RED alarm** on ships (they should never start dark, unlike ground SAMs which do so on purpose for Skynet IADS) and sets **weapon-free ROE**, so a fleet fires autonomously on any target that enters weapon range: SAMs on aircraft, anti-ship missiles / guns / torpedoes on enemy ships (submarines fire torpedoes). Ships still hold position (no attack waypoints) — this is aggressive defense, not a hunt.

Engagement is **option-driven** (ROE + alarm), not task-driven. Note the comment on `set_ship_engagement`: an `EngageTargets` task is **air-only and invalid for a ship controller** (DCS `me_action_db` offers ships only `NoTask`), and feeding it to the naval AI crashes DCS (`ACCESS_VIOLATION` in `AI::ControllerStack::start`) — so it is deliberately not used.

One file (`tgogenerator.py`); no behaviour change for ground groups.
