### PR TITLE
Don't crash New Game on an authored-but-empty squadron aircraft: key

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 * **[Campaigns]** Ability to define motor pool objects which spawn reserve armor
 * 
 ## Fixes
+* **[Engine]** A campaign squadron entry with an empty `aircraft:` key no longer crashes New Game generation — it is treated as an empty list. (#890)
 * **[Mission Generator]** EWR sites now get the DCS "EWR" enroute task and come up on RED alarm, so their radars actually scan and report contacts (previously they could sit inert, especially with the "red alert state" performance option off). Works with or without the Skynet IADS plugin.
 * **[Plugins]** Fix the escort leash never running (DCS has no `Group.getByID`; look the group up by name via mist), so escorts are actually held to their engagement range.
 * **[Mission Planning]** Carrier/LHA targets now offer SEAD in the flight-task list and no longer list SEAD Escort twice (their escorts are SAM platforms, so they can be suppressed directly like any other naval group).

--- a/game/campaignloader/campaignairwingconfig.py
+++ b/game/campaignloader/campaignairwingconfig.py
@@ -46,7 +46,10 @@ class SquadronConfig:
         return SquadronConfig(
             FlightType(data["primary"]),
             secondary,
-            data.get("aircraft", []),
+            # `aircraft:` authored but left empty parses as None; treat it as "any
+            # aircraft compatible with the primary task" (the find_squadron_for
+            # fallback) instead of crashing DefaultSquadronAssigner at New Game.
+            data.get("aircraft") or [],
             max_size,
             data.get("name", None),
             data.get("nickname", None),

--- a/tests/campaignloader/test_squadron_config.py
+++ b/tests/campaignloader/test_squadron_config.py
@@ -1,0 +1,19 @@
+from game.ato.flighttype import FlightType
+from game.campaignloader.campaignairwingconfig import SquadronConfig
+
+
+def test_empty_aircraft_key_parses_as_no_preference() -> None:
+    # An authored-but-empty `aircraft:` key parses as None, and
+    # DefaultSquadronAssigner iterates config.aircraft — without the guard that
+    # is a TypeError at New Game. Empty means "any aircraft compatible with the
+    # primary task", same as omitting the key entirely.
+    config = SquadronConfig.from_data({"primary": "BARCAP", "aircraft": None})
+    assert config.aircraft == []
+    assert config.primary is FlightType.BARCAP
+
+
+def test_aircraft_preferences_pass_through() -> None:
+    config = SquadronConfig.from_data(
+        {"primary": "BARCAP", "aircraft": ["F-14B Tomcat"]}
+    )
+    assert config.aircraft == ["F-14B Tomcat"]


### PR DESCRIPTION
Defensive two-character guard for an easy campaign-authoring accident.

A squadron entry with an **authored-but-empty** `aircraft:` key —

```yaml
- primary: Transport
  secondary: any
  aircraft:
  size: 2
```

— parses the key as `None`, `data.get("aircraft", [])` passes the `None` straight through (the key exists, so the default never applies), and `DefaultSquadronAssigner` then iterates `config.aircraft` (defaultsquadronassigner.py:61) → `TypeError: 'NoneType' object is not iterable` **at New Game**, killing the whole campaign.

This is exactly what a campaign ends up with whenever an author removes a squadron's aircraft entries but leaves the key — e.g. stripping a mod aircraft out of a list (which is how we hit it on our fork: purging a mod plane from a campaign copy left `aircraft:` empty and New Game crashed).

## Change

`data.get("aircraft", [])` → `data.get("aircraft") or []`: an empty key now means the same as an omitted key — "any aircraft compatible with the primary task" (the existing `find_squadron_for` fallback).

Test: `tests/campaignloader/test_squadron_config.py` pins None → `[]` and that real preferences still pass through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
