### PR TITLE
Load blue-block miz markers — 465 authored markers in 9 shipped campaigns never generate

### DIFF
--- a/game/campaignloader/mizcampaignloader.py
+++ b/game/campaignloader/mizcampaignloader.py
@@ -189,45 +189,54 @@ class MizCampaignLoader:
             if group.units[0].type == self.NEUTRAL_FOB_UNIT_TYPE:
                 yield group
 
+    # Marker-block convention: the RED country block is the coalition-agnostic
+    # default marker block (campaigns author BLUE SAM/EWR sites as red-block
+    # markers near blue fields and proximity decides the owner), so red-block
+    # markers bind to the nearest CP of either side. A group authored in the
+    # BLUE block is an explicit blue-ownership declaration: it was silently
+    # dropped for the classes below (22 authored markers across 7 shipped
+    # campaigns never generated), and now binds with blue preference (see
+    # objective_info).
+
     @property
     def ships(self) -> Iterator[ShipGroup]:
-        for group in self.red.ship_group:
+        for group in itertools.chain(self.blue.ship_group, self.red.ship_group):
             if group.units[0].type == self.SHIP_UNIT_TYPE:
                 yield group
 
     @property
     def offshore_strike_targets(self) -> Iterator[StaticGroup]:
-        for group in self.red.static_group:
+        for group in itertools.chain(self.blue.static_group, self.red.static_group):
             if group.units[0].type == self.OFFSHORE_STRIKE_TARGET_UNIT_TYPE:
                 yield group
 
     @property
     def missile_sites(self) -> Iterator[VehicleGroup]:
-        for group in self.red.vehicle_group:
+        for group in itertools.chain(self.blue.vehicle_group, self.red.vehicle_group):
             if group.units[0].type == self.MISSILE_SITE_UNIT_TYPE:
                 yield group
 
     @property
     def coastal_defenses(self) -> Iterator[VehicleGroup]:
-        for group in self.red.vehicle_group:
+        for group in itertools.chain(self.blue.vehicle_group, self.red.vehicle_group):
             if group.units[0].type == self.COASTAL_DEFENSE_UNIT_TYPE:
                 yield group
 
     @property
     def long_range_sams(self) -> Iterator[VehicleGroup]:
-        for group in self.red.vehicle_group:
+        for group in itertools.chain(self.blue.vehicle_group, self.red.vehicle_group):
             if group.units[0].type in self.LONG_RANGE_SAM_UNIT_TYPES:
                 yield group
 
     @property
     def medium_range_sams(self) -> Iterator[VehicleGroup]:
-        for group in self.red.vehicle_group:
+        for group in itertools.chain(self.blue.vehicle_group, self.red.vehicle_group):
             if group.units[0].type in self.MEDIUM_RANGE_SAM_UNIT_TYPES:
                 yield group
 
     @property
     def short_range_sams(self) -> Iterator[VehicleGroup]:
-        for group in self.red.vehicle_group:
+        for group in itertools.chain(self.blue.vehicle_group, self.red.vehicle_group):
             if group.units[0].type in self.SHORT_RANGE_SAM_UNIT_TYPES:
                 yield group
 
@@ -239,7 +248,7 @@ class MizCampaignLoader:
 
     @property
     def ewrs(self) -> Iterator[VehicleGroup]:
-        for group in self.red.vehicle_group:
+        for group in itertools.chain(self.blue.vehicle_group, self.red.vehicle_group):
             if group.units[0].type in self.EWR_UNIT_TYPE:
                 yield group
 
@@ -535,8 +544,43 @@ class MizCampaignLoader:
                 origin, list(reversed(waypoints))
             )
 
