### PR TITLE
only give guns a radar they can actually use (Fire Can ↔ KS-19)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,7 +25,7 @@
 * **[Campaigns]** Ability to define motor pool objects which spawn reserve armor
 * 
 ## Fixes
-* **[Mission Generator]** Generic AAA sites no longer pull in a SAM search/track radar (e.g. a Patriot STR sitting next to 8.8 cm Flak) that the guns cannot use. AAA gun-laying radars (SON-9 "Fire Can") are now a dedicated unit class, and the AAA Site layout's optional radar slot only accepts them, so a faction without a suitable AAA radar simply gets an unradar'd gun line instead of a useless SAM radar.
+* **[Mission Generator]** Generic AAA sites no longer pull in a radar the guns cannot use (e.g. a Patriot STR sitting next to 8.8 cm Flak). The SON-9 "Fire Can" gun-laying radar is now a dedicated unit class and only appears where it is explicitly bundled with its guns (the KS-19 + SON-9 preset); generic AAA sites no longer auto-fill a radar, so a gun line without a matching radar simply spawns without one.
 * **[Mission Generator]** EWR sites now get the DCS "EWR" enroute task and come up on RED alarm, so their radars actually scan and report contacts (previously they could sit inert, especially with the "red alert state" performance option off). Works with or without the Skynet IADS plugin.
 * **[Plugins]** Fix the escort leash never running (DCS has no `Group.getByID`; look the group up by name via mist), so escorts are actually held to their engagement range.
 * **[Mission Planning]** Carrier/LHA targets now offer SEAD in the flight-task list and no longer list SEAD Escort twice (their escorts are SAM platforms, so they can be suppressed directly like any other naval group).

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 * **[Campaigns]** Ability to define motor pool objects which spawn reserve armor
 * 
 ## Fixes
+* **[Mission Generator]** Generic AAA sites no longer pull in a SAM search/track radar (e.g. a Patriot STR sitting next to 8.8 cm Flak) that the guns cannot use. AAA gun-laying radars (SON-9 "Fire Can") are now a dedicated unit class, and the AAA Site layout's optional radar slot only accepts them, so a faction without a suitable AAA radar simply gets an unradar'd gun line instead of a useless SAM radar.
 * **[Mission Generator]** EWR sites now get the DCS "EWR" enroute task and come up on RED alarm, so their radars actually scan and report contacts (previously they could sit inert, especially with the "red alert state" performance option off). Works with or without the Skynet IADS plugin.
 * **[Plugins]** Fix the escort leash never running (DCS has no `Group.getByID`; look the group up by name via mist), so escorts are actually held to their engagement range.
 * **[Mission Planning]** Carrier/LHA targets now offer SEAD in the flight-task list and no longer list SEAD Escort twice (their escorts are SAM platforms, so they can be suppressed directly like any other naval group).

--- a/game/data/units.py
+++ b/game/data/units.py
@@ -7,6 +7,7 @@ from enum import unique, Enum
 class UnitClass(Enum):
     UNKNOWN = "Unknown"
     AAA = "AAA"
+    AAA_RADAR = "AAARadar"
     AIRCRAFT_CARRIER = "AircraftCarrier"
     APC = "APC"
     ARTILLERY = "Artillery"
