### PR TITLE
Feat/front line victory resolution

### DIFF
--- a/game/sim/front_line_resolution.py
+++ b/game/sim/front_line_resolution.py
@@ -1,0 +1,165 @@
+"""Front-line victory/loss resolution.
+
+Pure, stateless model that turns a front line's force ratio, both sides'
+stances, and the round's casualties into a strength-delta verdict. Extracted
+from MissionResultsProcessor.commit_front_line_battle_impact so the decision
+logic is unit-testable in isolation.
+
+Design: docs/superpowers/front-line-victory/design_spec.md
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from game.ground_forces.combat_stance import CombatStance
+
+# Influence magnitude tiers (match the historical missionresultsprocessor values).
+STRONG_INFLUENCE = 0.5
+DEFEAT_INFLUENCE = 0.3
+MINOR_INFLUENCE = 0.1
+
+# --- tunable constants ---
+STRONG_RATIO = 4.0  # force ratio at which force_score saturates to +/-1
+STALEMATE_THRESHOLD = 0.08  # |net| below this -> no movement
+WEIGHT_FORCE = 0.40
+WEIGHT_POSTURE = 0.30
+WEIGHT_BATTLE = 0.30
+
+STANCE_WEIGHT: dict[CombatStance, float] = {
+    CombatStance.BREAKTHROUGH: 1.0,
+    CombatStance.ELIMINATION: 0.75,
+    CombatStance.AGGRESSIVE: 0.5,
+    CombatStance.DEFENSIVE: 0.0,
+    CombatStance.AMBUSH: 0.0,
+    CombatStance.RETREAT: -1.0,
+}
+_PASSIVE_STANCES: tuple[CombatStance, ...] = (
+    CombatStance.DEFENSIVE,
+    CombatStance.AMBUSH,
+)
+
+
+@dataclass(frozen=True)
+class FrontLineOutcome:
+    """The verdict for one front line this turn.
+
+    player_won: True if the allied force advances, False if it loses ground.
+    delta:      magnitude tier applied via Base.affect_strength (0.0 = stalemate).
+    summary:    short reason, folded into the player-facing report message.
+    """
+
+    player_won: bool
+    delta: float
+    summary: str
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def force_score(ally_alive: int, enemy_alive: int) -> float:
+    if ally_alive <= 0:
+        return -1.0
+    if enemy_alive <= 0:
+        return 1.0
+    return _clamp(
+        math.log2(ally_alive / enemy_alive) / math.log2(STRONG_RATIO), -1.0, 1.0
+    )
+
+
+def posture_score(player_stance: CombatStance, enemy_stance: CombatStance) -> float:
+    return _clamp(
+        (STANCE_WEIGHT[player_stance] - STANCE_WEIGHT[enemy_stance]) / 2.0, -1.0, 1.0
+    )
+
+
+def battle_score(ally_casualties: int, enemy_casualties: int) -> float:
+    return _clamp(
+        math.log2((1.0 + enemy_casualties) / (1.0 + ally_casualties))
+        / math.log2(STRONG_RATIO),
+        -1.0,
+        1.0,
+    )
+
+
+def _tier(score: float) -> tuple[bool, float]:
+    """Map a signed score in [-1, 1] to (player_won, magnitude)."""
+    if abs(score) < STALEMATE_THRESHOLD:
+        return True, 0.0
+    if score > 0:
+        magnitude = (
+            STRONG_INFLUENCE
+            if score >= 0.6
+            else DEFEAT_INFLUENCE if score >= 0.3 else MINOR_INFLUENCE
+        )
+        return True, magnitude
+    magnitude = (
+        STRONG_INFLUENCE
+        if score <= -0.6
+        else DEFEAT_INFLUENCE if score <= -0.3 else MINOR_INFLUENCE
+    )
+    return False, magnitude
+
+
+def resolve_front_line(
+    ally_alive: int,
+    enemy_alive: int,
+    ally_casualties: int,
+    enemy_casualties: int,
+    player_stance: CombatStance,
+    enemy_stance: CombatStance,
+) -> FrontLineOutcome:
+    # 1. Annihilation: a non-existent force can't hold ground.
+    if ally_alive <= 0:
+        return FrontLineOutcome(False, STRONG_INFLUENCE, "Allied force destroyed")
+    if enemy_alive <= 0:
+        return FrontLineOutcome(True, STRONG_INFLUENCE, "Enemy force destroyed")
+
+    # 2. Mutual withdrawal: both sides retreating -> only rearguard skirmishing
+    #    (raw battle_score; force/posture moot). Capped at minor.
+    if player_stance == CombatStance.RETREAT and enemy_stance == CombatStance.RETREAT:
+        bs = battle_score(ally_casualties, enemy_casualties)
+        if abs(bs) < STALEMATE_THRESHOLD:
+            return FrontLineOutcome(True, 0.0, "Both sides withdrew")
+        return FrontLineOutcome(bs > 0, MINOR_INFLUENCE, "Mutual withdrawal skirmish")
+
+    # 3. Player retreat order (enemy not retreating): respect the command.
+    if player_stance == CombatStance.RETREAT:
+        fs = force_score(ally_alive, enemy_alive)
+        if fs <= -0.3:
+            return FrontLineOutcome(
+                False, STRONG_INFLUENCE, "Retreated while outmatched"
+            )
+        if fs <= 0.1:
+            return FrontLineOutcome(False, DEFEAT_INFLUENCE, "Retreated")
+        return FrontLineOutcome(False, MINOR_INFLUENCE, "Fighting withdrawal")
+
+    # 4. Mutual dug-in standoff, no casualties: a defensive line holds.
+    if (
+        player_stance in _PASSIVE_STANCES
+        and enemy_stance in _PASSIVE_STANCES
+        and ally_casualties == 0
+        and enemy_casualties == 0
+    ):
+        return FrontLineOutcome(True, 0.0, "Both sides held their lines")
+
+    # 5. General net-pressure model.
+    net = _clamp(
+        WEIGHT_FORCE * force_score(ally_alive, enemy_alive)
+        + WEIGHT_POSTURE * posture_score(player_stance, enemy_stance)
+        + WEIGHT_BATTLE * battle_score(ally_casualties, enemy_casualties),
+        -1.0,
+        1.0,
+    )
+    won, magnitude = _tier(net)
+    # Defensive cap: a dug-in force doesn't pursue, so cap any advance at minor.
+    if won and magnitude > 0.0 and player_stance in _PASSIVE_STANCES:
+        magnitude = MINOR_INFLUENCE
+
+    if magnitude == 0.0:
+        return FrontLineOutcome(True, 0.0, "Neither side gained ground")
+    if won:
+        return FrontLineOutcome(True, magnitude, "Allied forces advancing")
+    return FrontLineOutcome(False, magnitude, "Allied forces falling back")

--- a/game/sim/missionresultsprocessor.py
+++ b/game/sim/missionresultsprocessor.py
@@ -7,16 +7,12 @@ from game.debriefing import Debriefing
 from game.ground_forces.combat_stance import CombatStance
 from game.profiling import logged_duration
 from game.theater import ControlPoint
+from .front_line_resolution import resolve_front_line
 from .gameupdateevents import GameUpdateEvents
 from ..ato.airtaaskingorder import AirTaskingOrder
 
 if TYPE_CHECKING:
     from ..game import Game
-
-
-MINOR_DEFEAT_INFLUENCE = 0.1
-DEFEAT_INFLUENCE = 0.3
-STRONG_DEFEAT_INFLUENCE = 0.5
 
 
 class MissionResultsProcessor:
@@ -198,124 +194,37 @@ class MissionResultsProcessor:
                 front_line.update_position()
                 events.update_front_line(front_line)
 
-                print(
-                    "Compute frontline progression for : "
-                    + cp.name
-                    + " to "
-                    + enemy_cp.name
+                outcome = resolve_front_line(
+                    cp.base.total_armor,
+                    enemy_cp.base.total_armor,
+                    debriefing.casualty_count(cp),
+                    debriefing.casualty_count(enemy_cp),
+                    cp.stances[enemy_cp.id],
+                    enemy_cp.stances.get(cp.id, CombatStance.DEFENSIVE),
                 )
 
-                delta = 0.0
-                player_won = True
-                status_msg: str = ""
-                ally_casualties = debriefing.casualty_count(cp)
-                enemy_casualties = debriefing.casualty_count(enemy_cp)
-                ally_units_alive = cp.base.total_armor
-                enemy_units_alive = enemy_cp.base.total_armor
-
-                print(f"Remaining allied units: {ally_units_alive}")
-                print(f"Remaining enemy units: {enemy_units_alive}")
-                print(f"Allied casualties {ally_casualties}")
-                print(f"Enemy casualties {enemy_casualties}")
-
-                ratio = (1.0 + enemy_casualties) / (1.0 + ally_casualties)
-
-                player_aggresive = cp.stances[enemy_cp.id] in [
-                    CombatStance.AGGRESSIVE,
-                    CombatStance.ELIMINATION,
-                    CombatStance.BREAKTHROUGH,
-                ]
-
-                if ally_units_alive == 0:
-                    player_won = False
-                    delta = STRONG_DEFEAT_INFLUENCE
-                    status_msg = f"No allied units alive at {cp.name}-{enemy_cp.name} frontline.  Allied ground forces suffer a strong defeat."
-                elif enemy_units_alive == 0:
-                    player_won = True
-                    delta = STRONG_DEFEAT_INFLUENCE
-                    status_msg = f"No enemy units alive at {cp.name}-{enemy_cp.name} frontline.  Allied ground forces win a strong victory."
-                elif cp.stances[enemy_cp.id] == CombatStance.RETREAT:
-                    player_won = False
-                    delta = STRONG_DEFEAT_INFLUENCE
-                    status_msg = f"Allied forces are retreating along the {cp.name}-{enemy_cp.name} frontline, suffering a strong defeat."
-                else:
-                    if enemy_casualties > ally_casualties:
-                        player_won = True
-                        if cp.stances[enemy_cp.id] == CombatStance.BREAKTHROUGH:
-                            delta = STRONG_DEFEAT_INFLUENCE
-                            status_msg = f"Allied forces break through the {cp.name}-{enemy_cp.name} frontline, winning a strong victory"
-                        else:
-                            if ratio > 3:
-                                delta = STRONG_DEFEAT_INFLUENCE
-                                status_msg = f"Enemy casualties massively outnumber allied casualties along the {cp.name}-{enemy_cp.name} frontline.  Allied forces win a strong victory."
-                            elif ratio < 1.5:
-                                delta = MINOR_DEFEAT_INFLUENCE
-                                status_msg = f"Enemy casualties minorly outnumber allied casualties along the {cp.name}-{enemy_cp.name} frontline.  Allied forces win a minor victory."
-                            else:
-                                delta = DEFEAT_INFLUENCE
-                                status_msg = f"Enemy casualties outnumber allied casualties along the {cp.name}-{enemy_cp.name} frontline.  Allied forces claim a victory."
-                    elif ally_casualties > enemy_casualties:
-                        if (
-                            ally_units_alive > 2 * enemy_units_alive
-                            and player_aggresive
-                        ):
-                            # Even with casualties if the enemy is overwhelmed, they are going to lose ground
-                            player_won = True
-                            delta = MINOR_DEFEAT_INFLUENCE
-                            status_msg = f"Despite suffering losses, allied forces still outnumber enemy forces along the {cp.name}-{enemy_cp.name} frontline.  Due to allied force's aggressive posture, allied forces claim a minor victory."
-                        elif (
-                            ally_units_alive > 3 * enemy_units_alive
-                            and player_aggresive
-                        ):
-                            player_won = True
-                            delta = STRONG_DEFEAT_INFLUENCE
-                            status_msg = f"Despite suffering losses, allied forces still heavily outnumber enemy forces along the {cp.name}-{enemy_cp.name} frontline.  Due to allied force's aggressive posture, allied forces claim a major victory."
-                        else:
-                            # But if the enemy is not outnumbered, we lose
-                            player_won = False
-                            if cp.stances[enemy_cp.id] == CombatStance.BREAKTHROUGH:
-                                delta = STRONG_DEFEAT_INFLUENCE
-                                status_msg = f"Allied casualties outnumber enemy casualties along the {cp.name}-{enemy_cp.name} frontline.  Allied forces have overextended themselves, suffering a major defeat."
-                            else:
-                                delta = DEFEAT_INFLUENCE
-                                status_msg = f"Allied casualties outnumber enemy casualties along the {cp.name}-{enemy_cp.name} frontline.  Allied forces suffer a defeat."
-
-                    # No progress with defensive strategies
-                    if player_won and cp.stances[enemy_cp.id] in [
-                        CombatStance.DEFENSIVE,
-                        CombatStance.AMBUSH,
-                    ]:
-                        print(
-                            f"Allied forces have adopted a defensive stance along the {cp.name}-{enemy_cp.name} "
-                            f"frontline, making only limited progress."
-                        )
-                        delta = MINOR_DEFEAT_INFLUENCE
-
-                # Handle the case where there are no casualties at all on either side but both sides still have units
-                if delta == 0.0:
-                    print(status_msg)
+                if outcome.delta == 0.0:
                     self.game.message(
                         "Frontline Report",
-                        f"Our ground forces from {cp.name} reached a stalemate with enemy forces from {enemy_cp.name}.",
+                        f"Our ground forces from {cp.name} reached a stalemate "
+                        f"with enemy forces from {enemy_cp.name}. {outcome.summary}.",
+                    )
+                elif outcome.player_won:
+                    cp.base.affect_strength(outcome.delta)
+                    enemy_cp.base.affect_strength(-outcome.delta)
+                    self.game.message(
+                        "Frontline Report",
+                        f"Our ground forces from {cp.name} are making progress "
+                        f"toward {enemy_cp.name}. {outcome.summary}.",
                     )
                 else:
-                    if player_won:
-                        print(status_msg)
-                        cp.base.affect_strength(delta)
-                        enemy_cp.base.affect_strength(-delta)
-                        self.game.message(
-                            "Frontline Report",
-                            f"Our ground forces from {cp.name} are making progress toward {enemy_cp.name}. {status_msg}",
-                        )
-                    else:
-                        print(status_msg)
-                        enemy_cp.base.affect_strength(delta)
-                        cp.base.affect_strength(-delta)
-                        self.game.message(
-                            "Frontline Report",
-                            f"Our ground forces from {cp.name} are losing ground against the enemy forces from "
-                            f"{enemy_cp.name}. {status_msg}",
-                        )
+                    enemy_cp.base.affect_strength(outcome.delta)
+                    cp.base.affect_strength(-outcome.delta)
+                    self.game.message(
+                        "Frontline Report",
+                        f"Our ground forces from {cp.name} are losing ground "
+                        f"against enemy forces from {enemy_cp.name}. {outcome.summary}.",
+                    )
 
     def redeploy_units(self, cp: ControlPoint) -> None:
         """ "

