### PR TITLE
Airboss: add S3/A6 recovery tanker selection dropdown

### DIFF
--- a/game/plugins/luaplugin.py
+++ b/game/plugins/luaplugin.py
@@ -58,10 +58,17 @@ class PluginSettings:
 
 class LuaPluginOption(PluginSettings):
     def __init__(
-        self, identifier: str, name: str, min: Any, max: Any, value: Any
+        self,
+        identifier: str,
+        name: str,
+        min: Any,
+        max: Any,
+        value: Any,
+        possible_values: Optional[List[str]] = None,
     ) -> None:
         super().__init__(identifier, value)
         self.name = name
+        self.possible_values = possible_values
         if type(value) == int or type(value) == float:
             self.min, self.max = min, max
         else:
@@ -94,6 +101,7 @@ class LuaPluginDefinition:
                     min=option.get("minimumValue", 0),
                     max=option.get("maximumValue", 10000),
                     value=option.get("defaultValue"),
+                    possible_values=option.get("possibleValues"),
                 )
             )
 
@@ -180,13 +188,20 @@ class LuaPlugin(PluginSettings):
         if self.options:
             option_decls = []
             for option in self.options:
-                value = str(option.get_value).lower()
+                raw_value = option.get_value
+                if isinstance(raw_value, bool):
+                    value = str(raw_value).lower()
+                elif isinstance(raw_value, (int, float)):
+                    value = str(raw_value)
+                else:
+                    value = json.dumps(str(raw_value))
                 name = option.identifier
                 option_decls.append(f"    dcsRetribution.plugins.{name} = {value}")
 
             joined_options = "\n".join(option_decls)
 
