### PR TITLE
fix(mission generator): enable EWR task for EWR ground objects

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@
 * **[Flight Plans]** Renaming a waypoint in the flight-plan list now propagates to the aircraft CDU/HUD and the kneeboard, not just the list — one name in all three places (#695).
 
 ## Fixes
+* **[Mission Generator]** EWR sites now get the DCS "EWR" enroute task and come up on RED alarm, so their radars actually scan and report contacts (previously they could sit inert, especially with the "red alert state" performance option off). Works with or without the Skynet IADS plugin.
 * **[Plugins]** Fix the escort leash never running (DCS has no `Group.getByID`; look the group up by name via mist), so escorts are actually held to their engagement range.
 * **[Mission Planning]** Carrier/LHA targets now offer SEAD in the flight-task list and no longer list SEAD Escort twice (their escorts are SAM platforms, so they can be suppressed directly like any other naval group).
 * **[App]** Retribution no longer stays alive in the background after its window is closed: the API server's graceful shutdown is now bounded (uvicorn otherwise waited forever on the long-lived event-stream websocket and the join hung).

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -38,6 +38,7 @@ from dcs.task import (
     ControlledTask,
     Hold,
     EPLRS,
+    EWR,
     FireAtPoint,
     OptAlarmState,
     OptROE,
@@ -82,6 +83,7 @@ from game.theater import (
 )
 from game.theater.theatergroundobject import (
     CarrierGroundObject,
+    EwrGroundObject,
     GenericCarrierGroundObject,
     LhaGroundObject,
     MissileSiteGroundObject,
@@ -341,6 +343,7 @@ class GroundObjectGenerator:
                 )
                 vehicle_group.units[0].player_can_drive = True
                 self.enable_eplrs(vehicle_group, unit.type)
+                self.enable_ewr(vehicle_group)
                 vehicle_group.units[0].name = unit.unit_name
                 self.set_alarm_state(vehicle_group)
                 GroundForcePainter(faction, vehicle_group.units[0]).apply_livery()
@@ -424,10 +427,25 @@ class GroundObjectGenerator:
         if eplrs_enabled and unit_type.eplrs:
             group.points[0].tasks.append(EPLRS(group.id))
 
+    def enable_ewr(self, group: VehicleGroup) -> None:
+        # EWR radars need the DCS "EWR" enroute task to actively scan and report
+        # contacts to their coalition. Without it they sit inert. Applied only to
+        # dedicated EWR sites (not SAM-as-EWR groups, which Skynet controls by group
+        # name), so it complements the Skynet IADS plugin rather than fighting it:
+        # Skynet reads EWR detections by unit name and does not manage the task list.
+        # (The matching RED alarm state is forced in set_alarm_state.)
+        if isinstance(self.ground_object, EwrGroundObject):
+            group.points[0].tasks.append(EWR())
+
     def set_alarm_state(self, group: MovingGroup[Any], force_red: bool = False) -> None:
         # Ships pass force_red so they always defend; the perf toggle only exists
         # to let ground SAMs start "dark" for Skynet IADS, not to disarm fleets.
-        if force_red or self.game.settings.perf_red_alert_state:
+        # EWR sites must likewise never start dark: a GREEN alarm state leaves the
+        # radar passive (no emission), which would defeat the EWR() enroute task, so
+        # they always come up RED regardless of the perf toggle. Skynet drives EWRs
+        # live anyway, so this stays consistent with IADS control.
+        ewr = isinstance(self.ground_object, EwrGroundObject)
+        if force_red or ewr or self.game.settings.perf_red_alert_state:
             group.points[0].tasks.append(OptAlarmState(2))
         else:
             group.points[0].tasks.append(OptAlarmState(1))

--- a/game/pretense/pretensetgogenerator.py
+++ b/game/pretense/pretensetgogenerator.py
@@ -588,6 +588,7 @@ class PretenseGroundObjectGenerator(GroundObjectGenerator):
                 )
                 vehicle_group.units[0].player_can_drive = True
                 self.enable_eplrs(vehicle_group, unit.type)
+                self.enable_ewr(vehicle_group)
                 vehicle_group.units[0].name = unit.unit_name
                 self.set_alarm_state(vehicle_group)
                 GroundForcePainter(faction, vehicle_group.units[0]).apply_livery()

--- a/tests/missiongenerator/test_ewr_enroute_task.py
+++ b/tests/missiongenerator/test_ewr_enroute_task.py
@@ -1,0 +1,78 @@
+"""Tests for the EWR enroute task + forced RED alarm on EWR ground objects.
+
+Reverting the `isinstance(self.ground_object, EwrGroundObject)` guard in either
+`GroundObjectGenerator.enable_ewr` or `GroundObjectGenerator.set_alarm_state`
+makes the corresponding assertion below fail: these tests pin the EWR-only
+behaviour and prove non-EWR groups are left alone.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+from dcs.task import EWR, OptAlarmState
+
+from game.missiongenerator.tgogenerator import GroundObjectGenerator
+from game.theater.theatergroundobject import EwrGroundObject, VehicleGroupGroundObject
+
+
+def _generator(ground_object: Any, perf_red_alert_state: bool = False) -> Any:
+    game = SimpleNamespace(
+        settings=SimpleNamespace(perf_red_alert_state=perf_red_alert_state)
+    )
+    return GroundObjectGenerator(
+        ground_object, None, game, None, None  # type: ignore[arg-type]
+    )
+
+
+def _group() -> Any:
+    return SimpleNamespace(points=[SimpleNamespace(tasks=[])])
+
+
+# EwrGroundObject / VehicleGroupGroundObject are built without their heavy __init__
+# (which needs a full ControlPoint graph): enable_ewr/set_alarm_state only branch on
+# the runtime type, so a bare instance keeps the test focused on the behaviour.
+def _ewr_tgo() -> EwrGroundObject:
+    return object.__new__(EwrGroundObject)
+
+
+def _armor_tgo() -> VehicleGroupGroundObject:
+    return object.__new__(VehicleGroupGroundObject)
+
+
+def test_enable_ewr_adds_task_for_ewr_ground_object() -> None:
+    group = _group()
+    _generator(_ewr_tgo()).enable_ewr(group)
+
+    assert [type(t) for t in group.points[0].tasks] == [EWR]
+
+
+def test_enable_ewr_skips_non_ewr_ground_object() -> None:
+    group = _group()
+    _generator(_armor_tgo()).enable_ewr(group)
+
+    assert group.points[0].tasks == []
+
+
+def test_ewr_forces_red_alarm_even_when_perf_toggle_off() -> None:
+    group = _group()
+    _generator(_ewr_tgo(), perf_red_alert_state=False).set_alarm_state(group)
+
+    alarm = group.points[0].tasks[0]
+    assert isinstance(alarm, OptAlarmState)
+    assert alarm.value == 2  # RED
+
+
+def test_non_ewr_uses_green_alarm_when_perf_toggle_off() -> None:
+    group = _group()
+    _generator(_armor_tgo(), perf_red_alert_state=False).set_alarm_state(group)
+
+    assert group.points[0].tasks[0].value == 1  # GREEN
+
+
+def test_force_red_still_honored_for_non_ewr() -> None:
+    group = _group()
+    _generator(_armor_tgo(), perf_red_alert_state=False).set_alarm_state(
+        group, force_red=True
+    )
+
+    assert group.points[0].tasks[0].value == 2  # RED


### PR DESCRIPTION
EWR sites now get the DCS "EWR" enroute task and come up on RED alarm, so their radars actually scan and report contacts (previously they could sit inert, especially with the "red alert state" performance option off). Works with or without the Skynet IADS plugin.