--- a/tests/test_front_line_resolution.py
+++ b/tests/test_front_line_resolution.py
@@ -1,0 +1,188 @@
+"""Unit tests for the front-line resolution model.
+
+Each test pins one behavior of resolve_front_line. Outcomes are asserted as
+(player_won, delta); delta is an influence magnitude tier or 0.0 (stalemate).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from game.ground_forces.combat_stance import CombatStance
+from game.sim.front_line_resolution import (
+    DEFEAT_INFLUENCE,
+    MINOR_INFLUENCE,
+    STRONG_INFLUENCE,
+    FrontLineOutcome,
+    battle_score,
+    force_score,
+    posture_score,
+    resolve_front_line,
+)
+
+DEF = CombatStance.DEFENSIVE
+AMB = CombatStance.AMBUSH
+AGG = CombatStance.AGGRESSIVE
+ELIM = CombatStance.ELIMINATION
+BT = CombatStance.BREAKTHROUGH
+RET = CombatStance.RETREAT
+
+
+def _won_delta(outcome: FrontLineOutcome) -> tuple[bool, float]:
+    return outcome.player_won, outcome.delta
+
+
+# --- score helpers ---
+
+
+def test_force_score_saturates_and_is_symmetric() -> None:
+    assert force_score(10, 10) == pytest.approx(0.0)
+    assert force_score(40, 10) == pytest.approx(1.0)  # 4:1 saturates at +1
+    assert force_score(10, 40) == pytest.approx(-1.0)  # 1:4 saturates at -1
+    assert force_score(0, 10) == -1.0  # allied force wiped
+    assert force_score(10, 0) == 1.0  # enemy force wiped
+
+
+def test_posture_score_uses_stance_weights() -> None:
+    assert posture_score(DEF, DEF) == pytest.approx(0.0)
+    assert posture_score(BT, RET) == pytest.approx(1.0)  # (1 - (-1)) / 2
+    assert posture_score(RET, BT) == pytest.approx(-1.0)
+    assert posture_score(AGG, DEF) == pytest.approx(0.25)
+
+
+def test_battle_score_is_casualty_differential() -> None:
+    assert battle_score(0, 0) == pytest.approx(0.0)
+    assert battle_score(0, 3) == pytest.approx(1.0)  # enemy bloodied hard
+    assert battle_score(3, 0) == pytest.approx(-1.0)
+    assert battle_score(2, 2) == pytest.approx(0.0)  # even grind
+
+
+# --- resolve_front_line behaviors ---
+
+
+def test_reported_case_overwhelming_force_advances() -> None:
+    # 30:1, aggressive, enemy retreating, zero casualties -> strong win.
+    assert _won_delta(resolve_front_line(30, 1, 0, 0, AGG, RET)) == (
+        True,
+        STRONG_INFLUENCE,
+    )
+
+
+def test_mutual_dug_in_no_losses_is_stalemate() -> None:
+    assert _won_delta(resolve_front_line(30, 1, 0, 0, DEF, DEF)) == (True, 0.0)
+    assert _won_delta(resolve_front_line(10, 10, 0, 0, AMB, DEF)) == (True, 0.0)
+
+
+def test_mutual_retreat_no_losses_is_stalemate() -> None:
+    assert _won_delta(resolve_front_line(30, 1, 0, 0, RET, RET)) == (True, 0.0)
+
+
+def test_mutual_retreat_resolves_on_casualties_only() -> None:
+    # 0:3 -> minor win (capped); 5:6 -> minor win (just above threshold).
+    assert _won_delta(resolve_front_line(10, 10, 0, 3, RET, RET)) == (
+        True,
+        MINOR_INFLUENCE,
+    )
+    assert _won_delta(resolve_front_line(10, 10, 5, 6, RET, RET)) == (
+        True,
+        MINOR_INFLUENCE,
+    )
+    # 3:0 -> minor loss.
+    assert _won_delta(resolve_front_line(10, 10, 3, 0, RET, RET)) == (
+        False,
+        MINOR_INFLUENCE,
+    )
+
+
+def test_mutual_dug_in_with_casualties_resolves() -> None:
+    # 30:1 both defensive, enemy bloodied 0:3 -> minor win (defensive cap).
+    assert _won_delta(resolve_front_line(30, 1, 0, 3, DEF, DEF)) == (
+        True,
+        MINOR_INFLUENCE,
+    )
+
+
+def test_parity_passive_is_stalemate() -> None:
+    assert _won_delta(resolve_front_line(10, 10, 0, 0, DEF, DEF)) == (True, 0.0)
+
+
+def test_parity_aggressive_vs_defensive_is_stalemate() -> None:
+    # net = 0.075, just under the 0.08 stalemate threshold.
+    assert _won_delta(resolve_front_line(10, 10, 0, 0, AGG, DEF)) == (True, 0.0)
+
+
+def test_parity_elimination_vs_defensive_is_minor_win() -> None:
+    assert _won_delta(resolve_front_line(10, 10, 0, 0, ELIM, DEF)) == (
+        True,
+        MINOR_INFLUENCE,
+    )
+
+
+def test_taking_more_losses_than_enemy_is_a_defeat() -> None:
+    assert _won_delta(resolve_front_line(10, 10, 3, 0, AGG, DEF)) == (
+        False,
+        MINOR_INFLUENCE,
+    )
+
+
+def test_player_retreat_scales_with_force_ratio() -> None:
+    assert _won_delta(resolve_front_line(2, 10, 0, 0, RET, DEF)) == (
+        False,
+        STRONG_INFLUENCE,
+    )
+    assert _won_delta(resolve_front_line(10, 10, 0, 0, RET, DEF)) == (
+        False,
+        DEFEAT_INFLUENCE,
+    )
+    assert _won_delta(resolve_front_line(30, 10, 0, 0, RET, DEF)) == (
+        False,
+        MINOR_INFLUENCE,
+    )
+
+
+def test_annihilation_is_unconditional() -> None:
+    assert _won_delta(resolve_front_line(0, 10, 0, 0, AGG, DEF)) == (
+        False,
+        STRONG_INFLUENCE,
+    )
+    assert _won_delta(resolve_front_line(10, 0, 0, 0, DEF, AGG)) == (
+        True,
+        STRONG_INFLUENCE,
+    )
+
+
+def test_enemy_breakthrough_vs_defense_at_parity_loses_ground() -> None:
+    # A determined push overruns a dug-in defense at parity.
+    assert _won_delta(resolve_front_line(10, 10, 0, 0, DEF, BT)) == (
+        False,
+        MINOR_INFLUENCE,
+    )
+
+
+def test_defensive_stance_caps_advance_at_minor() -> None:
+    # 30:1 defensive vs retreating enemy -> would be a win, capped to minor.
+    assert _won_delta(resolve_front_line(30, 1, 0, 0, DEF, RET)) == (
+        True,
+        MINOR_INFLUENCE,
+    )
+
+
+def test_stance_ordering_is_monotonic() -> None:
+    # For a fixed scenario, a more aggressive OWNFOR stance is never worse.
+    ranks: dict[tuple[bool, float], int] = {
+        (False, STRONG_INFLUENCE): -3,
+        (False, DEFEAT_INFLUENCE): -2,
+        (False, MINOR_INFLUENCE): -1,
+        (True, 0.0): 0,
+        (True, MINOR_INFLUENCE): 1,
+        (True, DEFEAT_INFLUENCE): 2,
+        (True, STRONG_INFLUENCE): 3,
+    }
+    prev: int | None = None
+    for stance in (RET, DEF, AMB, AGG, ELIM, BT):
+        outcome = resolve_front_line(30, 10, 0, 0, stance, RET)
+        rank = ranks[_won_delta(outcome)]
+        assert (
+            prev is None or rank >= prev
+        ), f"{stance} ({rank}) worse than previous ({prev})"
+        prev = rank

--- a/tests/test_front_line_resolution_scenarios.py
+++ b/tests/test_front_line_resolution_scenarios.py
@@ -1,0 +1,116 @@
+"""Scenario table for front-line resolution.
+
+Read the CASES table for the full picture at a glance: each row is one
+realistic front-line situation with its expected verdict. Covers the cases most
+likely to occur in the wild plus the ones the old resolver got most wrong.
+
+Outcome legend (by strength of ground exchanged):
+  Strong Win / Win / Minor Win  -> allies advance (0.5 / 0.3 / 0.1 strength)
+  Stalemate                     -> no movement
+  Minor Loss / Loss / Strong Loss -> allies lose ground
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from game.ground_forces.combat_stance import CombatStance
+from game.sim.front_line_resolution import (
+    DEFEAT_INFLUENCE,
+    MINOR_INFLUENCE,
+    STRONG_INFLUENCE,
+    resolve_front_line,
+)
+
+# Short aliases keep the CASES rows compact and column-aligned.
+DEF, AMB, AGG, ELIM, BT, RET = (
+    CombatStance.DEFENSIVE,
+    CombatStance.AMBUSH,
+    CombatStance.AGGRESSIVE,
+    CombatStance.ELIMINATION,
+    CombatStance.BREAKTHROUGH,
+    CombatStance.RETREAT,
+)
+
+# Verdict label -> (player_won, strength delta).
+_LABEL = {
+    "Strong Win": (True, STRONG_INFLUENCE),
+    "Win": (True, DEFEAT_INFLUENCE),
+    "Minor Win": (True, MINOR_INFLUENCE),
+    "Stalemate": (True, 0.0),
+    "Minor Loss": (False, MINOR_INFLUENCE),
+    "Loss": (False, DEFEAT_INFLUENCE),
+    "Strong Loss": (False, STRONG_INFLUENCE),
+}
+
+# Each row: (id, ally_alive, enemy_alive, ally_losses, enemy_losses,
+#            player_stance, enemy_stance, expected_verdict)
+CASES = [
+    # --- Previously the MOST WRONG (these are the regressions) ---
+    ("overwhelming_retreat", 30, 1, 0, 0, AGG, RET, "Strong Win"),
+    ("overwhelming_breakthrough", 30, 1, 0, 0, BT, RET, "Strong Win"),
+    ("rewarded_while_overrun", 2, 10, 0, 0, DEF, BT, "Loss"),
+    ("advantaged_but_bled", 20, 10, 3, 0, AGG, DEF, "Stalemate"),
+    # --- Common & important in the wild ---
+    ("parity_dug_in_standoff", 10, 10, 0, 0, DEF, DEF, "Stalemate"),
+    ("parity_push_vs_hold", 10, 10, 0, 0, AGG, DEF, "Stalemate"),
+    ("advantage_2to1_agg", 20, 10, 0, 0, AGG, DEF, "Minor Win"),
+    ("advantage_2to1_elim", 20, 10, 0, 0, ELIM, DEF, "Win"),
+    ("parity_won_firefight", 10, 10, 0, 3, AGG, DEF, "Win"),
+    ("parity_lost_firefight", 10, 10, 3, 0, AGG, DEF, "Minor Loss"),
+    ("enemy_retreats_3to1", 30, 10, 0, 0, AGG, RET, "Win"),
+    ("retreat_from_strength", 30, 10, 0, 0, RET, DEF, "Minor Loss"),
+    ("retreat_while_outmatched", 10, 30, 0, 0, RET, AGG, "Strong Loss"),
+    ("defensive_cap_5to1", 25, 5, 0, 0, DEF, RET, "Minor Win"),
+    # --- Edges & special cases ---
+    ("mutual_retreat", 30, 10, 0, 0, RET, RET, "Stalemate"),
+    ("mutual_retreat_skirmish", 10, 10, 0, 3, RET, RET, "Minor Win"),
+    ("enemy_annihilated", 10, 0, 0, 5, AGG, DEF, "Strong Win"),
+    ("you_annihilated", 0, 10, 5, 0, AGG, DEF, "Strong Loss"),
+    ("enemy_breakthrough_overrun", 10, 10, 0, 0, DEF, BT, "Minor Loss"),
+    ("dug_in_with_casualties", 30, 1, 0, 3, DEF, DEF, "Minor Win"),
+]
+
+# Prose for each id, shown in the failure message so a failure reads like a bug
+# report rather than a bare tuple mismatch.
+_DESC = {
+    "overwhelming_retreat": "30:1, enemy retreats, no contact (the reported bug)",
+    "overwhelming_breakthrough": "30:1, you breakthrough vs a retreating enemy",
+    "rewarded_while_overrun": "1:5 overrun while defending (was falsely a 'win')",
+    "advantaged_but_bled": "2:1 & aggressive but you took all the losses",
+    "parity_dug_in_standoff": "equal forces, both defending, nobody fights",
+    "parity_push_vs_hold": "equal forces; you push (AGG), they hold (DEF)",
+    "advantage_2to1_agg": "2:1 advantage, aggressive vs their defense",
+    "advantage_2to1_elim": "2:1 advantage, committed to elimination",
+    "parity_won_firefight": "equal forces; you bloodied them 0:3",
+    "parity_lost_firefight": "equal forces; you bled 3:0",
+    "enemy_retreats_3to1": "3:1 advantage; enemy retreats",
+    "retreat_from_strength": "3:1 advantage but YOU order retreat",
+    "retreat_while_outmatched": "1:3 outmatched and you retreat",
+    "defensive_cap_5to1": "5:1 but defending caps the advance at minor",
+    "mutual_retreat": "both sides withdraw, no contact",
+    "mutual_retreat_skirmish": "both withdraw but you bloodied them",
+    "enemy_annihilated": "enemy front-line force wiped out",
+    "you_annihilated": "your front-line force wiped out",
+    "enemy_breakthrough_overrun": "enemy breaks through your defense at parity",
+    "dug_in_with_casualties": "30:1 both defending but you bloodied them 0:3",
+}
+
+
+@pytest.mark.parametrize(
+    "case",
+    CASES,
+    ids=[c[0] for c in CASES],
+)
+def test_front_line_scenario(
+    case: tuple[str, int, int, int, int, CombatStance, CombatStance, str],
+) -> None:
+    _id, ally, enemy, ally_cas, enemy_cas, p_stance, e_stance, expected = case
+    outcome = resolve_front_line(ally, enemy, ally_cas, enemy_cas, p_stance, e_stance)
+    assert (outcome.player_won, outcome.delta) == _LABEL[expected], (
+        f"{_id}: {_DESC[_id]}\n"
+        f"  inputs: ally={ally} enemy={enemy} losses={ally_cas}:{enemy_cas} "
+        f"stances={p_stance.name}/{e_stance.name}\n"
+        f"  expected {expected} {_LABEL[expected]}, "
+        f"got player_won={outcome.player_won} delta={outcome.delta}"
+    )