-            lua = textwrap.dedent(f"""\
+            lua = textwrap.dedent(
+                f"""\
                 -- {self.identifier} plugin configuration.
 
                 if dcsRetribution then
@@ -197,7 +212,8 @@ class LuaPlugin(PluginSettings):
                     {joined_options}
                 end
 
-            """)
+            """
+            )
 
             lua_generator.inject_lua_trigger(
                 lua, f"{self.identifier} plugin configuration"

--- a/game/plugins/luaplugin.py
+++ b/game/plugins/luaplugin.py
@@ -200,8 +200,7 @@ class LuaPlugin(PluginSettings):
 
             joined_options = "\n".join(option_decls)
 
-            lua = textwrap.dedent(
-                f"""\
+            lua_template = f"""\
                 -- {self.identifier} plugin configuration.
 
                 if dcsRetribution then
@@ -213,7 +212,7 @@ class LuaPlugin(PluginSettings):
                 end
 
             """
-            )
+            lua = textwrap.dedent(lua_template)
 
             lua_generator.inject_lua_trigger(
                 lua, f"{self.identifier} plugin configuration"

--- a/qt_ui/windows/settings/plugins.py
+++ b/qt_ui/windows/settings/plugins.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 from PySide6.QtCore import Qt, QLocale
 from PySide6.QtWidgets import (
     QCheckBox,
+    QComboBox,
     QGridLayout,
     QGroupBox,
     QLabel,
@@ -91,7 +92,15 @@ class PluginOptionsBox(QGroupBox):
             layout.addWidget(label, row, 0)
 
             val = option.get_value
-            if type(val) == bool:
+            if option.possible_values:
+                combobox = QComboBox()
+                combobox.addItems(option.possible_values)
+                if val in option.possible_values:
+                    combobox.setCurrentText(val)
+                combobox.currentTextChanged.connect(option.set_value)
+                layout.addWidget(combobox, row, 1)
+                self.widgets[option.identifier] = combobox
+            elif type(val) == bool:
                 checkbox = QCheckBox()
                 checkbox.setChecked(val)
                 checkbox.toggled.connect(option.set_value)
@@ -119,6 +128,8 @@ class PluginOptionsBox(QGroupBox):
             w = self.widgets[identifier]
             if isinstance(w, QCheckBox):
                 w.setChecked(value)
+            elif isinstance(w, QComboBox):
+                w.setCurrentText(value)
             elif isinstance(w, QDoubleSpinBox) or isinstance(w, QSpinBox):
                 w.setValue(value)
 

--- a/resources/plugins/_doc/plugins_readme.md
+++ b/resources/plugins/_doc/plugins_readme.md
@@ -23,6 +23,7 @@ Here's a quick rundown of the file's components :
   - `nameInUI` : the title of the option as it will appear in the plugins specific options user interface.
   - `mnemonic` : the short, technical name of the option. It's the name of the LUA variable passed to the configuration script, and the name of the option in the application's settings 
   - `defaultValue` : the selection value of the option, when first installed ; if true, option is selected.
+  - `possibleValues` : (optional) a list of string choices. When present, the option is rendered as a drop-down in the UI and the `defaultValue` should be one of the listed strings. The selected string is passed to the configuration script as a quoted LUA string.
 - `scriptsWorkOrders` : a list of work orders that can be used to load or disable loading a specific LUA script
   - `file` : the name of the LUA file in the plugin folder.
   - `mnemonic` : the technical name of the LUA component. The filename may be more precise than needed (e.g. include a version number) ; this is used to load each file only once, and also to disable loading a file

--- a/resources/plugins/airboss/airboss.lua
+++ b/resources/plugins/airboss/airboss.lua
@@ -811,7 +811,7 @@ local function AutoSetup()
         if airboss_options.enableRescueHelo then AddRescueHelo(cvn.name) end
         if airboss_options.enableAWACS      then AddShipAWACS(cvn.name) end
         if airboss_options.enableTanker then
-            if airboss_options.tankerType == "A6" then
+            if airboss_options.tankerType == "A-6" then
                 AddA6Tanker(cvn.name)
             else
                 AddTrickOrTreat(cvn.name)

--- a/resources/plugins/airboss/airboss.lua
+++ b/resources/plugins/airboss/airboss.lua
@@ -8,6 +8,7 @@ airboss_options = {
     ["rescueHeloDistance"] = 50,
     ["enableAWACS"] = false,
     ["enableTanker"] = false,
+    ["tankerType"] = "S3",
     ["enableForLHA"] = true,
     ["useUH60mod"] = false,
     ["rescueDuration"] = 3,
@@ -26,6 +27,7 @@ if dcsRetribution then
         airboss_options.rescueHeloDistance = dcsRetribution.plugins.airboss.rescueHeloDistance
         airboss_options.enableAWACS = dcsRetribution.plugins.airboss.enableAWACS
         airboss_options.enableTanker = dcsRetribution.plugins.airboss.enableTanker
+        airboss_options.tankerType = dcsRetribution.plugins.airboss.tankerType or airboss_options.tankerType
         airboss_options.enableForLHA = dcsRetribution.plugins.airboss.enableForLHA
         airboss_options.useUH60mod = dcsRetribution.plugins.airboss.useUH60mod
         airboss_options.rescueDuration = dcsRetribution.plugins.airboss.rescueDuration
@@ -325,6 +327,139 @@ function AddTrickOrTreat(nameOfCarrier)
     end)
 
     S3:Spawn()
+end
+
+-- A-6E TANKER (Heatblur)
+
+function AddA6Tanker(nameOfCarrier)
+    env.info("AIRBOSS: Loading A-6E Tanker")
+
+    -- Ensure BlueNavalUnitSet is initialized
+    if not BlueNavalUnitSet then
+        BlueNavalUnitSet = SET_UNIT:New():FilterCoalitions("blue"):FilterCategories("ship"):FilterStart()
+    end
+
+    local navalUnit = BlueNavalUnitSet:GetFirst()
+    local inferredCountryID = navalUnit and navalUnit:GetCountry() or country.id.USA
+
+    -- Generate unique names
+    local groupName = UTILS.UniqueName("TankerA6Group")
+    local unitName = UTILS.UniqueName("TankerA6Unit")
+
+    local TankerA6 = {
+        ["dynSpawnTemplate"] = false,
+        ["lateActivation"] = true,
+        ["tasks"] = {},
+        ["task"] = "Refueling",
+        ["uncontrolled"] = false,
+        ["taskSelected"] = true,
+        ["route"] = {
+            ["routeRelativeTOT"] = true,
+            ["points"] = {
+                [1] = {
+                    ["alt"] = 2000,
+                    ["action"] = "Turning Point",
+                    ["alt_type"] = "BARO",
+                    ["speed"] = 82.222222222222,
+                    ["task"] = {
+                        ["id"] = "ComboTask",
+                        ["params"] = {
+                            ["tasks"] = {
+                                { ["enabled"] = true, ["auto"] = true, ["id"] = "Tanker", ["number"] = 1, ["params"] = {} },
+                                { ["enabled"] = true, ["auto"] = true, ["id"] = "WrappedAction", ["number"] = 2, ["params"] = { ["action"] = { ["id"] = "ActivateBeacon", ["params"] = { ["type"] = 4, ["AA"] = false, ["callsign"] = "TKR", ["system"] = 4, ["channel"] = 1, ["modeChannel"] = "X", ["bearing"] = true, ["frequency"] = 962000000 } } } },
+                                { ["enabled"] = true, ["auto"] = true, ["id"] = "WrappedAction", ["number"] = 3, ["params"] = { ["action"] = { ["id"] = "Option", ["params"] = { ["value"] = true, ["name"] = 35 } } } }
+                            }
+                        }
+                    },
+                    ["type"] = "Turning Point",
+                    ["ETA"] = 0,
+                    ["ETA_locked"] = true,
+                    ["y"] = -110857.14285714,
+                    ["x"] = -18142.857142857,
+                    ["speed_locked"] = true,
+                    ["formation_template"] = ""
+                }
+            }
+        },
+        ["hidden"] = false,
+        ["units"] = {
+            [1] = {
+                ["alt"] = 2000,
+                ["alt_type"] = "BARO",
+                ["skill"] = "High",
+                ["speed"] = 82.222222222222,
+                ["type"] = "A6E",
+                ["psi"] = 0,
+                ["onboard_num"] = "021",
+                ["y"] = -110857.14285714,
+                ["x"] = -18142.857142857,
+                ["name"] = unitName,
+                -- Retribution Refueling loadout: D-704 buddy store on the centerline
+                -- pylon (3) with AERO-1D drop tanks on the wing pylons (1, 2, 4, 5).
+                ["payload"] = {
+                    ["pylons"] = {
+                        [1] = { ["CLSID"] = "{HB_A6E_AERO1D}" },
+                        [2] = { ["CLSID"] = "{HB_A6E_AERO1D}" },
+                        [3] = { ["CLSID"] = "{HB_A6E_D704}" },
+                        [4] = { ["CLSID"] = "{HB_A6E_AERO1D}" },
+                        [5] = { ["CLSID"] = "{HB_A6E_AERO1D}" }
+                    },
+                    ["fuel"] = 7229,
+                    ["flare"] = 30,
+                    ["chaff"] = 30,
+                    ["gun"] = 100
+                },
+                ["heading"] = 0,
+                ["callsign"] = {
+                    [1] = 5,
+                    [2] = 1,
+                    [3] = 1,
+                    [4] = "Arco11",
+                    ["name"] = "Arco11"
+                }
+            }
+        },
+        ["y"] = -110857.14285714,
+        ["x"] = -18142.857142857,
+        ["name"] = groupName,
+        ["communication"] = true,
+        ["start_time"] = 0,
+        ["modulation"] = 0,
+        ["frequency"] = 251
+    }
+
+    local A6 = SPAWN:NewFromTemplate(TankerA6, groupName)
+    A6:InitLateActivated()
+    A6:InitCountry(inferredCountryID)
+    A6:InitCategory(Group.Category.AIRPLANE)
+    A6:InitCoalition(coalition.side.BLUE)
+
+    A6:OnSpawnGroup(function(grp)
+        MESSAGE:New("AIRBOSS: Group Spawned Late Activated: " .. grp:GetName(), 15, "SPAWN"):ToLog()
+
+        local A6TED = RECOVERYTANKER:New(UNIT:FindByName(nameOfCarrier), grp:GetName())
+        A6TED:SetTACAN(57, "MLR", "Y")
+        A6TED:SetRadio(257, "AM")
+        A6TED:SetTakeoffHot()
+        A6TED:SetAltitude(8000)
+        A6TED:SetSpeed(275)
+        A6TED:SetRacetrackDistances(15, 15)
+        A6TED:SetHomeBase(nameOfCarrier)
+        A6TED:SetUnlimitedFuel(false)
+        A6TED:SetCallsign(CALLSIGN.Tanker.Arco)
+        A6TED:__Start(1)
+
+        function A6TED:OnAfterStart(From, Event, To)
+            if AirbossRetribution then
+                env.info("AIRBOSS: DETECTED FOR TANKER")
+                AirbossRetribution:SetRecoveryTanker(A6TED)
+            else
+                env.info("AIRBOSS: NOT DETECTED FOR TANKER")
+            end
+        end
+    end)
+
+    A6:Spawn()
 end
 
 -- SHIP AWACS
@@ -675,7 +810,13 @@ local function AutoSetup()
 
         if airboss_options.enableRescueHelo then AddRescueHelo(cvn.name) end
         if airboss_options.enableAWACS      then AddShipAWACS(cvn.name) end
-        if airboss_options.enableTanker     then AddTrickOrTreat(cvn.name) end
+        if airboss_options.enableTanker then
+            if airboss_options.tankerType == "A6" then
+                AddA6Tanker(cvn.name)
+            else
+                AddTrickOrTreat(cvn.name)
+            end
+        end
 
         -- Match escort by prefix +1
         for _, escort in ipairs(escortCandidates) do

--- a/resources/plugins/airboss/plugin.json
+++ b/resources/plugins/airboss/plugin.json
@@ -14,6 +14,12 @@
             "defaultValue": false
         },
         {
+            "nameInUI": "Recovery Tanker Aircraft",
+            "mnemonic": "tankerType",
+            "possibleValues": ["S3", "A6"],
+            "defaultValue": "S3"
+        },
+        {
             "nameInUI": "Enable Airboss AWACS",
             "mnemonic": "enableAWACS",
             "defaultValue": false

--- a/resources/plugins/airboss/plugin.json
+++ b/resources/plugins/airboss/plugin.json
@@ -16,8 +16,8 @@
         {
             "nameInUI": "Recovery Tanker Aircraft",
             "mnemonic": "tankerType",
-            "possibleValues": ["S3", "A6"],
-            "defaultValue": "S3"
+            "possibleValues": ["S-3", "A-6"],
+            "defaultValue": "S-3"
         },
         {
             "nameInUI": "Enable Airboss AWACS",


### PR DESCRIPTION
Add a plugin-option dropdown to choose between the S-3B and Heatblur A-6E as the Airboss recovery tanker (default S3). Introduces a string/choice plugin-option type (possibleValues) rendered as a combo box, with values injected as quoted Lua strings. Adds the A-6E tanker spawn (buddy-refuel loadout) and wires the CVN dispatch to the selected type.
<img width="617" height="231" alt="image" src="https://github.com/user-attachments/assets/0e029d1d-1948-49ee-94a5-6cd45fbecf85" />
