### PR TITLE
Faster mission generation: use shapely.contains_xy for land/sea point tests

### DIFF
--- a/game/theater/landmap.py
+++ b/game/theater/landmap.py
@@ -53,7 +53,11 @@ def load_landmap(filename: Path) -> Optional[Landmap]:
 
 
 def poly_contains(x: float, y: float, poly: Union[MultiPolygon, Polygon]) -> bool:
-    return poly.contains(geometry.Point(x, y))
+    # shapely.contains_xy skips constructing a Point object (and shapely's per-call
+    # decorator / inspect.signature overhead) — ~5x faster than poly.contains(Point(x, y)).
+    # is_on_land / is_in_sea call this thousands of times during FLOT + ground-object
+    # generation, where it was the top hotspot in a mission-generation profile.
+    return bool(shp.contains_xy(poly, x, y))
 
 
 def to_miz(landmap: Landmap, terrain: Terrain, mission_filename: str) -> None:


### PR DESCRIPTION
## What

`poly_contains` (used by `ConflictTheater.is_on_land` / `is_in_sea`) did `poly.contains(geometry.Point(x, y))`. This switches it to shapely's `shapely.contains_xy(poly, x, y)`.

## Why

Profiling a Take Off (mission generation) with py-spy on a large campaign, the top hotspots were all in this path: `flotgenerator.get_valid_position_for_group` → `is_on_land` / `is_in_sea` → `landmap.poly_contains` → shapely `.contains`. The FLOT step-back loop and ground-object placement call `is_on_land` thousands of times per turn, and each call

- constructs a `shapely.geometry.Point` object, and
- goes through shapely's per-call predicate wrapper, which calls `inspect.signature` (visible as `shapely/decorators.py` frames in the profile).

`shapely.contains_xy` takes the coordinates directly and skips both.

## Result

Benchmarked on a real landmap (~340 polygons / ~15k vertices), 5000 point tests:

- `poly.contains(Point(x, y))`: 0.161 s
- `shapely.contains_xy(poly, x, y)`: 0.031 s → **~5.3x faster**

Identical results (0 discrepancies over 4000 inclusion + exclusion point tests). Mission generation is noticeably faster in-game on large missions. `contains_xy` is available in shapely 2.0+ (this repo already uses shapely 2.x).