### PR TITLE
Fix malformed mkdir mode in _create_dir_if_needed (Linux/macOS)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 * **[UX]** Add the ability to filter campaigns by version, map, and performance
 
 ## Fixes
+* **[App]** On Linux/macOS the directories under `Retribution/` were created with a malformed permission mode (`755` was written as a decimal literal, giving `0o1363`), leaving them unlistable by their owner. Kneeboard generation crashed with a `PermissionError` and user-supplied factions, custom groups and layouts silently failed to load.
 * **[Data]** The F-14A-135-GR Early's payload file declared the wrong unitType, so the Early Tomcat flew every tasking unarmed; its loadouts now resolve (with a guard test pinning the payload to the airframe). (#889)
 * **[Mission Generator]** EWR sites now get the DCS "EWR" enroute task and come up on RED alarm, so their radars actually scan and report contacts (previously they could sit inert, especially with the "red alert state" performance option off). Works with or without the Skynet IADS plugin.
 * **[Plugins]** Fix the escort leash never running (DCS has no `Group.getByID`; look the group up by name via mist), so escorts are actually held to their engagement range.

--- a/game/persistency.py
+++ b/game/persistency.py
@@ -324,8 +324,7 @@ class MigrationUnpickler(pickle.Unpickler):
 
 
 def _create_dir_if_needed(path: Path) -> Path:
-    if not path.exists():
-        path.mkdir(755, parents=True)
+    path.mkdir(parents=True, exist_ok=True)
     return path
 
 


### PR DESCRIPTION
755 is a malformed argument on Linux/MacOS: it would need to be 0o755. Decimal 755 is extremely broken, with the owner not even having read perms. Windows discards this argument and is not affected. I opted to remove the argument and change the if statement to instead use the exist_ok argument. This matches the majority of mkdir() calls in the project, but not all of them. 0o755 is identical to the default permissions under the standard umask anyways.