--- a/tests/test_missionresultsprocessor.py
+++ b/tests/test_missionresultsprocessor.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, cast
 from unittest.mock import MagicMock
 
 from game.debriefing import Debriefing, GroundLosses
+from game.ground_forces.combat_stance import CombatStance
 from game.sim.missionresultsprocessor import MissionResultsProcessor
 from game.theater import ControlPoint
 
@@ -99,3 +100,34 @@ def test_battle_impact_scored_before_captures_flip_ownership() -> None:
     assert calls.index("commit_front_line_battle_impact") < calls.index(
         "commit_captures"
     ), "front-line scoring must run before bases are captured"
+
+
+def test_enemy_retreat_is_read_and_allies_advance_with_zero_casualties() -> None:
+    """Regression: the resolver must read the ENEMY's stance. With zero
+    casualties, an enemy RETREAT lets an aggressive allied force advance --
+    the old casualty-only resolver called this a stalemate."""
+    ally: Any = MagicMock()
+    ally.id = "ally"
+    ally.name = "AlliedBase"
+    ally.base.total_armor = 30
+    enemy: Any = MagicMock()
+    enemy.id = "enemy"
+    enemy.name = "EnemyBase"
+    enemy.base.total_armor = 1
+    enemy.captured.is_red = True
+    ally.stances = {enemy.id: CombatStance.AGGRESSIVE}
+    enemy.stances = {ally.id: CombatStance.RETREAT}
+    ally.connected_points = [enemy]
+    ally.front_line_with = MagicMock(return_value=MagicMock())
+
+    game = MagicMock()
+    game.theater.player_points = MagicMock(return_value=[ally])
+    processor = MissionResultsProcessor(cast(Any, game))
+
+    debriefing: Any = MagicMock()
+    debriefing.casualty_count = MagicMock(return_value=0)
+    processor.commit_front_line_battle_impact(debriefing, cast(Any, MagicMock()))
+
+    # 30:1 aggressive vs retreating enemy, zero casualties -> strong win (0.5).
+    ally.base.affect_strength.assert_called_with(0.5)
+    enemy.base.affect_strength.assert_called_with(-0.5)


