### PR TITLE
Custom victory conditions: authored win/lose blocks + domination/attrition options

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from .sim import GameUpdateEvents
     from .squadrons import AirWing
     from .threatzones import ThreatZones
+    from .victory import VictoryBaseline
 
 COMMISION_UNIT_VARIETY = 4
 COMMISION_LIMITS_SCALE = 1.5
@@ -121,6 +122,12 @@ class Game:
         self.date = date(start_date.year, start_date.month, start_date.day)
         self.game_stats = GameStats()
         self.notes = ""
+        # Custom victory conditions: the campaign-start strength snapshot the
+        # ratio conditions measure against (latched by initialize_turn), and
+        # the once-per-condition announce latch. Absent on old saves; every
+        # reader guards with getattr, so no save migration is needed.
+        self.victory_baseline: Optional[VictoryBaseline] = None
+        self.victory_announced: set[str] = set()
         self.ground_planners: dict[UUID, GroundPlanner] = {}
         self.informations: list[Information] = []
         self.message("Game Start", "-" * 40)
@@ -420,6 +427,18 @@ class Game:
         persistency.autosave(self)
 
     def check_win_loss(self) -> TurnState:
+        # Alternate endings (custom victory conditions): one evaluator ahead
+        # of the stock capture-everything defaults. Returns None when nothing
+        # is configured, so this path costs nothing and the territory checks
+        # below remain the universal fallback.
+        from .victory import victory_verdict
+
+        alternate = victory_verdict(self)
+        if alternate == "loss":
+            return TurnState.LOSS
+        if alternate == "win":
+            return TurnState.WIN
+
         if not self.theater.player_points(state_check=True):
             return TurnState.LOSS
 