@@ -46,6 +47,7 @@ class UnitClass(Enum):
 # All UnitClasses which can have AntiAir capabilities
 ANTI_AIR_UNIT_CLASSES = [
     UnitClass.AAA,
+    UnitClass.AAA_RADAR,
     UnitClass.AIRCRAFT_CARRIER,
     UnitClass.CRUISER,
     UnitClass.DESTROYER,

--- a/resources/layouts/anti_air/AAA_Site.yaml
+++ b/resources/layouts/anti_air/AAA_Site.yaml
@@ -7,6 +7,10 @@ groups:
   - AAA:
     - name: AAA Site Radar
       optional: true # Optional if the AAA Site has a Radar
+      # Only presets that explicitly bundle a gun-laying radar (e.g. the KS-19 +
+      # SON-9 Fire Can preset) get a radar. Generic AAA sites must NOT be auto-filled
+      # with one, because a gun-laying radar is only useful to its matching gun.
+      fill: false
       unit_count:
         - 1
       unit_classes:

--- a/resources/layouts/anti_air/AAA_Site.yaml
+++ b/resources/layouts/anti_air/AAA_Site.yaml
@@ -10,7 +10,7 @@ groups:
       unit_count:
         - 1
       unit_classes:
-        - SearchRadar
+        - AAARadar
     - name: AAA Site
       unit_count:
         - 2

--- a/resources/units/ground_units/Fire Can radar.yaml
+++ b/resources/units/ground_units/Fire Can radar.yaml
@@ -1,4 +1,4 @@
-class: SearchRadar
+class: AAARadar
 price: 8
 variants:
   AAA SON-9 Fire Can: null

--- a/resources/units/ground_units/SON_9.yaml
+++ b/resources/units/ground_units/SON_9.yaml
@@ -1,4 +1,4 @@
-class: SearchRadar
+class: AAARadar
 price: 8
 variants:
   AAA Fire Can SON-9: {}

--- a/tests/data/test_aaa_radar.py
+++ b/tests/data/test_aaa_radar.py
@@ -6,13 +6,19 @@ from typing import Any, cast
 
 import yaml
 
+from game.armedforces.forcegroup import ForceGroup
+from game.data.groups import GroupTask
 from game.data.units import ANTI_AIR_UNIT_CLASSES, UnitClass
 from game.dcs.groundunittype import GroundUnitType
 from game.factions.faction import Faction
-from game.layout.layout import TgoLayoutUnitGroup
+from game.layout.layout import TgoLayout, TgoLayoutGroup, TgoLayoutUnitGroup
 
 # The two SON-9 "Fire Can" variants are the only stand-alone AAA gun-laying radars.
 FIRE_CAN_VARIANTS = ["AAA Fire Can SON-9", "AAA SON-9 Fire Can"]
+# A KS-19 gun, the only gun the Fire Can should ever be paired with.
+KS19_GUN_VARIANT = "AAA KS-19 100mm"
+# A non-KS-19 AAA gun, which must never be given a Fire Can.
+S60_GUN_VARIANT = "S-60 57mm"
 # A SAM search radar that must NOT be usable to cue AAA guns.
 SAM_SEARCH_RADAR_VARIANT = "SAM Patriot STR"
 
@@ -20,7 +26,7 @@ AAA_SITE_LAYOUT = Path("resources/layouts/anti_air/AAA_Site.yaml")
 
 
 def _faction_with(*units: GroundUnitType) -> Faction:
-    """Minimal Faction stand-in exposing just what possible_types_for_faction reads."""
+    """Minimal Faction stand-in exposing just what the layout code reads."""
     return cast(
         Faction,
         SimpleNamespace(
@@ -31,14 +37,37 @@ def _faction_with(*units: GroundUnitType) -> Faction:
     )
 
 
-def _aaa_radar_slot() -> TgoLayoutUnitGroup:
+def _radar_slot() -> TgoLayoutUnitGroup:
     """Mirror the generic AAA Site radar slot after the fix."""
     return TgoLayoutUnitGroup(
         name="AAA Site Radar",
         layout_units=[],
         unit_classes=[UnitClass.AAA_RADAR],
         optional=True,
+        fill=False,
     )
+
+
+def _gun_slot() -> TgoLayoutUnitGroup:
+    return TgoLayoutUnitGroup(
+        name="AAA Site",
+        layout_units=[],
+        unit_classes=[UnitClass.AAA],
+    )
+
+
+def _generic_aaa_site_layout() -> TgoLayout:
+    layout = TgoLayout("AAA Site")
+    layout.tasks = [GroupTask.AAA]
+    layout.generic = True
+    layout.groups = [
+        TgoLayoutGroup(
+            group_name="AAA",
+            group_index=0,
+            unit_groups=[_radar_slot(), _gun_slot()],
+        )
+    ]
+    return layout
 
 
 def test_fire_can_radars_are_aaa_radar() -> None:
@@ -58,26 +87,55 @@ def test_sam_search_radar_class_unchanged() -> None:
     )
 
 
-def test_aaa_radar_slot_rejects_sam_search_radar() -> None:
-    # A faction whose only radar is a SAM search radar gets no radar for the AAA
-    # slot rather than a useless Patriot STR. The slot is optional, so this is empty.
-    patriot = GroundUnitType.named(SAM_SEARCH_RADAR_VARIANT)
-    faction = _faction_with(patriot)
-    assert _aaa_radar_slot().possible_types_for_faction(faction) == []
-
-
-def test_aaa_radar_slot_accepts_fire_can() -> None:
+def test_generic_aaa_site_never_gets_a_fire_can() -> None:
+    # A faction with a Fire Can and a non-KS-19 gun must NOT produce a generic AAA
+    # site that pairs the Fire Can with those guns: the radar slot does not auto-fill.
     fire_can = GroundUnitType.named(FIRE_CAN_VARIANTS[0])
-    patriot = GroundUnitType.named(SAM_SEARCH_RADAR_VARIANT)
-    # Even when a SAM search radar is also accessible, only the Fire Can is offered.
-    faction = _faction_with(fire_can, patriot)
-    assert _aaa_radar_slot().possible_types_for_faction(faction) == [
+    s60 = GroundUnitType.named(S60_GUN_VARIANT)
+    faction = _faction_with(fire_can, s60)
+
+    force_group = ForceGroup.for_layout(_generic_aaa_site_layout(), faction)
+
+    assert s60 in force_group.units
+    assert fire_can not in force_group.units
+
+
+def test_bundled_ks19_preset_pairs_fire_can_with_ks19() -> None:
+    # The preset path (KS-19 + SON-9 bundled together) still pairs them: the radar
+    # slot offers the Fire Can and the gun slot offers the KS-19.
+    fire_can = GroundUnitType.named(FIRE_CAN_VARIANTS[0])
+    ks19 = GroundUnitType.named(KS19_GUN_VARIANT)
+    force_group = ForceGroup(
+        name="KS-19/SON-9",
+        units=[fire_can, ks19],
+        statics=[],
+        tasks=[GroupTask.AAA],
+        layouts=[],
+    )
+
+    assert force_group.dcs_unit_types_for_group(_radar_slot()) == [
         fire_can.dcs_unit_type
     ]
+    assert ks19.dcs_unit_type in force_group.dcs_unit_types_for_group(_gun_slot())
 
 
-def test_aaa_site_layout_requires_aaa_radar() -> None:
-    # Guard the layout file itself: the radar slot must ask for AAA radars only.
+def test_non_ks19_bundle_gets_no_fire_can() -> None:
+    # A group that only has non-KS-19 guns has nothing to offer the radar slot.
+    s60 = GroundUnitType.named(S60_GUN_VARIANT)
+    force_group = ForceGroup(
+        name="S-60",
+        units=[s60],
+        statics=[],
+        tasks=[GroupTask.AAA],
+        layouts=[],
+    )
+
+    assert force_group.dcs_unit_types_for_group(_radar_slot()) == []
+
+
+def test_aaa_site_layout_radar_slot_is_gated() -> None:
+    # Guard the layout file itself: the radar slot must be an optional, non-filling
+    # AAA-radar-only slot so generic sites are never handed a gun-laying radar.
     data: dict[str, Any] = yaml.safe_load(AAA_SITE_LAYOUT.read_text(encoding="utf-8"))
     radar_slots = [
         unit_group
@@ -88,3 +146,5 @@ def test_aaa_site_layout_requires_aaa_radar() -> None:
     assert radar_slots, "AAA Site layout no longer has a radar slot"
     for slot in radar_slots:
         assert slot["unit_classes"] == [UnitClass.AAA_RADAR.value]
+        assert slot["optional"] is True
+        assert slot["fill"] is False

--- a/tests/data/test_aaa_radar.py
+++ b/tests/data/test_aaa_radar.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import yaml
+
+from game.data.units import ANTI_AIR_UNIT_CLASSES, UnitClass
+from game.dcs.groundunittype import GroundUnitType
+from game.factions.faction import Faction
+from game.layout.layout import TgoLayoutUnitGroup
+
+# The two SON-9 "Fire Can" variants are the only stand-alone AAA gun-laying radars.
+FIRE_CAN_VARIANTS = ["AAA Fire Can SON-9", "AAA SON-9 Fire Can"]
+# A SAM search radar that must NOT be usable to cue AAA guns.
+SAM_SEARCH_RADAR_VARIANT = "SAM Patriot STR"
+
+AAA_SITE_LAYOUT = Path("resources/layouts/anti_air/AAA_Site.yaml")
+
+
+def _faction_with(*units: GroundUnitType) -> Faction:
+    """Minimal Faction stand-in exposing just what possible_types_for_faction reads."""
+    return cast(
+        Faction,
+        SimpleNamespace(
+            name="Test Faction",
+            accessible_units=list(units),
+            has_access_to_dcs_type=lambda dcs_type: False,
+        ),
+    )
+
+
+def _aaa_radar_slot() -> TgoLayoutUnitGroup:
+    """Mirror the generic AAA Site radar slot after the fix."""
+    return TgoLayoutUnitGroup(
+        name="AAA Site Radar",
+        layout_units=[],
+        unit_classes=[UnitClass.AAA_RADAR],
+        optional=True,
+    )
+
+
+def test_fire_can_radars_are_aaa_radar() -> None:
+    for variant in FIRE_CAN_VARIANTS:
+        assert GroundUnitType.named(variant).unit_class is UnitClass.AAA_RADAR
+
+
+def test_aaa_radar_is_still_anti_air() -> None:
+    # Reclassifying must not drop the Fire Can from anti-air handling.
+    assert UnitClass.AAA_RADAR in ANTI_AIR_UNIT_CLASSES
+
+
+def test_sam_search_radar_class_unchanged() -> None:
+    # Leave-alone/negative case: SAM search radars stay SearchRadar.
+    assert GroundUnitType.named(SAM_SEARCH_RADAR_VARIANT).unit_class is (
+        UnitClass.SEARCH_RADAR
+    )
+
+
+def test_aaa_radar_slot_rejects_sam_search_radar() -> None:
+    # A faction whose only radar is a SAM search radar gets no radar for the AAA
+    # slot rather than a useless Patriot STR. The slot is optional, so this is empty.
+    patriot = GroundUnitType.named(SAM_SEARCH_RADAR_VARIANT)
+    faction = _faction_with(patriot)
+    assert _aaa_radar_slot().possible_types_for_faction(faction) == []
+
+
+def test_aaa_radar_slot_accepts_fire_can() -> None:
+    fire_can = GroundUnitType.named(FIRE_CAN_VARIANTS[0])
+    patriot = GroundUnitType.named(SAM_SEARCH_RADAR_VARIANT)
+    # Even when a SAM search radar is also accessible, only the Fire Can is offered.
+    faction = _faction_with(fire_can, patriot)
+    assert _aaa_radar_slot().possible_types_for_faction(faction) == [
+        fire_can.dcs_unit_type
+    ]
+
+
+def test_aaa_site_layout_requires_aaa_radar() -> None:
+    # Guard the layout file itself: the radar slot must ask for AAA radars only.
+    data: dict[str, Any] = yaml.safe_load(AAA_SITE_LAYOUT.read_text(encoding="utf-8"))
+    radar_slots = [
+        unit_group
+        for group in data["groups"]
+        for unit_group in next(iter(group.values()))
+        if unit_group["name"] == "AAA Site Radar"
+    ]
+    assert radar_slots, "AAA Site layout no longer has a radar slot"
+    for slot in radar_slots:
+        assert slot["unit_classes"] == [UnitClass.AAA_RADAR.value]


### PR DESCRIPTION
## Symptom
Generic AAA sites were being generated with a radar the guns can't use — e.g. a SAM search radar (Patriot STR) sitting next to 8.8 cm Flak / S-60 guns. It contributed nothing to the guns and looked wrong on the map.

## Root cause
The generic `AAA Site` layout's optional radar slot accepted `unit_classes: [SearchRadar]`. Both the SON-9 "Fire Can" (an AAA gun-laying radar) **and** every SAM search/track radar share `class: SearchRadar`, so `TgoLayoutUnitGroup.possible_types_for_faction` would fill that slot with whatever `SearchRadar` a faction owned. With `fill` defaulting to `True`, `ForceGroup.for_layout` / `initialize_for_faction` auto-added that radar to generic AAA sites regardless of which guns filled the gun slot.

## Fix (minimal, data-driven)
- Added a dedicated `UnitClass.AAA_RADAR` and registered it in `ANTI_AIR_UNIT_CLASSES` (so `is_anti_air` stays true).
- Reclassified the two SON-9 Fire Can variants (`SON_9.yaml`, `Fire Can radar.yaml`) from `SearchRadar` → `AAARadar`.
- Changed the `AAA Site` layout radar slot to `unit_classes: [AAARadar]` **and `fill: false`**.

Net behaviour, matching the rule *"Fire Can only with KS-19; otherwise no radar"*:
- **Generic AAA sites** never auto-fill a radar (`optional + fill: false` is skipped by `for_layout` / `initialize_for_faction`) → guns spawn without a radar instead of with a useless one.
- **KS-19 / KS-19_HDS presets** explicitly bundle the Fire Can with their KS-19 guns, so at generation `dcs_unit_types_for_group` intersects the `AAARadar` slot with the preset's own units and the Fire Can appears **only** there.
- The `AAARadar` class also guarantees a SAM `SearchRadar` can never match the AAA radar slot even if bundled.

EWR sites are unaffected (they use the `EarlyWarningRadar` class/slot). WWII German flak still gets no radar — the Würzburg (`FuSe-65`) is classed `EarlyWarningRadar`, not an AAA gun-laying radar.

## Tests
Added `tests/data/test_aaa_radar.py` (revert-failing):
- Fire Can variants are `AAARadar` and still in `ANTI_AIR_UNIT_CLASSES`; Patriot STR stays `SearchRadar` (negative case).
- `ForceGroup.for_layout` on the generic AAA layout with a faction that has a Fire Can + non-KS-19 gun yields **no** Fire Can.
- A bundled KS-19 + SON-9 group still pairs them; a non-KS-19 bundle offers nothing to the radar slot.
- Guards the layout file: radar slot is `optional`, `fill: false`, `unit_classes: [AAARadar]`.

`pytest`, `black --check`, and `mypy` all pass.

## Compatibility
No save-format change. Only an enum value was added (`SearchRadar` retained), so existing saves unpickle fine, and `GroundUnitType.__setstate__` re-derives unit metadata from resources on load. Already-generated AAA sites in in-progress saves are untouched; every newly generated site follows the new rule. The layout pickle cache auto-invalidates via its source signature.