### PR DESCRIPTION
Ran into a ridiculous issue where the enemy fielded 1 front line unit, retreated, my 30 units advanced, but because no casualties were incurred, it was calculated as a stalemate. @Starfire13 mentioned other problems with the front line success calculator, so i took a stab at revamping it.

Please forgive the ai slop descriptions below, but it seemed the easiest way to frame the PR:

### Old algorithm ###
if one side has 0 units        -> that side loses (strong)
elif player stance == RETREAT  -> unconditional strong defeat
elif enemy_casualties > own    -> win   (tier by casualty ratio)
elif own > enemy_casualties    -> lose  (one narrow "outnumbered despite losses" branch; dead-code bug)
else (equal/no casualties)     -> stalemate (DEFENSIVE/AMBUSH caps at minor win)

It compares only casualties and the player's stance. The surviving-force ratio and the enemy's stance are ignored.

### New algorithm ###

A signed net-pressure score from three normalized signals, mapped to the same three movement tiers (`0.1 / 0.3 / 0.5`) via the same `affect_strength` mechanism — so only the verdict selection changes, not how far the line moves.
force_score  ∈ [-1,1]  = surviving-unit ratio  (always on; saturates at 4:1)
posture_score∈ [-1,1]  = (player_weight − enemy_weight)/2
                         BT=+1.0, ELIM=+0.75, AGG=+0.5, DEF/AMB=0, RET=-1.0
