### PR TITLE
Headless Lua plugin test harness (lupa + faked DCS sandbox)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -26,3 +26,6 @@ ignore_missing_imports = True
 
 [mypy-uvicorn.*]
 ignore_missing_imports = True
+[mypy-lupa.*]
+# lupa ships no type stubs; used by the headless Lua plugin harness (tests/lua).
+ignore_missing_imports = True

--- a/tests/lua/README.md
+++ b/tests/lua/README.md
@@ -1,0 +1,50 @@
+# Headless Lua plugin harness
+
+Runs the real `resources/plugins/**/*.lua` scripts on Lua 5.1 — the dialect DCS
+embeds — inside the normal pytest run, against a faked mission-scripting
+sandbox (`dcs_stubs.lua`). No DCS install involved.
+
+## Why
+
+A Lua syntax check (`luac -p`) catches parse errors; nothing before this caught
+the next failure class up: **the script loads, errors at file scope or inside
+its first scheduled tick, and the feature silently never starts** — no crash,
+no CI signal, just a plugin that does nothing in the mission. The harness runs
+the plugin exactly as the mission would (config table first, then the script),
+drives a virtual clock through `timer.scheduleFunction`, and records every
+`trigger.action.*` side effect for assertions.
+
+## What it models — and what it doesn't
+
+Modeled: the sandbox API surface (env/timer/world/land/trigger/coalition/
+Group/Unit/StaticObject/missionCommands), a tiny test-populated unit world,
+weapon SHOT→track→impact fakes, and a minimal MOOSE facade for plugins that
+touch a few MOOSE classes. **Not modeled:** DCS AI, physics, weapons flight,
+LoS, or the real MOOSE runtime. A green harness test means "the script runs
+and does what it schedules"; whether the *sim* behaves still needs a fly.
+
+## Running
+
+```
+pytest tests/lua
+```
+
+The only dependency is `lupa` (already in requirements.txt).
+
+## Extending
+
+1. Build a `DcsPluginHarness`, emit the plugin's config with
+   `set_retribution_config(plugin_options={"<plugin>": {...}})`, then
+   `load_plugin_script(...)` in the same order the mission's work orders would.
+2. Populate the world (`add_group`/`add_airbase`/`add_static`), advance the
+   clock (`advance_to`), fire events (`fire_shot`/`fire_birth`/`fire_hit`).
+3. Assert on `records(...)` (explosions, texts, marks, menus, spawns, roe…)
+   and finish with `assert_no_lua_errors()` — scheduled-function and event
+   errors are captured, never swallowed.
+
+When a plugin needs a sandbox call the stubs lack, add a minimal, DCS-shaped
+fake to `dcs_stubs.lua` (keep the DCS conventions documented in its header:
+Vec3 `{x, y=up, z}`, `land.getHeight` takes a Vec2, scheduler return-time
+semantics).
+
+`test_splashdamage_runtime.py` is the reference consumer.