@@ -475,6 +494,13 @@ class Game:
             for_blue: True if the player coalition should be re-initialized.
             squadrons_start_full: True if generator setting was checked.
         """
+        # Latch the campaign-start strength baseline the alternate victory
+        # conditions measure against (a no-op after the first call, so the
+        # multiple-initializations-per-turn cases above are safe).
+        from .victory import ensure_victory_baseline
+
+        ensure_victory_baseline(self)
+
         # Check for win or loss condition FIRST!
         turn_state = self.check_win_loss()
         if turn_state in (TurnState.LOSS, TurnState.WIN):

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -69,6 +69,7 @@ GENERAL_SECTION = "General"
 PILOTS_AND_SQUADRONS_SECTION = "Pilots and Squadrons"
 HQ_AUTOMATION_SECTION = "HQ Automation"
 FLIGHT_PLANNER_AUTOMATION = "Flight Planner Automation"
+VICTORY_CONDITIONS_SECTION = "Victory Conditions"
 
 CAMPAIGN_DOCTRINE_PAGE = "Campaign Doctrine"
 DOCTRINE_DISTANCES_SECTION = "Doctrine distances"
@@ -598,6 +599,41 @@ class Settings:
         section=GENERAL_SECTION,
         default=False,
         detail=("If checked, Bandit's cloud presets will become available."),
+    )
+
+    # Victory conditions
+    alternate_victory_domination: int = bounded_int_option(
+        "Domination victory (% of bases held)",
+        page=CAMPAIGN_MANAGEMENT_PAGE,
+        section=VICTORY_CONDITIONS_SECTION,
+        default=0,
+        min=0,
+        max=100,
+        detail=(
+            "0 disables (the default). Otherwise, holding at least this percentage "
+            "of the map's non-neutral bases wins the campaign at the turn boundary "
+            "-- a limited war ends when the objective area is held, without the "
+            "total conquest the stock ending demands. Adds to the normal endings, "
+            "never replaces them. Pick a threshold above your starting share or "
+            "the campaign ends immediately. Works on any campaign; authored "
+            "`victory:` blocks in the campaign definition stack with it."
+        ),
+    )
+    alternate_victory_attrition: int = bounded_int_option(
+        "Attrition victory (enemy air below % of start)",
+        page=CAMPAIGN_MANAGEMENT_PAGE,
+        section=VICTORY_CONDITIONS_SECTION,
+        default=0,
+        min=0,
+        max=90,
+        detail=(
+            "0 disables (the default). Otherwise, grinding the enemy's total owned "
+            "airframes below this percentage of their campaign-start strength wins "
+            "the campaign -- destroy the enemy's military potential instead of "
+            "capturing every base. Measured against the force at campaign start "
+            "(enemy procurement rebuying airframes counts against you, so the "
+            "fight stays honest). Adds to the normal endings, never replaces them."
+        ),
     )
 
     # Pilots and Squadrons

--- a/game/victory.py
+++ b/game/victory.py
@@ -1,0 +1,695 @@
+"""Custom victory conditions: alternate, legible ends to the war.
+
+The stock win condition is total conquest -- ``Game.check_win_loss`` returns
+WIN only when the enemy owns zero control points -- which forces every
+campaign, including a limited war ("liberate Abkhazia", a maritime pressure
+campaign), into a full ground invasion. This module adds a shallow layer over
+that default:
+
+* **Authored tier:** a campaign YAML ``victory:`` block declaring ``win_when``
+  / ``lose_when`` condition lists -- victory control points, domination
+  thresholds, named high-value target destruction, category decapitation,
+  strength attrition vs. the campaign-start baseline, and air denial. Parsed
+  by :func:`parse_victory`, re-derived from the campaign YAML by name at load
+  (never pickled; the lookup degrades to "no profile" on any failure, never a
+  crash, so an old save whose campaign was removed still plays with the stock
+  endings).
+
+  .. code-block:: yaml
+
+      victory:
+        description: Liberate the coast
+        win_when:
+          - label: Take the coast
+            capture_cps: [Sukhumi-Babushara, Gudauta]
+          - enemy_air_below: 0.25
+            min_turn: 4
+        lose_when:
+          - lose_cps: [Kutaisi]
+
+* **Generic tier:** two opt-in Settings knobs usable on ANY campaign with
+  zero authoring -- ``alternate_victory_domination`` and
+  ``alternate_victory_attrition`` -- synthesized into the same condition
+  objects and stacked with any authored block.
+
+Semantics: a victory entry is a *requirement*, so EVERY field set on one
+entry must hold (AND within the entry), and the ``win_when`` / ``lose_when``
+lists are OR (any fully-met entry ends the war). That is what makes
+``min_turn`` usable as a guard ("not before turn 4") instead of nonsense
+("win at turn 4").
+
+Alternate conditions ADD to the stock endings, never replace them: capturing
+everything still wins and losing everything still loses. Evaluation is ground
+truth at the turn boundary only, and the AI planner never reads these
+conditions -- an author who wants the AI to pursue the objectives should
+shape the campaign (or the OOB) so they align with what the commander already
+values.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, Optional
+
+if TYPE_CHECKING:
+    from game.game import Game
+    from game.settings import Settings
+    from game.theater.controlpoint import ControlPoint
+    from game.theater.theatergroundobject import TheaterGroundObject
+
+#: The generic attrition knob is capped here: "enemy air below 95% of start"
+#: would end the war on the first kill, which is a losses counter, not a
+#: victory condition.
+MAX_ATTRITION_THRESHOLD = 90
+
+
+@dataclass(frozen=True)
+class VictoryCondition:
+    """One ``win_when`` / ``lose_when`` entry.
+
+    EVERY set field must hold for the entry to be met (AND semantics,
+    documented in the module docstring). ``label`` is an optional authored
+    display prefix; the Settings knobs synthesize unlabeled entries (their
+    prose already says everything).
+    """
+
+    label: Optional[str] = None
+    #: Guard: the entry cannot be met before this campaign turn.
+    min_turn: int = 0
+    #: ALL named control points are blue-owned.
+    capture_cps: tuple[str, ...] = ()
+    #: ANY named control point is red-owned (the ``lose_when`` staple).
+    lose_cps: tuple[str, ...] = ()
+    #: BLUE owns at least this fraction of the non-neutral control points.
+    territory_above: Optional[float] = None
+    #: BLUE owns less than this fraction of the non-neutral control points.
+    territory_below: Optional[float] = None
+    #: ALL ground objects with these names are fully dead (case-insensitive;
+    #: a name matching nothing can never be met -- typos are visible, not
+    #: silent wins).
+    destroy_targets: tuple[str, ...] = ()
+    #: NO red-owned ground object of these ``category`` strings has alive
+    #: units, AND the campaign-start baseline counted at least one (so an
+    #: absent category can never produce a vacuous instant win).
+    destroy_categories: tuple[str, ...] = ()
+    #: Red owned airframes (all squadrons) below this fraction of the baseline.
+    enemy_air_below: Optional[float] = None
+    #: Red front-line ground inventory below this fraction of the baseline.
+    enemy_ground_below: Optional[float] = None
+    #: Blue owned airframes below this fraction of the baseline (``lose_when``).
+    friendly_air_below: Optional[float] = None
+    #: NO red control point can currently field aircraft
+    #: (``runway_is_operational``: cratered airfields and sunk carriers are
+    #: denied; FOB helipads count as air power; a red off-map spawn is always
+    #: operational, so this condition is unreachable on those campaigns -- by
+    #: construction).
+    enemy_air_denied: bool = False
+
+
+@dataclass(frozen=True)
+class VictoryProfile:
+    """A campaign's alternate endings: any met entry ends the war."""
+
+    description: Optional[str] = None
+    win_when: tuple[VictoryCondition, ...] = ()
+    lose_when: tuple[VictoryCondition, ...] = ()
+
+
+@dataclass
+class VictoryBaseline:
+    """Campaign-start strength snapshot the ratio conditions run against.
+
+    Latched on the game the first time :func:`ensure_victory_baseline` runs
+    (turn 0 for a new game; first load for a pre-feature save). Snapshotted
+    unconditionally so a knob flipped on at turn 20 still measures against
+    the earliest state this build saw. ``red_categories`` counts red ground
+    objects per ``category`` so ``destroy_categories`` can prove the target
+    class ever existed.
+    """
+
+    red_air: int
+    blue_air: int
+    red_ground: int
+    red_categories: dict[str, int] = field(default_factory=dict)
+
+
+# --- live-state counters --------------------------------------------------------------
+
+
+def _air_strength(game: Game, blue: bool) -> int:
+    """Owned airframes across ALL of one side's squadrons.
+
+    The whole force, not just the air-superiority slice -- the attrition ask
+    is force strength, and a bomber wing is strength.
+    """
+    from game.theater.player import Player
+
+    player = Player.BLUE if blue else Player.RED
+    return sum(
+        squadron.owned_aircraft
+        for squadron in game.air_wing_for(player).iter_squadrons()
+    )
+
+
+def _ground_strength(game: Game, blue: bool) -> int:
+    """One side's front-line ground inventory (the force plan_groundwar fields)."""
+    from game.theater.player import Player
+
+    player = Player.BLUE if blue else Player.RED
+    return sum(
+        cp.base.total_armor
+        for cp in game.theater.controlpoints
+        if cp.captured is player
+    )
+
+
+def _territory(game: Game) -> tuple[int, int]:
+    """(blue-owned, total non-neutral) control points."""
+    from game.theater.player import Player
+
+    blue = 0
+    total = 0
+    for cp in game.theater.controlpoints:
+        if cp.captured is Player.NEUTRAL:
+            continue
+        total += 1
+        if cp.captured is Player.BLUE:
+            blue += 1
+    return blue, total
+
+
+def _red_category_counts(game: Game) -> dict[str, int]:
+    """Red-owned ground objects per ``category`` string (alive or dead)."""
+    from game.theater.player import Player
+
+    counts: dict[str, int] = {}
+    for tgo in game.theater.ground_objects:
+        if tgo.control_point.captured is Player.RED:
+            counts[tgo.category] = counts.get(tgo.category, 0) + 1
+    return counts
+
+
+def _red_alive_in_category(game: Game, category: str) -> int:
+    """Red-owned ground objects of ``category`` that still have alive units."""
+    from game.theater.player import Player
+
+    return sum(
+        1
+        for tgo in game.theater.ground_objects
+        if tgo.control_point.captured is Player.RED
+        and tgo.category == category
+        and any(unit.alive for unit in tgo.units)
+    )
+
+
+def _tgos_named(game: Game, name: str) -> list[TheaterGroundObject]:
+    """Every ground object matching ``name`` (case-insensitive, stripped)."""
+    wanted = name.strip().casefold()
+    return [
+        tgo
+        for tgo in game.theater.ground_objects
+        if tgo.name.strip().casefold() == wanted
+    ]
+
+
+def _cp_named(game: Game, name: str) -> Optional[ControlPoint]:
+    for cp in game.theater.controlpoints:
+        if cp.name == name:
+            return cp
+    return None
+
+
+def _operational_red_airbases(game: Game) -> int:
+    """Red control points that can currently field aircraft."""
+    from game.theater.player import Player
+
+    return sum(
+        1
+        for cp in game.theater.controlpoints
+        if cp.captured is Player.RED and cp.runway_is_operational()
+    )
+
+
+# --- the baseline latch ---------------------------------------------------------------
+
+
+def ensure_victory_baseline(game: Game) -> VictoryBaseline:
+    """Latch (or return) the campaign-start strength snapshot.
+
+    Called from ``Game.initialize_turn`` so a new game latches at turn 0; the
+    verdict also calls it defensively so a pre-feature save latches on first
+    read. Cheap (three sums + a category walk) and unconditional, so a
+    late-enabled knob still measures honestly.
+    """
+    baseline = getattr(game, "victory_baseline", None)
+    if baseline is None:
+        baseline = VictoryBaseline(
+            red_air=_air_strength(game, blue=False),
+            blue_air=_air_strength(game, blue=True),
+            red_ground=_ground_strength(game, blue=False),
+            red_categories=_red_category_counts(game),
+        )
+        game.victory_baseline = baseline
+    return baseline
+
+
+# --- evaluation -----------------------------------------------------------------------
+
+
+def _ratio_below(current: int, base: int, threshold: float) -> bool:
+    """A strength ratio vs. an empty baseline is unmeasurable, never met."""
+    if base <= 0:
+        return False
+    return current / base < threshold
+
+
+def condition_met(
+    game: Game, condition: VictoryCondition, baseline: VictoryBaseline
+) -> bool:
+    """AND semantics: every field set on the entry must hold."""
+    from game.theater.player import Player
+
+    if game.turn < condition.min_turn:
+        return False
+    for name in condition.capture_cps:
+        cp = _cp_named(game, name)
+        if cp is None or not cp.captured.is_blue:
+            return False
+    if condition.lose_cps:
+        if not any(
+            (cp := _cp_named(game, name)) is not None and cp.captured is Player.RED
+            for name in condition.lose_cps
+        ):
+            return False
+    if condition.territory_above is not None:
+        blue, total = _territory(game)
+        if total == 0 or blue / total < condition.territory_above:
+            return False
+    if condition.territory_below is not None:
+        blue, total = _territory(game)
+        if total == 0 or blue / total >= condition.territory_below:
+            return False
+    for name in condition.destroy_targets:
+        targets = _tgos_named(game, name)
+        if not targets:
+            return False
+        for tgo in targets:
+            if any(unit.alive for unit in tgo.units):
+                return False
+    for category in condition.destroy_categories:
+        if baseline.red_categories.get(category, 0) <= 0:
+            return False
+        if _red_alive_in_category(game, category) > 0:
+            return False
+    if condition.enemy_air_below is not None and not _ratio_below(
+        _air_strength(game, blue=False), baseline.red_air, condition.enemy_air_below
+    ):
+        return False
+    if condition.enemy_ground_below is not None and not _ratio_below(
+        _ground_strength(game, blue=False),
+        baseline.red_ground,
+        condition.enemy_ground_below,
+    ):
+        return False
+    if condition.friendly_air_below is not None and not _ratio_below(
+        _air_strength(game, blue=True), baseline.blue_air, condition.friendly_air_below
+    ):
+        return False
+    if condition.enemy_air_denied and _operational_red_airbases(game) > 0:
+        return False
+    return True
+
+
+# --- the knobs (generic tier) ---------------------------------------------------------
+
+
+def _knob_conditions(settings: Settings) -> tuple[VictoryCondition, ...]:
+    """The Settings-synthesized win conditions (0 = off, the default)."""
+    out = []
+    domination = int(getattr(settings, "alternate_victory_domination", 0) or 0)
+    if 0 < domination <= 100:
+        out.append(VictoryCondition(territory_above=domination / 100))
+    attrition = int(getattr(settings, "alternate_victory_attrition", 0) or 0)
+    if 0 < attrition <= MAX_ATTRITION_THRESHOLD:
+        out.append(VictoryCondition(enemy_air_below=attrition / 100))
+    return tuple(out)
+
+
+# --- parsing + the campaign lookup (rederive-never-pickle) ----------------------------
+
+_STRING_LIST_KEYS = ("capture_cps", "lose_cps", "destroy_targets", "destroy_categories")
+_FRACTION_KEYS = (
+    "territory_above",
+    "territory_below",
+    "enemy_air_below",
+    "enemy_ground_below",
+    "friendly_air_below",
+)
+_ALLOWED_ENTRY_KEYS = (
+    frozenset(_STRING_LIST_KEYS)
+    | frozenset(_FRACTION_KEYS)
+    | {"label", "min_turn", "enemy_air_denied"}
+)
+
+
+def _parse_string_list(raw: object, key: str) -> tuple[str, ...]:
+    if (
+        not isinstance(raw, list)
+        or not raw
+        or not all(isinstance(item, str) and item.strip() for item in raw)
+    ):
+        raise ValueError(f"victory: {key} must be a non-empty list of names: {raw!r}")
+    return tuple(str(item) for item in raw)
+
+
+def _parse_fraction(raw: object, key: str) -> float:
+    try:
+        value = float(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise ValueError(f"victory: {key} must be a number in (0, 1): {raw!r}")
+    if not 0 < value <= 1 or (key != "territory_above" and value == 1):
+        # territory_above: 1.0 ("own everything") is legal, if redundant with
+        # the stock ending; a *_below threshold of 1.0 is trivially near-true.
+        raise ValueError(f"victory: {key} must be a fraction in (0, 1): {raw!r}")
+    return value
+
+
+def _parse_entry(raw: object) -> VictoryCondition:
+    """One ``win_when`` / ``lose_when`` entry. Fails loudly on bad data, so a
+    broken campaign dies in tests rather than silently losing its ending."""
+    if not isinstance(raw, dict):
+        raise ValueError(f"victory: condition entry must be a mapping: {raw!r}")
+    unknown = set(raw) - _ALLOWED_ENTRY_KEYS
+    if unknown:
+        raise ValueError(
+            f"victory: unknown condition field(s) {sorted(unknown)} in {raw!r}"
+        )
+
+    def strings(key: str) -> tuple[str, ...]:
+        return _parse_string_list(raw[key], key) if key in raw else ()
+
+    def fraction(key: str) -> Optional[float]:
+        if key not in raw or raw[key] is None:
+            return None
+        return _parse_fraction(raw[key], key)
+
+    denied = raw.get("enemy_air_denied", False)
+    if denied not in (False, True):
+        raise ValueError(
+            f"victory: enemy_air_denied must be true (omit it otherwise): {raw!r}"
+        )
+    condition = VictoryCondition(
+        label=str(raw["label"]) if raw.get("label") else None,
+        min_turn=int(raw.get("min_turn", 0)),
+        capture_cps=strings("capture_cps"),
+        lose_cps=strings("lose_cps"),
+        territory_above=fraction("territory_above"),
+        territory_below=fraction("territory_below"),
+        destroy_targets=strings("destroy_targets"),
+        destroy_categories=strings("destroy_categories"),
+        enemy_air_below=fraction("enemy_air_below"),
+        enemy_ground_below=fraction("enemy_ground_below"),
+        friendly_air_below=fraction("friendly_air_below"),
+        enemy_air_denied=bool(denied),
+    )
+    has_condition = bool(
+        condition.capture_cps
+        or condition.lose_cps
+        or condition.territory_above is not None
+        or condition.territory_below is not None
+        or condition.destroy_targets
+        or condition.destroy_categories
+        or condition.enemy_air_below is not None
+        or condition.enemy_ground_below is not None
+        or condition.friendly_air_below is not None
+        or condition.enemy_air_denied
+    )
+    if not has_condition:
+        raise ValueError(
+            f"victory: entry has no condition (label/min_turn alone do not "
+            f"end a war): {raw!r}"
+        )
+    return condition
+
+
+def parse_victory(raw: object) -> Optional[VictoryProfile]:
+    """Parse a campaign YAML ``victory:`` block, or None when absent."""
+    if not raw:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError(f"victory: must be a mapping, got {type(raw).__name__}")
+    unknown = set(raw) - {"description", "win_when", "lose_when"}
+    if unknown:
+        raise ValueError(f"victory: unknown key(s) {sorted(unknown)}")
+    win_raw = raw.get("win_when") or []
+    lose_raw = raw.get("lose_when") or []
+    if not isinstance(win_raw, list) or not isinstance(lose_raw, list):
+        raise ValueError("victory: win_when/lose_when must be lists of conditions")
+    win = tuple(_parse_entry(entry) for entry in win_raw)
+    lose = tuple(_parse_entry(entry) for entry in lose_raw)
+    if not win and not lose:
+        raise ValueError("victory: needs at least one win_when or lose_when entry")
+    description = raw.get("description")
+    return VictoryProfile(
+        description=str(description) if description else None,
+        win_when=win,
+        lose_when=lose,
+    )
+
+
+#: Authored-profile cache keyed by campaign name. Definitions live in the
+#: campaign YAML and are re-derived per process, never pickled; tests may
+#: inject here.
+_PROFILE_CACHE: dict[str, Optional[VictoryProfile]] = {}
+
+
+def authored_victory_for(game: Game) -> Optional[VictoryProfile]:
+    """The campaign's authored ``victory:`` block, or None.
+
+    Any lookup/parse failure degrades to None with a log, never a crash -- an
+    old save whose campaign was removed (or whose block was broken by an
+    edit) still plays with the stock endings.
+    """
+    name = getattr(game, "campaign_name", None)
+    if not name:
+        return None
+    if name in _PROFILE_CACHE:
+        return _PROFILE_CACHE[name]
+    profile: Optional[VictoryProfile] = None
+    try:
+        import yaml
+
+        from game.campaignloader.campaign import Campaign
+
+        for path in Campaign.iter_campaign_defs():
+            try:
+                with path.open(encoding="utf-8") as campaign_file:
+                    data = yaml.safe_load(campaign_file)
+            except Exception:  # noqa: BLE001 -- one bad yaml must not kill the scan
+                continue
+            if isinstance(data, dict) and data.get("name") == name:
+                profile = parse_victory(data.get("victory"))
+                if profile is not None:
+                    logging.info(
+                        "Loaded victory conditions for %r: %d win / %d lose",
+                        name,
+                        len(profile.win_when),
+                        len(profile.lose_when),
+                    )
+                break
+    except Exception:  # noqa: BLE001
+        logging.exception("Victory conditions: lookup failed for %r", name)
+        profile = None
+    _PROFILE_CACHE[name] = profile
+    return profile
+
+
+def active_victory_profile(game: Game) -> Optional[VictoryProfile]:
+    """The authored block + the knob-synthesized conditions, or None.
+
+    The knobs are re-read every call (settings change mid-campaign); the
+    authored block comes from the process cache.
+    """
+    authored = authored_victory_for(game)
+    extra = _knob_conditions(game.settings)
+    if authored is None and not extra:
+        return None
+    if authored is None:
+        return VictoryProfile(win_when=extra)
+    if not extra:
+        return authored
+    return VictoryProfile(
+        description=authored.description,
+        win_when=authored.win_when + extra,
+        lose_when=authored.lose_when,
+    )
+
+
+# --- the verdict (the check_win_loss branch) ------------------------------------------
+
+
+def _announce(game: Game, condition: VictoryCondition, defeat: bool) -> None:
+    """Name the met condition beside the generic Victory!/Defeat! dialog.
+
+    Latched per condition text: the UI flow calls ``check_win_loss`` several
+    times around a turn boundary, and the message feed should carry the
+    "why" once. The latch persists (harmless -- the war is over).
+    """
+    text = condition.label or describe_condition(
+        game, condition, ensure_victory_baseline(game), live=False
+    )
+    announced: set[str] = getattr(game, "victory_announced", set())
+    key = ("defeat" if defeat else "victory") + ":" + text
+    if key in announced:
+        return
+    announced.add(key)
+    game.victory_announced = announced
+    if defeat:
+        game.message("Defeat condition met", text)
+    else:
+        game.message("Victory condition met", text)
+
+
+def victory_verdict(game: Game) -> Optional[Literal["win", "loss"]]:
+    """The alternate ending, or None while the war goes on.
+
+    Backs the alternate-endings branch in ``Game.check_win_loss`` ahead of
+    the stock territory checks. Loss precedence: a simultaneous collapse is
+    never a cheap win.
+    """
+    profile = active_victory_profile(game)
+    if profile is None:
+        return None
+    baseline = ensure_victory_baseline(game)
+    for condition in profile.lose_when:
+        if condition_met(game, condition, baseline):
+            _announce(game, condition, defeat=True)
+            return "loss"
+    for condition in profile.win_when:
+        if condition_met(game, condition, baseline):
+            _announce(game, condition, defeat=False)
+            return "win"
+    return None
+
+
+# --- display --------------------------------------------------------------------------
+
+
+def describe_condition(
+    game: Game,
+    condition: VictoryCondition,
+    baseline: VictoryBaseline,
+    live: bool = True,
+) -> str:
+    """One entry as prose, with live progress values when ``live``.
+
+    ``live=False`` (static prose) feeds the end-of-war banner; the live
+    variant ("Capture Sukhumi, Gudauta (1/2 held)") is the building block
+    for any conditions display a UI wants to add.
+    """
+    from game.theater.player import Player
+
+    bits = []
+    if condition.capture_cps:
+        names = ", ".join(condition.capture_cps)
+        now = ""
+        if live:
+            held = sum(
+                1
+                for name in condition.capture_cps
+                if (cp := _cp_named(game, name)) is not None and cp.captured.is_blue
+            )
+            now = f" ({held}/{len(condition.capture_cps)} held)"
+        bits.append(f"Capture {names}{now}")
+    if condition.lose_cps:
+        names = ", ".join(condition.lose_cps)
+        now = ""
+        if live:
+            fallen = sum(
+                1
+                for name in condition.lose_cps
+                if (cp := _cp_named(game, name)) is not None
+                and cp.captured is Player.RED
+            )
+            now = f" ({fallen}/{len(condition.lose_cps)} fallen)"
+        plural = "s" if len(condition.lose_cps) == 1 else ""
+        bits.append(f"{names} fall{plural} to the enemy{now}")
+    if condition.territory_above is not None:
+        now = ""
+        if live:
+            blue, total = _territory(game)
+            if total:
+                now = f" (now {blue / total:.0%})"
+        bits.append(f"Hold {condition.territory_above:.0%} of the bases{now}")
+    if condition.territory_below is not None:
+        now = ""
+        if live:
+            blue, total = _territory(game)
+            if total:
+                now = f" (now {blue / total:.0%})"
+        bits.append(
+            f"Friendly holdings fall below {condition.territory_below:.0%}{now}"
+        )
+    if condition.destroy_targets:
+        names = ", ".join(condition.destroy_targets)
+        now = ""
+        if live:
+            dead = 0
+            for name in condition.destroy_targets:
+                targets = _tgos_named(game, name)
+                if targets and not any(
+                    unit.alive for tgo in targets for unit in tgo.units
+                ):
+                    dead += 1
+            now = f" ({dead}/{len(condition.destroy_targets)} destroyed)"
+        bits.append(f"Destroy {names}{now}")
+    if condition.destroy_categories:
+        names = ", ".join(condition.destroy_categories)
+        now = ""
+        if live:
+            alive = sum(
+                _red_alive_in_category(game, category)
+                for category in condition.destroy_categories
+            )
+            now = f" ({alive} still standing)"
+        bits.append(f"Destroy every enemy {names} site{now}")
+    if condition.enemy_air_below is not None:
+        now = ""
+        if live and baseline.red_air:
+            ratio = _air_strength(game, blue=False) / baseline.red_air
+            now = f" (now {ratio:.0%})"
+        bits.append(
+            f"Enemy air force below {condition.enemy_air_below:.0%} of start{now}"
+        )
+    if condition.enemy_ground_below is not None:
+        now = ""
+        if live and baseline.red_ground:
+            ratio = _ground_strength(game, blue=False) / baseline.red_ground
+            now = f" (now {ratio:.0%})"
+        bits.append(
+            f"Enemy ground force below "
+            f"{condition.enemy_ground_below:.0%} of start{now}"
+        )
+    if condition.friendly_air_below is not None:
+        now = ""
+        if live and baseline.blue_air:
+            ratio = _air_strength(game, blue=True) / baseline.blue_air
+            now = f" (now {ratio:.0%})"
+        bits.append(
+            f"Friendly air force falls below "
+            f"{condition.friendly_air_below:.0%} of start{now}"
+        )
+    if condition.enemy_air_denied:
+        now = ""
+        if live:
+            operating = _operational_red_airbases(game)
+            plural = "" if operating == 1 else "s"
+            now = f" ({operating} enemy base{plural} still operating)"
+        bits.append(f"Deny the enemy air operations{now}")
+    text = " and ".join(bits)
+    if condition.min_turn > 1:
+        text += f" (not before turn {condition.min_turn})"
+    if condition.label:
+        return f"{condition.label} — {text}"
+    return text

--- a/tests/test_victory.py
+++ b/tests/test_victory.py
@@ -1,0 +1,441 @@
+"""Custom victory conditions: parse, evaluation, verdict, wiring.
+
+Locks the contracts documented in game/victory.py: AND-within-entry /
+OR-across-entries semantics, the no-vacuous-win rules (empty baselines and
+absent categories never fire), loss precedence, the knob synthesis, the
+announce latch, and that an unconfigured game is a byte-identical no-op all
+the way through the real ``Game.check_win_loss`` branch order.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Iterator, Optional, cast
+
+import pytest
+
+from game import victory as victory_mod
+from game.theater.player import Player
+from game.victory import (
+    VictoryCondition,
+    VictoryProfile,
+    active_victory_profile,
+    condition_met,
+    describe_condition,
+    ensure_victory_baseline,
+    parse_victory,
+    victory_verdict,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_profile_cache() -> Iterator[None]:
+    victory_mod._PROFILE_CACHE.clear()
+    yield
+    victory_mod._PROFILE_CACHE.clear()
+
+
+def _cp(
+    name: str,
+    owner: Player,
+    operational: bool = True,
+    armor: int = 0,
+) -> Any:
+    return SimpleNamespace(
+        name=name,
+        captured=owner,
+        runway_is_operational=lambda: operational,
+        base=SimpleNamespace(total_armor=armor),
+    )
+
+
+def _tgo(name: str, category: str, cp: Any, *alive: bool) -> Any:
+    return SimpleNamespace(
+        name=name,
+        category=category,
+        control_point=cp,
+        units=[SimpleNamespace(alive=a) for a in alive],
+    )
+
+
+def _wing(*owned: int) -> Any:
+    squadrons = [SimpleNamespace(owned_aircraft=n) for n in owned]
+    return SimpleNamespace(iter_squadrons=lambda: list(squadrons))
+
+
+def _game(
+    cps: Optional[list[Any]] = None,
+    tgos: Optional[list[Any]] = None,
+    red_air: tuple[int, ...] = (10,),
+    blue_air: tuple[int, ...] = (10,),
+    turn: int = 5,
+    domination: int = 0,
+    attrition: int = 0,
+    campaign_name: Optional[str] = None,
+) -> Any:
+    wings = {Player.RED: _wing(*red_air), Player.BLUE: _wing(*blue_air)}
+    messages: list[tuple[str, str]] = []
+    game = SimpleNamespace(
+        theater=SimpleNamespace(controlpoints=cps or [], ground_objects=tgos or []),
+        air_wing_for=lambda player: wings[player],
+        settings=SimpleNamespace(
+            alternate_victory_domination=domination,
+            alternate_victory_attrition=attrition,
+        ),
+        turn=turn,
+        campaign_name=campaign_name,
+        messages=messages,
+    )
+    game.message = lambda title, text="": messages.append((title, text))
+    return game
+
+
+def _baseline(game: Any) -> Any:
+    return ensure_victory_baseline(cast(Any, game))
+
+
+# --- parsing --------------------------------------------------------------------------
+
+
+def test_parse_full_block() -> None:
+    profile = parse_victory(
+        {
+            "description": "Liberate Abkhazia",
+            "win_when": [
+                {"capture_cps": ["Sukhumi", "Gudauta"], "label": "Take the coast"},
+                {"enemy_air_below": 0.1, "min_turn": 4},
+            ],
+            "lose_when": [{"lose_cps": ["Kutaisi"]}],
+        }
+    )
+    assert profile is not None
+    assert profile.description == "Liberate Abkhazia"
+    assert profile.win_when[0].capture_cps == ("Sukhumi", "Gudauta")
+    assert profile.win_when[0].label == "Take the coast"
+    assert profile.win_when[1].enemy_air_below == 0.1
+    assert profile.win_when[1].min_turn == 4
+    assert profile.lose_when[0].lose_cps == ("Kutaisi",)
+
+
+def test_parse_absent_block_is_none() -> None:
+    assert parse_victory(None) is None
+    assert parse_victory({}) is None
+
+
+def test_parse_rejects_bad_shapes() -> None:
+    with pytest.raises(ValueError):
+        parse_victory("win")
+    with pytest.raises(ValueError):
+        parse_victory({"win_when": [{"capture_cps": ["A"]}], "extra": True})
+    with pytest.raises(ValueError):
+        parse_victory({"win_when": [{"capture_the_flag": ["A"]}]})
+    with pytest.raises(ValueError):
+        # label/min_turn alone do not end a war.
+        parse_victory({"win_when": [{"label": "x", "min_turn": 3}]})
+    with pytest.raises(ValueError):
+        parse_victory({"description": "no conditions at all"})
+    with pytest.raises(ValueError):
+        parse_victory({"win_when": [{"capture_cps": []}]})
+    with pytest.raises(ValueError):
+        parse_victory({"win_when": [{"enemy_air_below": 0.0}]})
+    with pytest.raises(ValueError):
+        parse_victory({"win_when": [{"enemy_air_below": 1.0}]})
+    with pytest.raises(ValueError):
+        parse_victory({"win_when": [{"territory_below": 1.0}]})
+    with pytest.raises(ValueError):
+        parse_victory({"win_when": [{"enemy_air_denied": False}]})
+
+
+def test_parse_territory_above_one_is_legal() -> None:
+    profile = parse_victory({"win_when": [{"territory_above": 1.0}]})
+    assert profile is not None
+    assert profile.win_when[0].territory_above == 1.0
+
+
+# --- evaluation -----------------------------------------------------------------------
+
+
+def test_capture_cps_requires_all_named_blue() -> None:
+    game = _game(cps=[_cp("A", Player.BLUE), _cp("B", Player.RED)])
+    baseline = _baseline(game)
+    partial = VictoryCondition(capture_cps=("A", "B"))
+    assert not condition_met(game, partial, baseline)
+    game.theater.controlpoints[1].captured = Player.BLUE
+    assert condition_met(game, VictoryCondition(capture_cps=("A", "B")), baseline)
+    # A typo'd name can never be met -- visible in the UI, never a silent win.
+    assert not condition_met(game, VictoryCondition(capture_cps=("Nope",)), baseline)
+
+
+def test_lose_cps_fires_on_any_named_red() -> None:
+    game = _game(cps=[_cp("A", Player.BLUE), _cp("B", Player.RED)])
+    baseline = _baseline(game)
+    assert condition_met(game, VictoryCondition(lose_cps=("A", "B")), baseline)
+    assert not condition_met(game, VictoryCondition(lose_cps=("A",)), baseline)
+
+
+def test_territory_thresholds() -> None:
+    game = _game(
+        cps=[
+            _cp("A", Player.BLUE),
+            _cp("B", Player.BLUE),
+            _cp("C", Player.RED),
+            _cp("N", Player.NEUTRAL),
+        ]
+    )
+    baseline = _baseline(game)
+    # 2/3 non-neutral bases are blue.
+    assert condition_met(game, VictoryCondition(territory_above=0.6), baseline)
+    assert not condition_met(game, VictoryCondition(territory_above=0.7), baseline)
+    assert condition_met(game, VictoryCondition(territory_below=0.7), baseline)
+    assert not condition_met(game, VictoryCondition(territory_below=0.5), baseline)
+
+
+def test_destroy_targets_needs_every_named_tgo_dead() -> None:
+    cp = _cp("A", Player.RED)
+    game = _game(
+        cps=[cp],
+        tgos=[
+            _tgo("HQ North", "commandcenter", cp, False, False),
+            _tgo("HQ South", "commandcenter", cp, True),
+        ],
+    )
+    baseline = _baseline(game)
+    assert condition_met(
+        game, VictoryCondition(destroy_targets=("hq north",)), baseline
+    )
+    both = VictoryCondition(destroy_targets=("HQ North", "HQ South"))
+    assert not condition_met(game, both, baseline)
+    # A name matching nothing can never be met.
+    missing = VictoryCondition(destroy_targets=("HQ West",))
+    assert not condition_met(game, missing, baseline)
+
+
+def test_destroy_categories_baseline_guards_the_vacuous_win() -> None:
+    cp = _cp("A", Player.RED)
+    game = _game(cps=[cp], tgos=[_tgo("Comms", "comms", cp, True)])
+    baseline = _baseline(game)
+    cond = VictoryCondition(destroy_categories=("comms",))
+    assert not condition_met(game, cond, baseline)
+    game.theater.ground_objects[0].units[0].alive = False
+    assert condition_met(game, cond, baseline)
+    # A category the campaign never fielded can never produce a win.
+    absent = VictoryCondition(destroy_categories=("power",))
+    assert not condition_met(game, absent, baseline)
+
+
+def test_destroy_categories_capturing_the_site_counts_as_denial() -> None:
+    # The last comms site's base gets CAPTURED intact: red owns no alive comms
+    # any more, which is the condition's meaning ("the enemy no longer operates
+    # any"), and the baseline proves the class existed.
+    cp = _cp("A", Player.RED)
+    game = _game(cps=[cp], tgos=[_tgo("Comms", "comms", cp, True)])
+    baseline = _baseline(game)
+    cp.captured = Player.BLUE
+    assert condition_met(
+        game, VictoryCondition(destroy_categories=("comms",)), baseline
+    )
+
+
+def test_strength_ratios_measure_against_the_baseline() -> None:
+    game = _game(red_air=(10, 10), blue_air=(8,))
+    baseline = _baseline(game)
+    assert baseline.red_air == 20
+    cond = VictoryCondition(enemy_air_below=0.5)
+    assert not condition_met(game, cond, baseline)
+    # Red loses one whole squadron: 10/20 is not < 0.5 ...
+    game.air_wing_for(Player.RED).iter_squadrons()[0].owned_aircraft = 0
+    assert not condition_met(game, cond, baseline)
+    # ... one more airframe down is.
+    game.air_wing_for(Player.RED).iter_squadrons()[1].owned_aircraft = 9
+    assert condition_met(game, cond, baseline)
+
+
+def test_empty_baseline_never_fires_a_ratio_condition() -> None:
+    game = _game(red_air=(0,))
+    baseline = _baseline(game)
+    assert not condition_met(game, VictoryCondition(enemy_air_below=0.9), baseline)
+    assert not condition_met(game, VictoryCondition(enemy_ground_below=0.9), baseline)
+
+
+def test_ground_and_friendly_ratios() -> None:
+    game = _game(
+        cps=[_cp("A", Player.RED, armor=10), _cp("B", Player.BLUE, armor=4)],
+        blue_air=(10,),
+    )
+    baseline = _baseline(game)
+    assert baseline.red_ground == 10
+    game.theater.controlpoints[0].base.total_armor = 1
+    assert condition_met(game, VictoryCondition(enemy_ground_below=0.2), baseline)
+    game.air_wing_for(Player.BLUE).iter_squadrons()[0].owned_aircraft = 2
+    assert condition_met(game, VictoryCondition(friendly_air_below=0.3), baseline)
+
+
+def test_air_denial_counts_operational_red_bases() -> None:
+    game = _game(
+        cps=[
+            _cp("Red field", Player.RED, operational=True),
+            _cp("Blue field", Player.BLUE, operational=True),
+        ]
+    )
+    baseline = _baseline(game)
+    cond = VictoryCondition(enemy_air_denied=True)
+    assert not condition_met(game, cond, baseline)
+    # Cratered/captured: the red field stops operating; blue fields never count.
+    game.theater.controlpoints[0].runway_is_operational = lambda: False
+    assert condition_met(game, cond, baseline)
+
+
+def test_and_semantics_within_one_entry() -> None:
+    game = _game(cps=[_cp("A", Player.BLUE)], red_air=(10,), turn=5)
+    baseline = _baseline(game)
+    both = VictoryCondition(capture_cps=("A",), enemy_air_below=0.5)
+    # The CP is held but the air condition is not met -> the entry is not met.
+    assert not condition_met(game, both, baseline)
+    game.air_wing_for(Player.RED).iter_squadrons()[0].owned_aircraft = 1
+    assert condition_met(game, both, baseline)
+
+
+def test_min_turn_guards_the_entry() -> None:
+    game = _game(cps=[_cp("A", Player.BLUE)], turn=2)
+    baseline = _baseline(game)
+    cond = VictoryCondition(capture_cps=("A",), min_turn=4)
+    assert not condition_met(game, cond, baseline)
+    game.turn = 4
+    assert condition_met(game, cond, baseline)
+
+
+# --- the baseline latch ---------------------------------------------------------------
+
+
+def test_baseline_latches_once() -> None:
+    game = _game(red_air=(10,))
+    first = _baseline(game)
+    game.air_wing_for(Player.RED).iter_squadrons()[0].owned_aircraft = 2
+    assert _baseline(game) is first
+    assert _baseline(game).red_air == 10
+
+
+# --- knobs + profile merge ------------------------------------------------------------
+
+
+def test_no_configuration_means_no_profile() -> None:
+    assert active_victory_profile(_game()) is None
+
+
+def test_domination_knob_synthesizes_a_win_condition() -> None:
+    game = _game(cps=[_cp("A", Player.BLUE), _cp("B", Player.RED)], domination=80)
+    profile = active_victory_profile(game)
+    assert profile is not None
+    assert profile.win_when[0].territory_above == 0.8
+    assert not profile.lose_when
+
+
+def test_attrition_knob_synthesizes_a_win_condition() -> None:
+    profile = active_victory_profile(_game(attrition=10))
+    assert profile is not None
+    assert profile.win_when[0].enemy_air_below == 0.1
+
+
+def test_authored_profile_and_knobs_stack() -> None:
+    authored = VictoryProfile(
+        description="Test war",
+        win_when=(VictoryCondition(capture_cps=("A",)),),
+        lose_when=(VictoryCondition(lose_cps=("B",)),),
+    )
+    victory_mod._PROFILE_CACHE["Test Campaign"] = authored
+    game = _game(campaign_name="Test Campaign", attrition=10)
+    profile = active_victory_profile(game)
+    assert profile is not None
+    assert profile.description == "Test war"
+    assert len(profile.win_when) == 2
+    assert profile.win_when[0].capture_cps == ("A",)
+    assert profile.win_when[1].enemy_air_below == 0.1
+    assert len(profile.lose_when) == 1
+
+
+# --- the verdict ----------------------------------------------------------------------
+
+
+def test_verdict_none_without_configuration() -> None:
+    assert victory_verdict(_game(cps=[_cp("A", Player.BLUE)])) is None
+
+
+def test_verdict_win_announces_once() -> None:
+    game = _game(cps=[_cp("A", Player.BLUE), _cp("B", Player.RED)], domination=50)
+    assert victory_verdict(game) == "win"
+    assert victory_verdict(game) == "win"
+    banners = [m for m in game.messages if m[0] == "Victory condition met"]
+    assert len(banners) == 1
+    assert "50%" in banners[0][1]
+
+
+def test_loss_takes_precedence_over_a_simultaneous_win() -> None:
+    authored = VictoryProfile(
+        win_when=(VictoryCondition(capture_cps=("A",)),),
+        lose_when=(VictoryCondition(lose_cps=("B",)),),
+    )
+    victory_mod._PROFILE_CACHE["Test Campaign"] = authored
+    game = _game(
+        cps=[_cp("A", Player.BLUE), _cp("B", Player.RED)],
+        campaign_name="Test Campaign",
+    )
+    assert victory_verdict(game) == "loss"
+    assert game.messages[0][0] == "Defeat condition met"
+
+
+def test_verdict_uses_the_label_in_the_banner() -> None:
+    authored = VictoryProfile(
+        win_when=(VictoryCondition(label="Take the coast", capture_cps=("A",)),),
+    )
+    victory_mod._PROFILE_CACHE["Test Campaign"] = authored
+    game = _game(cps=[_cp("A", Player.BLUE)], campaign_name="Test Campaign")
+    assert victory_verdict(game) == "win"
+    assert game.messages[0] == ("Victory condition met", "Take the coast")
+
+
+# --- the real check_win_loss branch order ---------------------------------------------
+
+
+def test_check_win_loss_wiring() -> None:
+    # Drive the REAL Game.check_win_loss with a duck-typed self: the victory
+    # branch wins on the domination knob, and with nothing configured the
+    # stock territory checks still rule.
+    from game.game import Game, TurnState
+
+    cps = [_cp("A", Player.BLUE), _cp("B", Player.RED)]
+    game = _game(cps=cps, domination=50)
+    game.theater.player_points = lambda state_check=False: [cps[0]]
+    game.theater.enemy_points = lambda state_check=False: [cps[1]]
+    assert Game.check_win_loss(cast(Any, game)) is TurnState.WIN
+
+    quiet = _game(cps=cps)
+    quiet.theater.player_points = lambda state_check=False: [cps[0]]
+    quiet.theater.enemy_points = lambda state_check=False: [cps[1]]
+    assert Game.check_win_loss(cast(Any, quiet)) is TurnState.CONTINUE
+
+
+# --- display prose --------------------------------------------------------------------
+
+
+def test_describe_live_prose() -> None:
+    authored_win = VictoryCondition(enemy_air_below=0.1)
+    authored_loss = VictoryCondition(lose_cps=("B",))
+    game = _game(cps=[_cp("B", Player.BLUE)], red_air=(10,))
+    baseline = _baseline(game)
+    assert (
+        describe_condition(game, authored_win, baseline)
+        == "Enemy air force below 10% of start (now 100%)"
+    )
+    assert (
+        describe_condition(game, authored_loss, baseline)
+        == "B falls to the enemy (0/1 fallen)"
+    )
+
+
+def test_describe_without_live_values() -> None:
+    game = _game(cps=[_cp("A", Player.BLUE)])
+    baseline = _baseline(game)
+    text = describe_condition(
+        game, VictoryCondition(capture_cps=("A",)), baseline, live=False
+    )
+    assert text == "Capture A"


### PR DESCRIPTION
## What

Alternate, legible ends to the war. The stock win condition is total conquest — `check_win_loss` returns WIN only when the enemy owns zero control points — which forces every campaign, including a limited war ("liberate the coast", a maritime pressure campaign), into a full ground invasion. This adds the community-requested shallow layer over that default, in two tiers over one engine (`game/victory.py`):

**Authored tier** — a campaign YAML `victory:` block declaring `win_when` / `lose_when` condition lists:

```yaml
victory:
  description: Liberate the coast
  win_when:
    - label: Take the coast
      capture_cps: [Sukhumi-Babushara, Gudauta]
    - enemy_air_below: 0.25   # attrit their air force to a quarter of start
      min_turn: 4             # guard: not before turn 4
  lose_when:
    - lose_cps: [Kutaisi]
```

Available condition fields: `capture_cps` (all named CPs blue) · `lose_cps` (any named CP red) · `territory_above` / `territory_below` (fraction of non-neutral CPs) · `destroy_targets` (all named TGOs fully dead) · `destroy_categories` (no red TGO of the class left alive) · `enemy_air_below` / `enemy_ground_below` / `friendly_air_below` (strength vs. the campaign-start baseline) · `enemy_air_denied` (no red CP with an operational runway) · `min_turn` guard · `label`.

**Generic tier** — two opt-in Settings knobs usable on ANY campaign with zero authoring (Campaign Management → Victory Conditions, both default 0 = off): **domination** (hold ≥ N% of the bases) and **attrition** (enemy air below N% of start, capped at 90 — "below 95%" would be a losses counter, not a victory condition). They synthesize into the same condition objects and stack with an authored block.

## Design decisions

- **A victory entry is a requirement, not a trigger**: EVERY field set on one entry must hold (AND within the entry); the `win_when` / `lose_when` lists are OR (any fully-met entry ends the war). That is what makes `min_turn` a guard ("not before turn 4") instead of nonsense ("win at turn 4").
- **Alternate endings ADD to the stock endings, never replace them.** Capturing everything still wins, losing everything still loses. Loss precedence on a simultaneous win+loss — a collapse is never a cheap win.
- **No vacuous wins.** Ratio conditions measure against a campaign-start `VictoryBaseline` latched in `initialize_turn` (getattr-guarded, so old saves latch on first load and need no migration); an empty baseline never fires. `destroy_categories` also requires the baseline to have counted at least one object of the class, so a category the campaign never fielded can't produce an instant win. A typo'd CP/TGO name can never be met — visible, never a silent win.
- **`enemy_air_denied`** counts `runway_is_operational()` — cratered airfields and sunk carriers are denied, FOB helipads count as air power, and a red off-map spawn is always operational, so the condition is unreachable on those campaigns by construction.
- **Announce once**: when a condition ends the war, `game.message()` names it ("Victory condition met — Take the coast") beside the generic Victory!/Defeat! dialog, latched per condition text because the UI flow calls `check_win_loss` several times around a turn boundary.
- **Zero planner coupling.** Ground truth, turn-boundary only; the AI commander never reads these conditions.
- Authored blocks are re-derived from the campaign YAML by name at load and never pickled; any lookup/parse failure degrades to "no profile" with a log (an old save whose campaign was removed still plays with the stock endings), while a broken block fails loudly in `parse_victory` so campaign CI catches it.

## Provenance

Running in the 414th fork (as fork feature §75) with the same engine + 30 of these tests; the fork additionally renders the conditions as a live checklist on its map-ribbon UI — `describe_condition(live=True)` ("Capture Sukhumi, Gudauta (1/2 held)") is the building block for that display and ships here, so a UI surface is a small follow-up if wanted.

## Testing

- `pytest tests` — 466 passed, 2 skipped (28 new tests: parse validation, every condition field, AND/OR semantics, baseline latch + no-vacuous-win guards, knob synthesis + stacking, loss precedence, the announce latch, and the real `Game.check_win_loss` branch order driven duck-typed)
- `mypy game tests` — no issues (490 files)
- `black --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
