### PR TITLE
Update forum thread URL in help menu

### DIFF
--- a/qt_ui/uiconstants.py
+++ b/qt_ui/uiconstants.py
@@ -8,7 +8,7 @@ from .liberation_theme import get_theme_icons
 URLS: Dict[str, str] = {
     "Manual": "https://github.com/dcs-retribution/dcs-retribution/wiki",
     "Repository": "https://github.com/dcs-retribution/dcs-retribution",
-    "ForumThread": "https://forums.eagle.ru/showthread.php?t=214834",
+    "ForumThread": "https://forum.dcs.world/topic/368593-dcs-retribution-dynamic-campaign-generator/",
     "Issues": "https://github.com/dcs-retribution/dcs-retribution/issues",
     "Releases": "https://github.com/dcs-retribution/dcs-retribution/releases",
 }


### PR DESCRIPTION
Existing link is dead cos it's pointing to the old Liberation eagle.ru forum thread.