### PR TITLE
Culling: keep scenery-objective kill tracking in culled regions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 
 
 ## Fixes
+* **[Mission Generation]** Scenery objectives keep their kill-tracking trigger zones (and Skynet command stand-ins) even when performance culling skips the rest of the objective. The map buildings backing a scenery objective exist whether or not the campaign spawns anything, so bombing one in a culled region used to visibly destroy a target whose death was never recorded at debrief.
 * **[Plugins]** Fix the escort leash never running (DCS has no `Group.getByID`; look the group up by name via mist), so escorts are actually held to their engagement range.
 * **[Mission Planning]** Carrier/LHA targets now offer SEAD in the flight-task list and no longer list SEAD Escort twice (their escorts are SAM platforms, so they can be suppressed directly like any other naval group).
 * **[App]** Retribution no longer stays alive in the background after its window is closed: the API server's graceful shutdown is now bounded (uvicorn otherwise waited forever on the long-lived event-stream websocket and the join hung).

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -284,8 +284,14 @@ class GroundObjectGenerator:
         return self.game.iads_considerate_culling(self.ground_object)
 
     def generate(self) -> None:
-        if self.culled:
-            return
+        # Culling skips the objects that cost performance: spawned statics,
+        # vehicles and ships. It must NOT skip the scenery-objective apparatus
+        # below — the map buildings backing a scenery objective exist whether
+        # or not the campaign spawns anything, so a culled trigger zone leaves
+        # a bombable, visibly-collapsing target whose death is never recorded
+        # (the kill silently vanishes at debrief). The zone, its kill-tracking
+        # trigger rule, and the one-static IADS stand-in cost nothing.
+        culled = self.culled
         for group in self.ground_object.groups:
             vehicle_units = []
             ship_units = []
@@ -293,7 +299,7 @@ class GroundObjectGenerator:
             for unit in group.units:
                 if unit.is_static:
                     if isinstance(unit, SceneryUnit):
-                        # Special handling for scenery objects
+                        # Special handling for scenery objects: never culled.
                         self.add_trigger_zone_for_scenery(unit)
                         if (
                             self.game.settings.plugin_option("skynetiads")
@@ -302,7 +308,7 @@ class GroundObjectGenerator:
                         ):
                             # Generate a unit which can be controlled by skynet
                             self.generate_iads_command_unit(unit)
-                    else:
+                    elif not culled:
                         # Create a static group for each static unit
                         self.create_static_group(unit)
                 elif unit.is_vehicle and unit.alive:
@@ -311,6 +317,8 @@ class GroundObjectGenerator:
                 elif unit.is_ship and unit.alive:
                     # All alive Ships
                     ship_units.append(unit)
+            if culled:
+                continue
             if vehicle_units:
                 self.create_vehicle_group(group.group_name, vehicle_units)
             if ship_units:

--- a/tests/test_culling.py
+++ b/tests/test_culling.py
@@ -1,0 +1,58 @@
+"""Culling must not erase scenery-objective kill tracking.
+
+A scenery objective's map buildings exist whether or not the campaign spawns
+anything, so a culled trigger zone leaves a bombable, visibly-collapsing
+target whose death is never recorded — the kill silently vanishes at debrief.
+The apparatus (trigger zone, MapObjectIsDead rule, IADS command stand-in)
+costs nothing, so it generates regardless of culling; culling keeps its
+performance win for real spawnable content.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from game.missiongenerator.tgogenerator import GroundObjectGenerator
+from game.theater.theatergroup import SceneryUnit
+
+
+def _culled_generator(unit: MagicMock) -> GroundObjectGenerator:
+    group = MagicMock()
+    group.units = [unit]
+    ground_object = MagicMock()
+    ground_object.groups = [group]
+    game = MagicMock()
+    game.iads_considerate_culling.return_value = True  # this TGO is culled
+    game.settings.plugin_option.return_value = False
+    return GroundObjectGenerator(
+        ground_object, MagicMock(), game, MagicMock(), MagicMock()
+    )
+
+
+def test_culled_scenery_objective_keeps_kill_tracking() -> None:
+    scenery = MagicMock(spec=SceneryUnit)
+    scenery.is_static = True
+    generator = _culled_generator(scenery)
+
+    with patch.object(
+        GroundObjectGenerator, "add_trigger_zone_for_scenery"
+    ) as add_zone, patch.object(
+        GroundObjectGenerator, "create_static_group"
+    ) as create_static:
+        generator.generate()
+
+    add_zone.assert_called_once_with(scenery)
+    create_static.assert_not_called()
+
+
+def test_culled_tgo_still_skips_spawnable_content() -> None:
+    # The other half of the contract: culling still buys its performance —
+    # a culled TGO's real statics never spawn.
+    static = MagicMock()
+    static.is_static = True
+    generator = _culled_generator(static)
+
+    with patch.object(GroundObjectGenerator, "create_static_group") as create_static:
+        generator.generate()
+
+    create_static.assert_not_called()


### PR DESCRIPTION
Found by code inspection while investigating a field report of kills silently vanishing at debrief in culled regions.

## The bug

A culled TGO skips *everything* in `GroundObjectGenerator.generate`, including `add_trigger_zone_for_scenery` — but the map buildings backing a scenery objective exist whether or not the campaign spawns anything. So a scenery objective in a culled region is a bombable, visibly-collapsing target whose death is **never recorded**: no `MapObjectIsDead` rule exists, the kill never reaches `dead_events`, and the strike vanishes at debrief with no trace. Skynet also loses its command stand-in for culled IADS scenery nodes.

## The fix

The scenery apparatus — trigger zone, kill-tracking trigger rule, one static infantry — costs effectively nothing, so it now generates regardless of culling. A culled TGO's real spawnable statics, vehicles, and ships are still skipped: culling keeps its performance win.

## Tests

`tests/test_culling.py` locks both halves of the contract: culled scenery keeps its kill tracking; culled spawnable statics still never spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