--- a/tests/lua/dcs_stubs.lua
+++ b/tests/lua/dcs_stubs.lua
@@ -1,0 +1,1073 @@
+-------------------------------------------------------------------------------
+-- Headless fake of the vanilla-DCS mission scripting environment, for running
+-- resources/plugins/**.lua under pytest via lupa (Lua 5.1 -- the DCS dialect).
+--
+-- Scope: just enough of the sandbox API for plugin smoke tests -- a virtual
+-- clock driving timer.scheduleFunction, recording trigger.action.* calls, and
+-- a tiny unit/group world the tests populate. It does NOT model DCS AI, LoS,
+-- physics, or weapons flight; anything behavioral still needs the in-game pass
+-- (docs/dev/414th-ingame-pass-checklist.md). What it catches is the class of
+-- "the script errors at file scope / in a timer tick and the feature silently
+-- never runs" bug that luac -p cannot see.
+--
+-- Conventions mirrored from DCS:
+--   * timer.scheduleFunction(fn, args, t): fn(args, time) -> next time | nil.
+--   * Points are { x = north, y = up, z = east }; Vec2 is { x = north, y = east }.
+--   * land.getHeight takes a Vec2 ({ x, y = east }).
+-- The test harness object is exposed as the DcsHarness global.
+-------------------------------------------------------------------------------
+
+local Harness = {
+    now = 0,
+    records = {
+        explosions = {}, -- { x, y, z, power, t }
+        smokes = {}, -- { x, y, z, color, t }
+        bigSmokes = {}, -- { x, y, z, preset, density, name, t }
+        stoppedEffects = {},
+        texts = {}, -- { side, text, duration, t }
+        marks = {}, -- { id, text, x, y, z, side, t }
+        removedMarks = {},
+        menus = {}, -- { side, path }
+        firedTasks = {}, -- { group, x, y, radius, rounds, t }
+        aiOnOff = {}, -- { group, on, t } from Controller:setOnOff
+        controllerTasks = {}, -- { group, taskId, targetGroupId, t } from Controller:setTask
+        controllerResets = {}, -- { group, t } from Controller:resetTask
+        options = {}, -- { group, option, value, t } from Controller:setOption
+        spawns = {}, -- { template, alias, base, takeoff, altitude, grouping, speedKt, t }
+        roe = {}, -- { group, option, t } from MOOSE Option* calls
+        radioTransmissions = {}, -- { file, x, y, z, mod, loop, hz, power, name, t }
+        stoppedTransmissions = {}, -- transmission names
+        sounds = {}, -- { groupId, file, t } from outSound*
+        destroyedStatics = {}, -- static unit names removed via StaticObject:destroy
+        addedStatics = {}, -- { country, name, typeName, x, y, t } from coalition.addStaticObject
+
+        infos = {},
+        warnings = {},
+        errors = {}, -- env.error + errors escaping scheduled functions
+    },
+    groupsByName = {},
+    groupsBySideCat = {}, -- [side][category] -> list
+    airbases = {}, -- name -> AirbaseFake (Harness.addAirbase)
+    markPanels = {},
+    terrainHeight = 0,
+}
+DcsHarness = Harness
+
+-------------------------------------------------------------------------------
+-- env
+-------------------------------------------------------------------------------
+env = {
+    info = function(msg)
+        table.insert(Harness.records.infos, tostring(msg))
+    end,
+    warning = function(msg)
+        table.insert(Harness.records.warnings, tostring(msg))
+    end,
+    error = function(msg)
+        table.insert(Harness.records.errors, tostring(msg))
+    end,
+}
+
+-------------------------------------------------------------------------------
+-- timer: a virtual clock. Nothing runs until the test advances time.
+-------------------------------------------------------------------------------
+local schedule = {} -- { fn, args, t, id }
+local nextScheduleId = 0
+
+timer = {
+    getTime = function()
+        return Harness.now
+    end,
+    scheduleFunction = function(fn, args, t)
+        nextScheduleId = nextScheduleId + 1
+        table.insert(schedule, { fn = fn, args = args, t = t or Harness.now, id = nextScheduleId })
+        return nextScheduleId
+    end,
+    removeFunction = function(id)
+        for i, e in ipairs(schedule) do
+            if e.id == id then
+                table.remove(schedule, i)
+                return
+            end
+        end
+    end,
+}
+
+function Harness.pendingCount()
+    return #schedule
+end
+
+-- Run every scheduled function due up to (and including) t, in time order,
+-- honoring DCS reschedule-by-return semantics. Then park the clock at t.
+function Harness.advanceTo(t)
+    while true do
+        local best, bestIndex
+        for i, e in ipairs(schedule) do
+            if e.t <= t and (not best or e.t < best.t or (e.t == best.t and e.id < best.id)) then
+                best, bestIndex = e, i
+            end
+        end
+        if not best then
+            break
+        end
+        table.remove(schedule, bestIndex)
+        Harness.now = best.t
+        local ok, nextT = pcall(best.fn, best.args, Harness.now)
+        if not ok then
+            table.insert(Harness.records.errors, "scheduled function error: " .. tostring(nextT))
+        elseif type(nextT) == "number" then
+            best.t = nextT
+            table.insert(schedule, best)
+        end
+    end
+    Harness.now = t
+end
+
+-------------------------------------------------------------------------------
+-- Units and groups
+-------------------------------------------------------------------------------
+coalition = {
+    side = { NEUTRAL = 0, RED = 1, BLUE = 2 },
+}
+
+Group = {
+    Category = { AIRPLANE = 0, HELICOPTER = 1, GROUND = 2, SHIP = 3, TRAIN = 4 },
+}
+
+-- The vanilla AI option enums a plugin needs to set alarm states / ROE via
+-- Controller:setOption (values match the DCS mission scripting environment).
+AI = {
+    Option = {
+        Ground = {
+            id = { ROE = 0, ALARM_STATE = 9 },
+            val = {
+                ALARM_STATE = { AUTO = 0, GREEN = 1, RED = 2 },
+            },
+        },
+    },
+}
+
+country = {
+    id = { RUSSIA = 0, USA = 2 },
+}
+
+local UnitFake = {}
+UnitFake.__index = UnitFake
+
+function UnitFake:isExist()
+    return self.exists ~= false
+end
+
+function UnitFake:getLife()
+    return self.life or 1
+end
+
+function UnitFake:getPoint()
+    return { x = self.x or 0, y = self.alt or 0, z = self.z or 0 }
+end
+
+function UnitFake:getVelocity()
+    return self.velocity or { x = 0, y = 0, z = 0 }
+end
+
+function UnitFake:getName()
+    return self.name
+end
+
+function UnitFake:getTypeName()
+    return self.typeName or "FAKE"
+end
+
+function UnitFake:hasAttribute(attr)
+    return (self.attributes or {})[attr] == true
+end
+
+function UnitFake:inAir()
+    return self.airborne == true
+end
+
+function UnitFake:getCoalition()
+    return self.side
+end
+
+function UnitFake:getGroup()
+    return self.group
+end
+
+-- nil for AI; a per-unit spec {playerName = ...} models a human-crewed slot.
+function UnitFake:getPlayerName()
+    return self.playerName
+end
+
+function UnitFake:getID()
+    return self.id or 0
+end
+
+function UnitFake:getCountry()
+    return self.country or 0
+end
+
+function UnitFake:getCallsign()
+    return self.callsign or self.name
+end
+
+-- DCS Position3: p = point, x/y/z = orthonormal orientation vectors. A level,
+-- north-facing unit by default; tests may pass an explicit orient = { x = {...},
+-- y = {...}, z = {...} } in the unit spec to model pitch/bank.
+function UnitFake:getPosition()
+    local orient = self.orient or {}
+    return {
+        p = self:getPoint(),
+        x = orient.x or { x = 1, y = 0, z = 0 },
+        y = orient.y or { x = 0, y = 1, z = 0 },
+        z = orient.z or { x = 0, y = 0, z = 1 },
+    }
+end
+
+function UnitFake:getCategory()
+    return Object and Object.Category and Object.Category.UNIT or 1
+end
+
+function UnitFake:getDesc()
+    return self.desc or { category = self.unitCategory or 2, attributes = self.attributes or {} }
+end
+
+-- Group-level controller: records setOnOff (the ground AI sleep lever). Extend with
+-- setOption/setTask recording if a plugin under test needs them.
+local ControllerFake = {}
+ControllerFake.__index = ControllerFake
+
+function ControllerFake:setOnOff(on)
+    table.insert(Harness.records.aiOnOff, {
+        group = self.group:getName(),
+        on = on == true,
+        t = Harness.now,
+    })
+end
+
+function ControllerFake:setTask(task)
+    table.insert(Harness.records.controllerTasks, {
+        group = self.group:getName(),
+        taskId = task and task.id,
+        targetGroupId = task and task.params and task.params.groupId,
+        t = Harness.now,
+    })
+end
+
+function ControllerFake:resetTask()
+    table.insert(Harness.records.controllerResets, {
+        group = self.group:getName(),
+        t = Harness.now,
+    })
+end
+
+function ControllerFake:setOption(optionId, value)
+    table.insert(Harness.records.options, {
+        group = self.group:getName(),
+        option = optionId,
+        value = value,
+        t = Harness.now,
+    })
+end
+
+local GroupFake = {}
+GroupFake.__index = GroupFake
+
+function GroupFake:isExist()
+    return self.exists ~= false
+end
+
+function GroupFake:getController()
+    self.controller = self.controller or setmetatable({ group = self }, ControllerFake)
+    return self.controller
+end
+
+function GroupFake:getName()
+    return self.name
+end
+
+function GroupFake:getID()
+    return self.id
+end
+
+function GroupFake:getUnits()
+    return self.units
+end
+
+function GroupFake:getUnit(i)
+    return self.units[i]
+end
+
+function GroupFake:getSize()
+    return #self.units
+end
+
+function GroupFake:getCoalition()
+    return self.side
+end
+
+Group.getByName = function(name)
+    return Harness.groupsByName[name]
+end
+
+function GroupFake:getCategory()
+    return self.category
+end
+
+-- Vanilla Unit table: getByName scans the registered groups (the same world
+-- UNIT.FindByName wraps below); Category matches the DCS unit-category enum.
+Unit = {
+    Category = {
+        AIRPLANE = 0,
+        HELICOPTER = 1,
+        GROUND_UNIT = 2,
+        SHIP = 3,
+        STRUCTURE = 4,
+    },
+    SensorType = { OPTIC = 0, RADAR = 1, IRST = 2, RWR = 3 },
+}
+
+Unit.getByName = function(name)
+    for _, g in pairs(Harness.groupsByName) do
+        for _, u in ipairs(g:getUnits()) do
+            if u:getName() == name then
+                return u
+            end
+        end
+    end
+    return nil
+end
+
+-- Object category enum + dispatcher (DCS Object.getCategory works on any
+-- object; fakes carry their class via objectCategory, defaulting to UNIT).
+Object = {
+    Category = {
+        VOID = 0,
+        UNIT = 1,
+        WEAPON = 2,
+        STATIC = 3,
+        BASE = 4,
+        SCENERY = 5,
+        CARGO = 6,
+        FORTIFICATION = 3, -- DCS reports fortifications as statics
+    },
+}
+
+Object.getCategory = function(obj)
+    if obj and obj.objectCategory then
+        return obj.objectCategory
+    end
+    return Object.Category.UNIT
+end
+
+Weapon = {
+    Category = { SHELL = 0, MISSILE = 1, ROCKET = 2, BOMB = 3 },
+}
+
+-- spec = { name, side, category, units = { { name, type, x, z, alt, agl?, life,
+-- exists, airborne, attributes = {...}, velocity = {x,y,z} }, ... } }
+function Harness.addGroup(spec)
+    local grp = setmetatable({
+        name = spec.name,
+        id = spec.id,
+        side = spec.side,
+        category = spec.category,
+        exists = spec.exists,
+        units = {},
+    }, GroupFake)
+    for _, u in ipairs(spec.units or {}) do
+        local unit = setmetatable({
+            name = u.name,
+            typeName = u.type,
+            x = u.x,
+            z = u.z,
+            alt = u.alt or 0,
+            life = u.life,
+            exists = u.exists,
+            airborne = u.airborne,
+            attributes = u.attributes,
+            velocity = u.velocity,
+            playerName = u.playerName,
+            id = u.id,
+            country = u.country or spec.country,
+            callsign = u.callsign,
+            orient = u.orient,
+            desc = u.desc,
+            side = spec.side,
+            group = grp,
+        }, UnitFake)
+        table.insert(grp.units, unit)
+    end
+    Harness.groupsByName[spec.name] = grp
+    Harness.groupsBySideCat[spec.side] = Harness.groupsBySideCat[spec.side] or {}
+    local byCat = Harness.groupsBySideCat[spec.side]
+    byCat[spec.category] = byCat[spec.category] or {}
+    table.insert(byCat[spec.category], grp)
+    return grp
+end
+
+-- Mutate a live unit's fields mid-test (teleport, airborne flip, velocity...):
+-- the harness has no physics, so mover tests reposition units by hand.
+function Harness.updateUnit(groupName, unitIndex, fields)
+    local g = Harness.groupsByName[groupName]
+    if not g then
+        error("updateUnit: no such group " .. tostring(groupName))
+    end
+    local u = g.units[unitIndex]
+    if not u then
+        error(
+            "updateUnit: no unit " .. tostring(unitIndex) .. " in " .. tostring(groupName)
+        )
+    end
+    for k, v in pairs(fields) do
+        u[k] = v
+    end
+end
+
+coalition.getGroups = function(side, category)
+    local byCat = Harness.groupsBySideCat[side]
+    if not byCat then
+        return {}
+    end
+    if category == nil then
+        local all = {}
+        for _, groups in pairs(byCat) do
+            for _, g in ipairs(groups) do
+                table.insert(all, g)
+            end
+        end
+        return all
+    end
+    return byCat[category] or {}
+end
+
+-- Units currently crewed by a human (playerName set), DCS coalition.getPlayers shape.
+coalition.getPlayers = function(side)
+    local players = {}
+    local byCat = Harness.groupsBySideCat[side]
+    if byCat then
+        for _, groups in pairs(byCat) do
+            for _, g in ipairs(groups) do
+                for _, u in ipairs(g:getUnits()) do
+                    if u.playerName and u:isExist() then
+                        table.insert(players, u)
+                    end
+                end
+            end
+        end
+    end
+    return players
+end
+
+coalition.getStaticObjects = function(_)
+    return {}
+end
+
+coalition.addStaticObject = function(countryId, data)
+    table.insert(Harness.records.addedStatics, {
+        country = countryId,
+        name = data and data.name,
+        typeName = data and data.type,
+        x = data and data.x,
+        y = data and data.y,
+        t = Harness.now,
+    })
+    return data
+end
+
+coalition.addGroup = function(countryId, category, data)
+    -- Late-spawn path (Super Gaggle et al.): register the group so subsequent
+    -- Group.getByName / GROUP:FindByName lookups see it.
+    local units = {}
+    for _, u in ipairs((data or {}).units or {}) do
+        table.insert(units, {
+            name = u.name,
+            type = u.type,
+            x = u.x,
+            z = u.y, -- mission-format y is east
+            alt = u.alt,
+            airborne = (u.alt or 0) > 0,
+        })
+    end
+    return Harness.addGroup({
+        name = (data or {}).name or ("spawned-" .. tostring(countryId)),
+        side = Harness.countrySide and Harness.countrySide[countryId] or coalition.side.RED,
+        category = category,
+        units = units,
+    })
+end
+
+-------------------------------------------------------------------------------
+-- land / world / trigger / missionCommands
+-------------------------------------------------------------------------------
+land = {
+    SurfaceType = { LAND = 1, SHALLOW_WATER = 2, WATER = 3, ROAD = 4, RUNWAY = 5 },
+    getHeight = function(_)
+        return Harness.terrainHeight
+    end,
+    -- Whole-map surface type; tests override Harness.surfaceType (a constant or
+    -- a function of the queried Vec2) to model water/road patches.
+    getSurfaceType = function(vec2)
+        if type(Harness.surfaceType) == "function" then
+            return Harness.surfaceType(vec2)
+        end
+        return Harness.surfaceType or 1
+    end,
+    getIP = function(_, _, _)
+        return nil
+    end,
+}
+
+local eventHandlers = {}
+
+world = {
+    event = {
+        S_EVENT_SHOT = 1,
+        S_EVENT_HIT = 2,
+        S_EVENT_DEAD = 8,
+        S_EVENT_BIRTH = 15,
+        S_EVENT_EJECTION = 6,
+        S_EVENT_LAND = 4,
+        S_EVENT_KILL = 28,
+    },
+    VolumeType = { SEGMENT = 0, BOX = 1, SPHERE = 2, PYRAMID = 3 },
+    -- Sphere search over the registered units (the only volume plugins use).
+    -- ofcatergory/handler semantics follow DCS: handler(obj, data) per found
+    -- object; a false return stops the search.
+    searchObjects = function(_category, volume, handler, data)
+        local center = volume and volume.params and volume.params.point
+        local radius = volume and volume.params and volume.params.radius or 0
+        for _, g in pairs(Harness.groupsByName) do
+            for _, u in ipairs(g:getUnits()) do
+                if u:isExist() and center then
+                    local pt = u:getPoint()
+                    local dx, dy, dz = pt.x - center.x, pt.y - center.y, pt.z - center.z
+                    if (dx * dx + dy * dy + dz * dz) <= radius * radius then
+                        local go = handler(u, data)
+                        if go == false then
+                            return
+                        end
+                    end
+                end
+            end
+        end
+    end,
+    addEventHandler = function(handler)
+        table.insert(eventHandlers, handler)
+    end,
+    getMarkPanels = function()
+        return Harness.markPanels
+    end,
+}
+
+function Harness.fireEvent(event)
+    for _, h in ipairs(eventHandlers) do
+        local ok, err = pcall(h.onEvent, h, event)
+        if not ok then
+            table.insert(Harness.records.errors, "event handler error: " .. tostring(err))
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Weapon fake for S_EVENT_SHOT tests. A released weapon that a plugin tracks to
+-- impact: it exists until vanishAt (relative to the virtual clock), then the
+-- tracker resolves its last sampled position as the impact point.
+-------------------------------------------------------------------------------
+local WeaponFake = {}
+WeaponFake.__index = WeaponFake
+
+local nextWeaponId = 70000
+
+function WeaponFake:isExist()
+    if self.vanishAt and Harness.now >= self.vanishAt then
+        return false
+    end
+    return self.exists ~= false
+end
+
+function WeaponFake:getTypeName()
+    return self.typeName or "FAKE_WPN"
+end
+
+function WeaponFake:getPoint()
+    return { x = self.x or 0, y = self.alt or 0, z = self.z or 0 }
+end
+
+function WeaponFake:getVelocity()
+    return self.velocity or { x = 0, y = 0, z = 0 }
+end
+
+function WeaponFake:getLauncher()
+    return self.launcher
+end
+
+function WeaponFake:getDesc()
+    return self.desc or { category = self.category or 3, warhead = self.warhead }
+end
+
+function WeaponFake:getCategory()
+    return Object.Category.WEAPON
+end
+
+-- DCS weapon objects expose a Position3 like units do; weapons fly nose-first
+-- along their velocity, but a level default is enough for trackers that only
+-- read .x as a direction seed.
+function WeaponFake:getPosition()
+    return {
+        p = self:getPoint(),
+        x = { x = 1, y = 0, z = 0 },
+        y = { x = 0, y = 1, z = 0 },
+        z = { x = 0, y = 0, z = 1 },
+    }
+end
+
+function Harness.makeWeapon(spec)
+    nextWeaponId = nextWeaponId + 1
+    return setmetatable({
+        typeName = spec.typeName,
+        x = spec.x,
+        z = spec.z,
+        alt = spec.alt,
+        velocity = spec.velocity,
+        exists = spec.exists,
+        vanishAt = spec.vanishAt,
+        category = spec.category,
+        desc = spec.desc,
+        launcher = spec.launcher,
+        objectCategory = 2, -- Object.Category.WEAPON
+        id_ = spec.id_ or nextWeaponId,
+    }, WeaponFake)
+end
+
+-- Fire an S_EVENT_SHOT. spec = { weapon = { typeName, x, z, alt, velocity, vanishAt },
+-- initiator = "<group name>" } -- the group's first unit is the shooter.
+function Harness.fireShot(spec)
+    local initiator = nil
+    local g = spec.initiator and Harness.groupsByName[spec.initiator] or nil
+    if g then
+        initiator = g:getUnit(1)
+    end
+    local wspec = spec.weapon or {}
+    wspec.launcher = wspec.launcher or initiator
+    Harness.fireEvent({
+        id = world.event.S_EVENT_SHOT,
+        weapon = Harness.makeWeapon(wspec),
+        initiator = initiator,
+    })
+end
+
+-- Fire an S_EVENT_BIRTH for a group's first unit (the slotting pilot). The unit
+-- object is the real UnitFake, so getGroup()/getPlayerName()/getID() work.
+function Harness.fireBirth(groupName)
+    local g = Harness.groupsByName[groupName]
+    Harness.fireEvent({
+        id = world.event.S_EVENT_BIRTH,
+        initiator = g and g:getUnit(1) or nil,
+    })
+end
+
+-- Fire an S_EVENT_HIT on a group's first unit (the victim). The target is the
+-- real UnitFake, so getGroup()/getName() work in the handler.
+function Harness.fireHit(groupName)
+    local g = Harness.groupsByName[groupName]
+    Harness.fireEvent({
+        id = world.event.S_EVENT_HIT,
+        target = g and g:getUnit(1) or nil,
+    })
+end
+
+trigger = {
+    smokeColor = { Green = 0, Red = 1, White = 2, Orange = 3, Blue = 4 },
+    action = {
+        explosion = function(point, power)
+            table.insert(Harness.records.explosions, {
+                x = point.x,
+                y = point.y,
+                z = point.z,
+                power = power,
+                t = Harness.now,
+            })
+        end,
+        smoke = function(point, color)
+            table.insert(Harness.records.smokes, {
+                x = point.x,
+                y = point.y,
+                z = point.z,
+                color = color,
+                t = Harness.now,
+            })
+        end,
+        effectSmokeBig = function(point, preset, density, name)
+            table.insert(Harness.records.bigSmokes, {
+                x = point.x,
+                y = point.y,
+                z = point.z,
+                preset = preset,
+                density = density,
+                name = name,
+                t = Harness.now,
+            })
+        end,
+        effectSmokeStop = function(name)
+            table.insert(Harness.records.stoppedEffects, name)
+        end,
+        stopEffect = function(name)
+            table.insert(Harness.records.stoppedEffects, name)
+        end,
+        outTextForCoalition = function(side, text, duration)
+            table.insert(Harness.records.texts, {
+                side = side,
+                text = tostring(text),
+                duration = duration,
+                t = Harness.now,
+            })
+        end,
+        outText = function(text, duration)
+            table.insert(Harness.records.texts, {
+                side = -1,
+                text = tostring(text),
+                duration = duration,
+                t = Harness.now,
+            })
+        end,
+        outTextForGroup = function(groupId, text, duration, clearview)
+            table.insert(Harness.records.texts, {
+                groupId = groupId,
+                text = tostring(text),
+                duration = duration,
+                clearview = clearview,
+                t = Harness.now,
+            })
+        end,
+        outSoundForGroup = function(groupId, file)
+            table.insert(Harness.records.sounds, {
+                groupId = groupId,
+                file = tostring(file),
+                t = Harness.now,
+            })
+        end,
+        markToCoalition = function(id, text, point, side)
+            table.insert(Harness.records.marks, {
+                id = id,
+                text = tostring(text),
+                x = point.x,
+                y = point.y,
+                z = point.z,
+                side = side,
+                t = Harness.now,
+            })
+        end,
+        removeMark = function(id)
+            table.insert(Harness.records.removedMarks, id)
+        end,
+        radioTransmission = function(file, point, modulation, loop, frequency, power, name)
+            table.insert(Harness.records.radioTransmissions, {
+                file = tostring(file),
+                x = point.x,
+                y = point.y,
+                z = point.z,
+                mod = modulation,
+                loop = loop,
+                hz = frequency,
+                power = power,
+                name = name and tostring(name) or nil,
+                t = Harness.now,
+            })
+        end,
+        stopRadioTransmission = function(name)
+            table.insert(Harness.records.stoppedTransmissions, tostring(name))
+        end,
+    },
+}
+
+net = {
+    get_player_list = function()
+        return {}
+    end,
+    get_player_info = function(_)
+        return nil
+    end,
+}
+
+-------------------------------------------------------------------------------
+-- StaticObject: placed statics by name. Tests register them via
+-- Harness.addStatic{ name = ..., exists = true|false }; getByName returns nil
+-- for anything unregistered (a culled / never-spawned / scenery object).
+-------------------------------------------------------------------------------
+local staticsByName = {}
+
+StaticObject = {
+    getByName = function(name)
+        return staticsByName[name]
+    end,
+}
+
+function Harness.addStatic(spec)
+    staticsByName[spec.name] = {
+        isExist = function(self)
+            return not self.destroyed and spec.exists ~= false
+        end,
+        destroy = function(self)
+            self.destroyed = true
+            staticsByName[spec.name] = nil
+            table.insert(Harness.records.destroyedStatics, spec.name)
+        end,
+    }
+end
+
+missionCommands = {
+    addSubMenu = function(name, parent)
+        table.insert(Harness.records.menus, { side = -1, path = tostring(name) })
+        return { name }
+    end,
+    addCommand = function(name, parent, fn, arg)
+        table.insert(Harness.records.menus, { side = -1, path = tostring(name), fn = fn, arg = arg })
+        return { name }
+    end,
+    removeItem = function(_) end,
+    addSubMenuForCoalition = function(side, name, parent)
+        table.insert(Harness.records.menus, { side = side, path = tostring(name) })
+        return { name }
+    end,
+    addCommandForCoalition = function(side, name, parent, fn, arg)
+        table.insert(Harness.records.menus, { side = side, path = tostring(name), fn = fn, arg = arg })
+        return { name }
+    end,
+    removeItemForCoalition = function(_, _) end,
+    addSubMenuForGroup = function(gid, name, parent)
+        table.insert(Harness.records.menus, { gid = gid, path = tostring(name) })
+        return { name }
+    end,
+    addCommandForGroup = function(gid, name, parent, fn, arg)
+        table.insert(Harness.records.menus, { gid = gid, path = tostring(name), fn = fn, arg = arg })
+        return { name }
+    end,
+    removeItemForGroup = function(_, _) end,
+}
+
+-------------------------------------------------------------------------------
+-- Minimal MOOSE facade (only the surface the plugins under test touch).
+-- Wraps the fake groups/units above -- NOT the real Moose.lua.
+-------------------------------------------------------------------------------
+local MooseCoord = {}
+MooseCoord.__index = MooseCoord
+
+function MooseCoord:GetVec2()
+    return { x = self.x, y = self.z } -- MOOSE Vec2: x = north, y = east
+end
+
+function MooseCoord:GetLandHeight()
+    return Harness.terrainHeight
+end
+
+local MooseUnit = {}
+MooseUnit.__index = MooseUnit
+
+function MooseUnit:IsAlive()
+    return self.unit:isExist() and self.unit:getLife() > 0
+end
+
+function MooseUnit:GetCoordinate()
+    local p = self.unit:getPoint()
+    return setmetatable({ x = p.x, y = p.y, z = p.z }, MooseCoord)
+end
+
+function MooseUnit:GetCoalition()
+    return self.unit:getCoalition()
+end
+
+local MooseGroup = {}
+MooseGroup.__index = MooseGroup
+
+function MooseGroup:IsAlive()
+    if not self.group:isExist() then
+        return false
+    end
+    for _, u in ipairs(self.group:getUnits()) do
+        if u:isExist() and u:getLife() > 0 then
+            return true
+        end
+    end
+    return false
+end
+
+function MooseGroup:GetUnit(i)
+    local u = self.group:getUnit(i)
+    if not u then
+        return nil
+    end
+    return setmetatable({ unit = u }, MooseUnit)
+end
+
+function MooseGroup:GetCoordinate()
+    local u = self.group:getUnit(1)
+    if not u then
+        return nil
+    end
+    local p = u:getPoint()
+    return setmetatable({ x = p.x, y = p.y, z = p.z }, MooseCoord)
+end
+
+function MooseGroup:GetCoalition()
+    return self.group:getCoalition()
+end
+
+function MooseGroup:TaskFireAtPoint(vec2, radius, rounds, weaponType)
+    return { point = vec2, radius = radius, rounds = rounds, weaponType = weaponType }
+end
+
+function MooseGroup:PushTask(task, _)
+    table.insert(Harness.records.firedTasks, {
+        group = self.group:getName(),
+        x = task.point.x,
+        y = task.point.y,
+        radius = task.radius,
+        rounds = task.rounds,
+        weaponType = task.weaponType,
+        t = Harness.now,
+    })
+end
+
+GROUP = {}
+
+function GROUP.FindByName(_, name)
+    local g = Harness.groupsByName[name]
+    if not g then
+        return nil
+    end
+    return setmetatable({ group = g }, MooseGroup)
+end
+
+function MooseGroup:GetName()
+    return self.group:getName()
+end
+
+function MooseGroup:OptionROEWeaponFree()
+    table.insert(Harness.records.roe, {
+        group = self.group:getName(),
+        option = "WeaponFree",
+        t = Harness.now,
+    })
+end
+
+function MooseGroup:OptionROTEvadeFire()
+    table.insert(Harness.records.roe, {
+        group = self.group:getName(),
+        option = "EvadeFire",
+        t = Harness.now,
+    })
+end
+
+UNIT = {}
+
+function UNIT.FindByName(_, name)
+    for _, g in pairs(Harness.groupsByName) do
+        for _, u in ipairs(g:getUnits()) do
+            if u:getName() == name then
+                return setmetatable({ unit = u }, MooseUnit)
+            end
+        end
+    end
+    return nil
+end
+
+-------------------------------------------------------------------------------
+-- AIRBASE / SPAWN fakes (MOOSE surface for the redscramble plugin). Airbases
+-- are registered by tests via Harness.addAirbase{ name, x, z, elev, side };
+-- SPAWN:SpawnAtAirbase records the spawn and synthesizes a real harness group
+-- (units at the airbase, airborne when Takeoff.Air) so the plugin's own vector
+-- loop can find and task it.
+-------------------------------------------------------------------------------
+local AirbaseFake = {}
+AirbaseFake.__index = AirbaseFake
+
+function AirbaseFake:GetVec2()
+    return { x = self.x, y = self.z } -- MOOSE Vec2: x = north, y = east
+end
+
+function AirbaseFake:GetCoordinate()
+    return setmetatable({ x = self.x, y = self.elev or 0, z = self.z }, MooseCoord)
+end
+
+function AirbaseFake:GetCoalition()
+    return self.side
+end
+
+AIRBASE = {}
+
+function AIRBASE.FindByName(_, name)
+    return Harness.airbases[name]
+end
+
+function Harness.addAirbase(spec)
+    Harness.airbases[spec.name] = setmetatable({
+        name = spec.name,
+        x = spec.x or 0,
+        z = spec.z or 0,
+        elev = spec.elev or 0,
+        side = spec.side,
+    }, AirbaseFake)
+end
+
+SPAWN = { Takeoff = { Air = 1, Runway = 2, Hot = 3, Cold = 4 } }
+
+local SpawnFake = {}
+SpawnFake.__index = SpawnFake
+
+function SPAWN.NewWithAlias(_, template, alias)
+    return setmetatable({
+        template = template,
+        alias = alias,
+        counter = 0,
+        grouping = 2,
+        speedKt = nil,
+    }, SpawnFake)
+end
+
+function SpawnFake:InitGrouping(n)
+    self.grouping = n
+    return self
+end
+
+function SpawnFake:InitSpeedKnots(kt)
+    self.speedKt = kt
+    return self
+end
+
+local nextSpawnGroupId = 9000
+
+function SpawnFake:SpawnAtAirbase(airbase, takeoff, altitude)
+    self.counter = self.counter + 1
+    local name = self.alias .. "#" .. string.format("%03d", self.counter)
+    table.insert(Harness.records.spawns, {
+        template = self.template,
+        alias = self.alias,
+        base = airbase and airbase.name or "?",
+        takeoff = takeoff,
+        altitude = altitude,
+        grouping = self.grouping,
+        speedKt = self.speedKt,
+        t = Harness.now,
+    })
+    nextSpawnGroupId = nextSpawnGroupId + 1
+    local units = {}
+    for i = 1, self.grouping do
+        units[#units + 1] = {
+            name = name .. "-" .. i,
+            type = "FAKE_FIGHTER",
+            x = airbase and airbase.x or 0,
+            z = airbase and airbase.z or 0,
+            alt = altitude or 0,
+            airborne = takeoff == SPAWN.Takeoff.Air,
+        }
+    end
+    local grp = Harness.addGroup({
+        name = name,
+        id = nextSpawnGroupId,
+        side = coalition.side.RED,
+        category = Group.Category.AIRPLANE,
+        units = units,
+    })
+    return setmetatable({ group = grp }, MooseGroup)
+end

--- a/tests/lua/harness.py
+++ b/tests/lua/harness.py
@@ -1,0 +1,149 @@
+"""Headless Lua plugin harness: runs resources/plugins scripts under lupa.
+
+Loads tests/lua/dcs_stubs.lua (a fake of the vanilla-DCS mission scripting
+sandbox) into a real Lua 5.1 interpreter -- the dialect DCS runs -- then loads a
+plugin script against a dcsRetribution config table built from plain Python
+dicts. Tests drive the virtual clock and assert on the recorded trigger/timer
+activity.
+
+This complements, never replaces, in-game testing: it catches the "script
+errors and the feature silently never starts" class of bug that a luac -p
+syntax check cannot, but it models no DCS AI, physics, or weapons flight.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import lupa.lua51
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STUBS = Path(__file__).resolve().parent / "dcs_stubs.lua"
+
+
+class DcsPluginHarness:
+    def __init__(self) -> None:
+        self.lua = lupa.lua51.LuaRuntime(unpack_returned_tuples=False)
+        self.lua.execute(STUBS.read_text(encoding="utf-8"))
+        self.harness = self.lua.globals().DcsHarness
+
+    # -- config ---------------------------------------------------------------
+
+    def to_lua(self, value: Any) -> Any:
+        """Recursively convert Python dicts/lists/scalars to Lua tables."""
+        if isinstance(value, dict):
+            table = self.lua.table()
+            for key, item in value.items():
+                table[key] = self.to_lua(item)
+            return table
+        if isinstance(value, (list, tuple)):
+            table = self.lua.table()
+            for index, item in enumerate(value, start=1):
+                table[index] = self.to_lua(item)
+            return table
+        return value
+
+    def set_retribution_config(
+        self,
+        plugin_options: dict[str, dict[str, Any]] | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        """Build the dcsRetribution global the generator would have emitted.
+
+        ``plugin_options`` fills ``dcsRetribution.plugins.<name>`` (the
+        specificOptions each plugin's configuration work order reads);
+        ``extra`` merges additional top-level keys for plugins that read a
+        dedicated config node.
+        """
+        config: dict[str, Any] = {"plugins": plugin_options or {}}
+        for key, value in (extra or {}).items():
+            config[key] = value
+        self.lua.globals().dcsRetribution = self.to_lua(config)
+
+    # -- plugin loading / time ------------------------------------------------
+
+    def load_plugin_script(self, relative_path: str) -> None:
+        """Execute a plugin script exactly as the mission would at load."""
+        script = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        self.lua.execute(script)
+
+    def advance_to(self, mission_time: float) -> None:
+        """Run all scheduled functions due up to mission_time (virtual clock)."""
+        self.harness.advanceTo(mission_time)
+
+    def add_group(self, spec: dict[str, Any]) -> None:
+        self.harness.addGroup(self.to_lua(spec))
+
+    def add_airbase(self, spec: dict[str, Any]) -> None:
+        """Register an airbase for AIRBASE:FindByName.
+
+        ``{"name": ..., "x": ..., "z": ..., "elev": ..., "side": ...}``."""
+        self.harness.addAirbase(self.to_lua(spec))
+
+    def add_static(self, spec: dict[str, Any]) -> None:
+        """Register a placed static for StaticObject.getByName.
+
+        ``{"name": ..., "exists": False}`` models an existed-and-destroyed
+        static; anything unregistered returns nil (culled / scenery)."""
+        self.harness.addStatic(self.to_lua(spec))
+
+    def update_unit(
+        self, group_name: str, fields: dict[str, Any], unit_index: int = 1
+    ) -> None:
+        """Mutate a live unit's fields mid-test (teleport, airborne, velocity).
+
+        The harness models no physics, so mover tests reposition by hand."""
+        self.harness.updateUnit(group_name, unit_index, self.to_lua(fields))
+
+    def fire_event(self, event: dict[str, Any]) -> None:
+        self.harness.fireEvent(self.to_lua(event))
+
+    def fire_shot(self, spec: dict[str, Any]) -> None:
+        """Fire an S_EVENT_SHOT with a tracked weapon fake.
+
+        spec = {"weapon": {"typeName", "x", "z", "alt", "velocity", "vanishAt"},
+                "initiator": "<group name>"} -- the group's first unit is the shooter.
+        """
+        self.harness.fireShot(self.to_lua(spec))
+
+    def fire_birth(self, group_name: str) -> None:
+        """Fire an S_EVENT_BIRTH for a group's first unit (a pilot slotting in)."""
+        self.harness.fireBirth(group_name)
+
+    def fire_hit(self, group_name: str) -> None:
+        """Fire an S_EVENT_HIT on a group's first unit (the victim)."""
+        self.harness.fireHit(group_name)
+
+    def pending_scheduled(self) -> int:
+        return int(self.harness.pendingCount())
+
+    # -- recorded activity ----------------------------------------------------
+
+    def to_python(self, value: Any) -> Any:
+        """Recursively convert Lua tables back to Python lists/dicts."""
+        if lupa.lua51.lua_type(value) != "table":
+            return value
+        keys = list(value.keys())
+        if keys and all(isinstance(k, (int, float)) for k in keys):
+            return [self.to_python(value[k]) for k in sorted(keys)]
+        return {k: self.to_python(value[k]) for k in keys}
+
+    def records(self, name: str) -> list[Any]:
+        recorded = self.to_python(self.harness.records[name])
+        if recorded is None or recorded == {}:
+            return []
+        assert isinstance(recorded, list)
+        return recorded
+
+    @property
+    def side(self) -> Any:
+        return self.lua.globals().coalition.side
+
+    @property
+    def category(self) -> Any:
+        return self.lua.globals().Group.Category
+
+    def assert_no_lua_errors(self) -> None:
+        errors = self.records("errors")
+        assert not errors, f"Lua errors escaped the plugin: {errors}"

--- a/tests/lua/test_splashdamage_runtime.py
+++ b/tests/lua/test_splashdamage_runtime.py
@@ -1,0 +1,165 @@
+"""Splash Damage 3 plugin: headless runtime smoke tests.
+
+The first consumer of the Lua harness: loads the real
+``resources/plugins/splashdamage3`` scripts (main script + the sd3-config
+configuration work order) against a generated-mission-shaped
+``dcsRetribution`` table and drives the weapon-tracking loop on the virtual
+clock. What this pins is the class of bug the ``luac -p`` syntax gate cannot
+see: the script erroring at file scope or in a scheduled tick and the whole
+plugin silently never running.
+
+Deliberately NOT pinned: explosion power numbers (tuning values under active
+discussion upstream) and anything requiring DCS physics or AI.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .harness import DcsPluginHarness
+
+MAIN_SCRIPT = (
+    "resources/plugins/splashdamage3/Splash_Damage_3.4.2_Standard_Retribution.lua"
+)
+CONFIG_SCRIPT = "resources/plugins/splashdamage3/sd3-config.lua"
+
+
+def plugin_defaults() -> dict[str, Any]:
+    """The specificOptions defaults from splashdamage3/plugin.json, as the
+    mission generator would emit them into dcsRetribution.plugins."""
+    return {
+        "game_messages": False,
+        "debug": False,
+        "weapon_missing_message": False,
+        "enable_radio_menu": False,
+        "wave_explosions": True,
+        "larger_explosions": True,
+        "use_dynamic_blast_radius": True,
+        "dynamic_blast_radius_modifier": 200,
+        "damage_model": True,
+        "static_damage_boost": 2000,
+        "overall_scaling": 3,
+        "unit_disabled_health": 30,
+        "unit_cant_fire_health": 40,
+        "infantry_cant_fire_health": 60,
+        "cluster_enabled": False,
+        "cluster_bomblet_reduction_modifier": True,
+        "cluster_bomblet_damage_modifier": 1,
+        "rocket_multiplier": 130,
+        "shipRadarDamageEnable": False,
+        "oca_aircraft_damage_boost": 3000,
+        "ordnance_protection": True,
+        "ordnance_protection_radius": 800,
+        "detect_ordnance_destruction": True,
+        "snap_to_ground_if_destroyed_by_large_explosion": False,
+        "max_snapped_height": 80,
+        "recent_large_explosion_snap": True,
+        "recent_large_explosion_range": 100,
+        "recent_large_explosion_time": 4,
+        "groundunitordnance_damage_modifier": 1,
+        "groundunitordnance_blastwave_modifier": 4,
+    }
+
+
+def loaded_harness() -> DcsPluginHarness:
+    harness = DcsPluginHarness()
+    harness.set_retribution_config(plugin_options={"splashdamage3": plugin_defaults()})
+    harness.load_plugin_script(MAIN_SCRIPT)
+    harness.load_plugin_script(CONFIG_SCRIPT)
+    return harness
+
+
+def add_shooter(harness: DcsPluginHarness) -> None:
+    harness.add_group(
+        {
+            "name": "Hog",
+            "side": 2,
+            "category": 0,
+            "units": [
+                {
+                    "name": "Hog-1",
+                    "type": "A-10C_2",
+                    "x": 0.0,
+                    "z": 0.0,
+                    "alt": 2000.0,
+                    "airborne": True,
+                }
+            ],
+        }
+    )
+
+
+def test_scripts_load_and_start_the_tracking_loop() -> None:
+    harness = loaded_harness()
+    harness.assert_no_lua_errors()
+    # The main script announces itself and schedules its weapon-tracking tick;
+    # the config work order confirms it consumed the Retribution options.
+    infos = harness.records("infos")
+    assert any("SPLASH DAMAGE" in line for line in infos)
+    assert any("Splash Damage 3.4.2 plugin - Setting Up" in line for line in infos)
+    assert harness.pending_scheduled() >= 1
+
+
+def test_config_percent_options_are_normalized() -> None:
+    # sd3-config's contract: the generator emits UI percentages and the config
+    # work order divides them down to the fractions the script multiplies by.
+    harness = loaded_harness()
+    options = harness.to_python(harness.lua.eval("splash_damage_options"))
+    assert options["overall_scaling"] == plugin_defaults()["overall_scaling"] / 100
+    assert (
+        options["dynamic_blast_radius_modifier"]
+        == plugin_defaults()["dynamic_blast_radius_modifier"] / 100
+    )
+    assert options["game_messages"] is False
+
+
+def test_tracked_bomb_detonates_at_its_impact_point() -> None:
+    harness = loaded_harness()
+    add_shooter(harness)
+    harness.advance_to(1.0)
+    # A released Mk-84 (a known explTable entry) that the sim removes at t=6:
+    # the tracker must resolve the disappearance as an impact and place the
+    # scripted explosion at the weapon's last known position.
+    harness.fire_shot(
+        {
+            "weapon": {
+                "typeName": "Mk_84",
+                "x": 500.0,
+                "z": 300.0,
+                "alt": 800.0,
+                "velocity": {"x": 50.0, "y": -120.0, "z": 0.0},
+                "vanishAt": 6.0,
+            },
+            "initiator": "Hog",
+        }
+    )
+    harness.advance_to(30.0)
+    harness.assert_no_lua_errors()
+    explosions = harness.records("explosions")
+    assert len(explosions) == 1
+    assert explosions[0]["x"] == 500.0
+    assert explosions[0]["z"] == 300.0
+    assert explosions[0]["power"] > 0
+
+
+def test_unknown_weapon_is_ignored_without_errors() -> None:
+    harness = loaded_harness()
+    add_shooter(harness)
+    harness.advance_to(1.0)
+    harness.fire_shot(
+        {
+            "weapon": {
+                "typeName": "NOT_A_REAL_WEAPON",
+                "x": 100.0,
+                "z": 100.0,
+                "alt": 500.0,
+                "vanishAt": 4.0,
+            },
+            "initiator": "Hog",
+        }
+    )
+    harness.advance_to(30.0)
+    harness.assert_no_lua_errors()
+    assert harness.records("explosions") == []
+    # The script's own breadcrumb for an un-cataloged weapon.
+    assert any("missing from script" in line for line in harness.records("infos"))


### PR DESCRIPTION
## What

A headless runtime test harness for the `resources/plugins` Lua: `tests/lua/` runs the **real plugin scripts** on Lua 5.1 — the dialect DCS embeds — via `lupa` (already pinned in requirements.txt), against `dcs_stubs.lua`, a faked mission-scripting sandbox. It runs inside the normal `pytest tests` invocation, so CI picks it up with zero workflow changes.

The harness provides:
- a **virtual clock** driving `timer.scheduleFunction` with DCS's reschedule-by-return semantics,
- **recorded side effects** (`trigger.action.*` explosions/smoke/texts/marks/menus, controller tasking, spawns…) for assertions,
- a tiny **test-populated world** (groups/units/airbases/statics, `coalition.getGroups`, `Unit.getByName`, orientation-aware `getPosition`),
- **weapon fakes** for the SHOT → track → impact pattern (`world.searchObjects`, `land.getSurfaceType`, `Object`/`Weapon` category enums),
- a **minimal MOOSE facade** for plugins touching a few MOOSE classes,
- and error capture: a script erroring at file scope, in a scheduled tick, or in an event handler **fails the test** instead of vanishing.

**First consumer:** `test_splashdamage_runtime.py` loads the real Splash Damage 3 main script + `sd3-config.lua` against the plugin.json defaults and pins: load-without-errors + the tracking loop starting, the percent-option normalization contract (`overall_scaling` 3 → 0.03), a tracked Mk-84 detonating at its last known position when the sim removes it, and the unknown-weapon ignore path. Explosion *power values* are deliberately not pinned (tuning is under discussion in #880).

## Why

The plugins have **zero runtime coverage** today. A syntax check catches parse errors; nothing catches the next class up — the script loads, errors at file scope or in its first tick, and the feature **silently never starts**. No crash, no log the player reads, no CI signal. The 414th fork has run this harness pattern across its plugin stack since June and it keeps catching exactly that class before missions fly.

Scope note: the harness models **no DCS AI, physics, or weapons flight** — a green test means "the script runs and does what it schedules"; sim behavior still needs in-game verification. `tests/lua/README.md` documents scope and how to extend.

## Testing

- `pytest tests` — 442 passed, 2 skipped (the 4 new tests included)
- `mypy game tests` — no issues (one `mypy.ini` stanza added: lupa ships no type stubs)
- `black --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)