### PR TITLE
Pin pre-commit and github actions to black 26.5.1 to ensure they're the same between dev + ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - uses: psf/black@stable
         with:
-          src: "."
-          options: "--check"
+          python-version: "3.11"
+      - name: Install Black
+        run: python -m pip install "$(grep '^black==' requirements.txt)"
+      - name: Black
+        run: black --check .
 
   mypy:
     name: Type checking

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
+  - repo: local
     hooks:
       - id: black
-        language_version: python3
+        name: black
+        entry: black
+        language: system
+        types: [python]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ anyio==3.7.1
 asgiref==3.8.1
 atomicwrites==1.4.1
 attrs==25.3.0
-black==26.3.1
+black==26.5.1
 certifi==2025.1.31
 cfgv==3.4.0
 click==8.1.8


### PR DESCRIPTION
Should fix the issue @Drexyl was seeing. I was able to reproduce locally with one of his commits and ensure that the pre-commit hook was reformatting things under 24.8.0 to a way that 26.5.1 disagreed with. 

Makes the pre-commit + ci linter use the version of black installed by the virtual env + requirements.txt so it all stays consistent against a single version to update.