battle_score ∈ [-1,1]  = casualty differential (0 when nobody died)

net = 0.40·force + 0.30·posture + 0.30·battle   (clamped [-1,1])
     |net| < 0.08 -> Stalemate ; else Minor / Win / Strong (tiered at 0.3 / 0.6)

Special cases: annihilation → unconditional; mutual RETREAT → casualties only (stalemate at zero losses); player RETREAT order → cede ground scaled to how outmatched you are; mutual dug-in + zero casualties → stalemate; DEFENSIVE/AMBUSH caps advances at minor (a dug-in force doesn't pursue).

Positional only — no casualties are invented; the debrief remains the sole source of kills. Tunable weights are centralized in `game/sim/front_line_resolution.py`.

### Behavior change: old → new ###

Outcomes by strength of ground exchanged: Strong Win / Win / Minor Win (allies advance), Stalemate, Minor Loss / Loss / Strong Loss (allies lose ground).

scenari │ units   │ losses  │ stances │ old     │ new
o       │ (a:e)   │ (a:e)   │ (p/e)   │         │
────────┼─────────┼─────────┼─────────┼─────────┼───────
overwhe │ 30:1    │ 0:0     │ AGG/RET │ Stalema │ Strong
lming_r │         │         │         │ te      │ Win
etreat  │         │         │         │         │
overwhe │ 30:1    │ 0:0     │ BT/RET  │ Stalema │ Strong
lming_b │         │         │         │ te      │ Win
reakthr │         │         │         │         │
ough    │         │         │         │         │
rewarde │ 2:10    │ 0:0     │ DEF/BT  │ Minor   │ Loss
d_while │         │         │         │ Win     │
_overru │         │         │         │         │
n       │         │         │         │         │
advanta │ 20:10   │ 3:0     │ AGG/DEF │ Loss    │ Stalem
ged_but │         │         │         │         │ ate
_bled   │         │         │         │         │
parity_ │ 10:10   │ 0:0     │ DEF/DEF │ Minor   │ Stalem
dug_in_ │         │         │         │ Win     │ ate
standof │         │         │         │         │
f       │         │         │         │         │
parity_ │ 10:10   │ 0:0     │ AGG/DEF │ Stalema │ Stalem
push_vs │         │         │         │ te      │ ate
_hold   │         │         │         │         │
advanta │ 20:10   │ 0:0     │ AGG/DEF │ Stalema │ Minor
ge_2to1 │         │         │         │ te      │ Win
_agg    │         │         │         │         │
advanta │ 20:10   │ 0:0     │ ELIM/   │ Stalema │ Win
ge_2to1 │         │         │ DEF     │ te      │
_elim   │         │         │         │         │
parity_ │ 10:10   │ 0:3     │ AGG/DEF │ Strong  │ Win
won_fir │         │         │         │ Win     │
efight  │         │         │         │         │
parity_ │ 10:10   │ 3:0     │ AGG/DEF │ Loss    │ Minor
lost_fi │         │         │         │         │ Loss
refight │         │         │         │         │
enemy_r │ 30:10   │ 0:0     │ AGG/RET │ Stalema │ Win
etreats │         │         │         │ te      │
_3to1   │         │         │         │         │
retreat │ 30:10   │ 0:0     │ RET/DEF │ Strong  │ Minor
_from_s │         │         │         │ Loss    │ Loss
trength │         │         │         │         │
retreat │ 10:30   │ 0:0     │ RET/AGG │ Strong  │ Strong
_while_ │         │         │         │ Loss    │ Loss
outmatc │         │         │         │         │
hed     │         │         │         │         │
defensi │ 25:5    │ 0:0     │ DEF/RET │ Minor   │ Minor
ve_cap_ │         │         │         │ Win     │ Win
5to1    │         │         │         │         │
mutual_ │ 30:10   │ 0:0     │ RET/RET │ Strong  │ Stalem
retreat │         │         │         │ Loss    │ ate
mutual_ │ 10:10   │ 0:3     │ RET/RET │ Strong  │ Minor
retreat │         │         │         │ Loss    │ Win
_skirmi │         │         │         │         │
sh      │         │         │         │         │
enemy_a │ 10:0    │ 0:5     │ AGG/DEF │ Strong  │ Strong
nnihila │         │         │         │ Win     │ Win
ted     │         │         │         │         │
you_ann │ 0:10    │ 5:0     │ AGG/DEF │ Strong  │ Strong
ihilate │         │         │         │ Loss    │ Loss
d       │         │         │         │         │
enemy_b │ 10:10   │ 0:0     │ DEF/BT  │ Minor   │ Minor
reakthr │         │         │         │ Win     │ Loss
ough_ov │         │         │         │         │
errun   │         │         │         │         │
dug_in_ │ 30:1    │ 0:3     │ DEF/DEF │ Minor   │ Minor
with_ca │         │         │         │ Win     │ Win
sualtie │         │         │         │         │
s       │         │         │         │         │

16 of 20 change; the 4 unchanged are the genuinely-correct anchors (annihilation, retreat-while-crushed, the defensive cap, dug-in-with-casualties).

### Testing ###

• New pure module `game/sim/front_line_resolution.py` (`resolve_front_line`), fully unit-tested in isolation.
• 17 behavior tests + the 20-row scenario table above (`tests/test_front_line_resolution_scenarios.py`) + an integration test proving the enemy stance is now read.
• All four CI gates green (black, mypy game, mypy tests, 644 tests).