+    @cached_property
+    def _blue_block_group_ids(self) -> set[int]:
+        """Object ids of every group authored in the BLUE country block.
+
+        Consulted by objective_info ONLY for marker classes (callers that pass
+        prefer_blue -- SAM/EWR/missile/coastal/ship/offshore): for those, a
+        blue-block group is an explicit blue-ownership declaration and binds a
+        nearby blue control point. The economy objects (armor/factories/ammo/
+        strike) are also authored in the blue block by convention but must NOT
+        get the preference -- they bind by proximity like everything else, so
+        their callers leave prefer_blue False. Red-block groups get no
+        preference either: the red block is the coalition-agnostic default
+        marker block, whose markers bind by proximity to either side (blue air
+        defenses are conventionally authored as red-block markers near blue
+        fields).
+        """
+        ids: set[int] = set()
+        for collection in (
+            self.blue.vehicle_group,
+            self.blue.ship_group,
+            self.blue.static_group,
+            self.blue.plane_group,
+        ):
+            for group in collection:
+                ids.add(id(group))
+        return ids
+
+    # How much farther a blue control point may be than the marker's nearest
+    # field before the blue-block preference is dropped and proximity decides
+    # (see objective_info). Legitimate near-field markers (Operation Dynamo's
+    # evacuation flotilla, ~30 km) sit well under this; without the bound, a
+    # blue-block object sitting on an enemy base far from any blue field would
+    # be yanked across the map to it.
+    BLUE_BLOCK_MAX_DETOUR = meters(50000)
+
     def objective_info(
-        self, near: Positioned, allow_naval: bool = False
+        self, near: Positioned, allow_naval: bool = False, prefer_blue: bool = False
     ) -> Tuple[ControlPoint, Distance]:
         zones_containing_point = [
             z
@@ -597,50 +641,80 @@ class MizCampaignLoader:
             raise RuntimeError(
                 f"All control points have an influence zone but no zones contain {near} at {near.position}"
             )
+        # A blue-block MARKER (SAM/EWR/missile/coastal/ship/offshore -- callers
+        # that pass prefer_blue) binds the nearest BLUE control point when one
+        # is reasonably close, not merely the nearest of either side: authoring
+        # a marker in the blue block is an explicit ownership declaration, and
+        # nearest-any binding can hand it to the enemy field next door, where
+        # the objective then silently never generates (the owning faction has
+        # no ForceGroup for the other side's hardware). The preference is
+        # scoped to those marker classes and bounded by BLUE_BLOCK_MAX_DETOUR:
+        # the blue block also holds the economy objects (armor/factories/ammo/
+        # strike, authored blue-side as a convention), and an unbounded,
+        # all-class preference would re-own enemy-territory economy objects to
+        # distant blue fields across the map. Authored influence zones above
+        # stay authoritative.
         closest = min(
             fallback_candidates,
             key=lambda cp: cp.position.distance_to_point(near.position),
         )
+        if prefer_blue and id(near) in self._blue_block_group_ids:
+            friendly = [
+                cp for cp in fallback_candidates if cp.starting_coalition is Player.BLUE
+            ]
+            if friendly:
+                nearest_blue = min(
+                    friendly,
+                    key=lambda cp: cp.position.distance_to_point(near.position),
+                )
+                detour = meters(
+                    nearest_blue.position.distance_to_point(near.position)
+                    - closest.position.distance_to_point(near.position)
+                )
+                if detour <= self.BLUE_BLOCK_MAX_DETOUR:
+                    closest = nearest_blue
         distance = meters(closest.position.distance_to_point(near.position))
         return closest, distance
 
     def add_preset_locations(self) -> None:
         for static in self.offshore_strike_targets:
-            closest, distance = self.objective_info(static)
+            closest, distance = self.objective_info(static, prefer_blue=True)
             closest.preset_locations.offshore_strike_locations.append(
                 PresetLocation.from_group(static)
             )
 
         for ship in self.ships:
-            closest, distance = self.objective_info(ship, allow_naval=True)
+            closest, distance = self.objective_info(
+                ship, allow_naval=True, prefer_blue=True
+            )
             closest.preset_locations.ships.append(PresetLocation.from_group(ship))
 
         for group in self.missile_sites:
-            closest, distance = self.objective_info(group)
+            closest, distance = self.objective_info(group, prefer_blue=True)
             closest.preset_locations.missile_sites.append(
                 PresetLocation.from_group(group)
             )
 
         for group in self.coastal_defenses:
-            closest, distance = self.objective_info(group)
+            closest, distance = self.objective_info(group, prefer_blue=True)
             closest.preset_locations.coastal_defenses.append(
                 PresetLocation.from_group(group)
             )
 
         for group in self.long_range_sams:
-            closest, distance = self.objective_info(group)
+            closest, distance = self.objective_info(group, prefer_blue=True)
             closest.preset_locations.long_range_sams.append(
                 PresetLocation.from_group(group)
             )
 
         for group in self.medium_range_sams:
-            closest, distance = self.objective_info(group)
+            closest, distance = self.objective_info(group, prefer_blue=True)
             closest.preset_locations.medium_range_sams.append(
                 PresetLocation.from_group(group)
             )
 
         for group in self.short_range_sams:
-            closest, distance = self.objective_info(group)
+            closest, distance = self.objective_info(group, prefer_blue=True)
             closest.preset_locations.short_range_sams.append(
                 PresetLocation.from_group(group)
             )
@@ -650,7 +724,7 @@ class MizCampaignLoader:
             closest.preset_locations.aaa.append(PresetLocation.from_group(group))
 
         for group in self.ewrs:
-            closest, distance = self.objective_info(group)
+            closest, distance = self.objective_info(group, prefer_blue=True)
             closest.preset_locations.ewrs.append(PresetLocation.from_group(group))
 
         for group in self.armor_groups:

--- a/game/theater/start_generator.py
+++ b/game/theater/start_generator.py
@@ -497,7 +497,13 @@ class AirbaseGroundObjectGenerator(ControlPointGroundObjectGenerator):
                 GroupTask.EARLY_WARNING_RADAR
             )
             if not unit_group:
-                logging.error(f"{self.faction_name} has no ForceGroup for EWR")
+                logging.error(
+                    f"{self.faction_name} has no ForceGroup for EWR -- the "
+                    f"marker {position.original_name!r} bound to "
+                    f"{self.control_point.name} at ({position.x:.0f}, "
+                    f"{position.y:.0f}) will not generate (misplaced marker "
+                    "binding to the wrong side's control point?)"
+                )
                 return
             self.generate_ground_object_from_group(
                 unit_group, position, GroupTask.EARLY_WARNING_RADAR

--- a/tests/test_miz_marker_binding.py
+++ b/tests/test_miz_marker_binding.py
@@ -1,0 +1,169 @@
+"""Blue-block miz markers generate, and bind to blue control points.
+
+The RED country block is the coalition-agnostic default marker block: blue air
+defenses are conventionally authored as red-block markers near blue fields and
+proximity decides the owner. But a marker authored in the BLUE block was
+silently dropped for most classes (ships / SAMs / EWRs / missile / coastal /
+offshore strike) -- 22 authored markers across 7 shipped campaigns never
+generated -- and the classes that did walk both blocks bound coalition-blind,
+so one side's marker could be handed to the other, where the objective then
+silently never generates.
+
+Contract locked here: every marker class also walks the blue block; a
+blue-block MARKER binds the nearest BLUE control point when one is reasonably
+close (bounded by BLUE_BLOCK_MAX_DETOUR, scoped to marker classes only so the
+blue-block economy objects keep binding by proximity); red-block markers keep
+the nearest-any proximity convention.
+"""
+
+from pathlib import Path
+
+import pytest
+from dcs.countries import (
+    CombinedJointTaskForcesBlue,
+    CombinedJointTaskForcesRed,
+)
+from dcs.mission import Mission
+from dcs.statics import Fortification
+from dcs.terrain.caucasus import Caucasus
+from dcs.vehicles import AirDefence
+
+from game import persistency
+from game.campaignloader.mizcampaignloader import MizCampaignLoader
+from game.theater.theaterloader import TheaterLoader
+
+
+@pytest.fixture(autouse=True)
+def _init_persistency(tmp_path_factory: pytest.TempPathFactory) -> None:
+    persistency.setup(
+        str(tmp_path_factory.mktemp("saved_games")),
+        prefer_liberation_payloads=False,
+        port=0,
+    )
+
+
+def _build_test_miz(path: Path) -> None:
+    mission = Mission(terrain=Caucasus())
+    blue_field = mission.terrain.airports["Kutaisi"]
+    red_field = mission.terrain.airports["Senaki-Kolkhi"]
+    blue_field.set_blue()
+    red_field.set_red()
+
+    blue_country = CombinedJointTaskForcesBlue()
+    red_country = CombinedJointTaskForcesRed()
+    mission.coalition["blue"].add_country(blue_country)
+    mission.coalition["red"].add_country(red_country)
+
+    # A BLUE-block EWR marker planted right next to the RED field: nearest-any
+    # binding would hand it to red, but the blue block declares blue ownership.
+    mission.vehicle_group(
+        blue_country,
+        "Blue EWR marker",
+        AirDefence.x_1L13_EWR,
+        red_field.position.point_from_heading(45, 3000),
+    )
+
+    # A RED-block SHORAD marker next to the BLUE field: the coalition-agnostic
+    # proximity convention must keep binding it to the blue field (this is how
+    # campaigns conventionally author blue air defenses).
+    mission.vehicle_group(
+        red_country,
+        "Red block SHORAD marker",
+        AirDefence.Strela_1_9P31,
+        blue_field.position.point_from_heading(90, 3000),
+    )
+
+    mission.save(str(path))
+
+
+def test_marker_coalition_binding(tmp_path: Path) -> None:
+    miz = tmp_path / "marker_binding.miz"
+    _build_test_miz(miz)
+
+    theater = TheaterLoader("caucasus").load()
+    MizCampaignLoader(miz, theater).populate_theater()
+
+    kutaisi = theater.control_point_named("Kutaisi")
+    senaki = theater.control_point_named("Senaki-Kolkhi")
+
+    # The blue-block EWR generated at all (was silently dropped) and bound the
+    # blue field even though the red field is 3 km away.
+    assert len(kutaisi.preset_locations.ewrs) == 1
+    assert not senaki.preset_locations.ewrs
+
+    # The red-block marker still binds by proximity: blue field owns it.
+    assert len(kutaisi.preset_locations.short_range_sams) == 1
+    assert not senaki.preset_locations.short_range_sams
+
+
+def _build_scoping_miz(path: Path) -> None:
+    """Kutaisi (blue) far from two red fields, with blue-block objects on the
+    red fields: an economy object (factory) and a marker (EWR) beyond the
+    detour bound, plus a near-field marker that should still prefer blue."""
+    mission = Mission(terrain=Caucasus())
+    kutaisi = mission.terrain.airports["Kutaisi"]  # blue
+    senaki = mission.terrain.airports["Senaki-Kolkhi"]  # red, ~37 km from Kutaisi
+    min_vody = mission.terrain.airports["Mineralnye Vody"]  # red, ~235 km away
+    kutaisi.set_blue()
+    senaki.set_red()
+    min_vody.set_red()
+
+    blue_country = CombinedJointTaskForcesBlue()
+    red_country = CombinedJointTaskForcesRed()
+    mission.coalition["blue"].add_country(blue_country)
+    mission.coalition["red"].add_country(red_country)
+
+    # Blue-block FACTORY sitting on the distant red field. The blue block holds
+    # the economy objects by convention; an all-class preference would re-own
+    # them to distant blue fields. It must bind the red field it sits on.
+    mission.static_group(
+        blue_country,
+        "Blue block factory",
+        Fortification.Workshop_A,
+        min_vody.position.point_from_heading(0, 3000),
+    )
+
+    # Blue-block EWR on the distant red field: nearest blue field (Kutaisi) is
+    # ~235 km away, far past BLUE_BLOCK_MAX_DETOUR, so proximity decides.
+    mission.vehicle_group(
+        blue_country,
+        "Blue EWR far",
+        AirDefence.x_1L13_EWR,
+        min_vody.position.point_from_heading(45, 3000),
+    )
+
+    # Blue-block EWR next to the near red field (~37 km detour, within the
+    # bound): the near-field preference still binds the blue field.
+    mission.vehicle_group(
+        blue_country,
+        "Blue EWR near",
+        AirDefence.x_1L13_EWR,
+        senaki.position.point_from_heading(45, 3000),
+    )
+
+    mission.save(str(path))
+
+
+def test_blue_block_preference_is_scoped_and_bounded(tmp_path: Path) -> None:
+    miz = tmp_path / "scoping.miz"
+    _build_scoping_miz(miz)
+
+    theater = TheaterLoader("caucasus").load()
+    MizCampaignLoader(miz, theater).populate_theater()
+
+    kutaisi = theater.control_point_named("Kutaisi")
+    senaki = theater.control_point_named("Senaki-Kolkhi")
+    min_vody = theater.control_point_named("Mineralnye Vody")
+
+    # Economy object is never preferred to a distant blue field -- binds the
+    # red field it sits on.
+    assert len(min_vody.preset_locations.factories) == 1
+    assert not kutaisi.preset_locations.factories
+
+    # Marker beyond the detour bound binds by proximity (the red field), not
+    # the 235 km-distant blue field.
+    assert len(min_vody.preset_locations.ewrs) == 1
+
+    # Marker within the detour bound still prefers the blue field.
+    assert len(kutaisi.preset_locations.ewrs) == 1
+    assert not senaki.preset_locations.ewrs


### PR DESCRIPTION
`MizCampaignLoader` reads ships / offshore-strike / missile / coastal / LORAD / MERAD / SHORAD / EWR markers from the **RED country block only** — a marker authored in the BLUE block is silently dropped. A sweep of the shipped campaigns finds **465 authored blue-block markers across 9 campaigns that never generate**:

| campaign | dropped markers |
|---|---|
| normandy_full | **352** (SHORAD/missile/coastal belts) |
| normandy_small | **91** (75 SHORAD + 9 missile + 7 coastal) |
| operation_dynamo | 9 (the evacuation flotilla ships) |
| operation_allied_sword | 7 (oil platforms) |
| syria_full_map | 2 |
| golan_heights_lite / mozdok_to_maykop / RetakeTheFalklands / tripoint_hostility | 1 each |

(Marker units in the blue block — Tunguska/Scud/Silkworm placeholders on a WW2 map — are unambiguous authoring intent; the generator substitutes faction-appropriate hardware as usual.)

## What this does

1. **Every marker class also walks the blue block** (`itertools.chain(self.blue…, self.red…)`), the same way `aaa`/`armor_groups`/`helipads` already do.
2. **A blue-block marker prefers the nearest BLUE control point** — authoring in the blue block is an explicit ownership declaration, and nearest-any binding can hand the marker to the enemy field next door, where the objective then *silently never generates* (the owning faction has no ForceGroup for the other side's hardware; the only trace is a log line). Two guards keep this surgical:
   - **Scoped**: only the marker-class callers pass `prefer_blue` — the economy objects (armor/factories/ammo/strike) are *also* authored blue-block by convention and must keep binding by proximity, or red's economy would be re-owned to distant blue fields. (We shipped the unbounded version first on our fork and it re-owned 782 economy objects across the campaign set — Sperenberg's factory bound Frankfurt 408 km away. The scoping below is the corrected, verified shape.)
   - **Bounded** by `BLUE_BLOCK_MAX_DETOUR` (50 km): a legit near-field marker (Dynamo's flotilla, ~30 km) binds blue; a blue-block object sitting on an enemy base far from any blue field binds by proximity instead of being yanked across the map.
3. **Red-block markers are untouched** — the red block stays the coalition-agnostic default marker block binding by proximity, which is how campaigns conventionally author *blue* defenses near blue fields; binding red markers to red CPs would strip blue's defenses across the whole campaign set and is deliberately not done.
4. `generate_ewrs`' no-ForceGroup error now names the stranded marker, the bound CP, and its coordinates, so a mis-bound marker is diagnosable from the log line alone.

## Verified

- New integration test `tests/test_miz_marker_binding.py` (synthetic Caucasus miz built with pydcs): blue-block EWR planted 3 km from a red field generates and binds the blue field; red-block SHORAD next to a blue field still binds it by proximity; a blue-block **factory** on a distant red field binds the red field (scoping); a blue-block EWR beyond the detour bound binds by proximity; one within the bound binds blue.
- `normandy_small` headless end-to-end with the patch: `populate_theater` completes; the 75 SHORAD markers bind 54 blue / 21 by proximity; missile + coastal sites land on blue CPs.
- Full suite 440 passed, Black + mypy clean.

## ⚠️ One judgment call for you

The Normandy campaigns dominate the count (443 of the 465). Those markers are authored content that has plausibly been dead since the campaign-loader rework — resurrecting them is a real balance/density change for two campaigns that have been played for years without them (and Normandy was deliberately decluttered once, bfa0e4ba). If you'd rather keep the mechanical fix but not the Normandy resurrection, I'm happy to add a commit pruning/re-blocking those markers in the two Normandy mizzes — the fix itself is campaign-agnostic either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
