### PR TITLE
Fix/motorpool spawn orientation

### DIFF
--- a/game/missiongenerator/motorpoolpopulator.py
+++ b/game/missiongenerator/motorpoolpopulator.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from dcs.mapping import Point
-
 from game.dcs.groundunittype import GroundUnitType
 from game.ground_forces.ai_ground_planner import reserve_armor_for
 from game.theater.theatergroup import TheaterGroup, TheaterUnit
@@ -17,7 +15,7 @@ if TYPE_CHECKING:
 _SPACING_M = 12.0
 _COLUMNS = 5
 # Keep the Garage_A building at the authored marker; start vehicles clear of it
-# in the building's local +x/+y corner. 150 ft is the authoring-friendly value.
+# behind the building. 150 ft is the authoring-friendly value.
 _GRID_OFFSET_M = 45.72
 
 
@@ -110,14 +108,15 @@ class MotorpoolPopulator:
         self, tgo: MotorpoolGroundObject, unit_type: GroundUnitType, index: int
     ) -> TheaterUnit:
         origin = tgo.position
-        dx = _GRID_OFFSET_M + (index % _COLUMNS) * _SPACING_M
-        dy = _GRID_OFFSET_M + (index // _COLUMNS) * _SPACING_M
-        # Lay the grid in the garage's local frame, then rotate it clockwise about
-        # the authored Garage_A marker so the parking lot follows its directionality.
-        pos = PointWithHeading.from_point(
-            Point(origin.x + dx, origin.y + dy, origin._terrain), tgo.heading
-        )
-        pos.rotate(origin, tgo.heading)
+        # Park behind the garage: the first row is offset opposite its heading and
+        # each additional row continues farther in that direction. Within a row,
+        # vehicles are spaced along the garage's right-hand side.
+        behind = tgo.heading.opposite.degrees
+        lateral = tgo.heading.right.degrees
+        pos = origin.point_from_heading(
+            behind, _GRID_OFFSET_M + (index // _COLUMNS) * _SPACING_M
+        ).point_from_heading(lateral, (index % _COLUMNS) * _SPACING_M)
+        pos = PointWithHeading.from_point(pos, tgo.heading)
         return TheaterUnit(
             self.game.next_unit_id(),
             str(unit_type),

--- a/tests/missiongenerator/test_motorpool_populator.py
+++ b/tests/missiongenerator/test_motorpool_populator.py
@@ -104,15 +104,17 @@ def _unit_positions(tgo: MotorpoolGroundObject) -> list[Point]:
     return [u.position for g in tgo.groups for u in g.units]
 
 
-def test_grid_starts_clear_of_building_at_zero_heading() -> None:
+def test_grid_spawns_behind_north_facing_garage() -> None:
     gut = _gut()
     tgo, cp = _motorpool({gut: 3}, heading=0.0)
     MotorpoolPopulator(cast("Game", _game([cp], cap=10))).populate()
     positions = _unit_positions(tgo)
     assert len(positions) == 3
-    assert positions[0].x == 45.72 and positions[0].y == 45.72
-    assert positions[1].x == 57.72 and abs(positions[1].y - 45.72) < 1e-6
-    assert positions[2].x == 69.72 and abs(positions[2].y - 45.72) < 1e-6
+    # DCS x is north/south in this project: a north-facing garage's parking
+    # grid must be south of the authored Garage_A marker.
+    assert abs(positions[0].x + 45.72) < 1e-6 and abs(positions[0].y) < 1e-6
+    assert abs(positions[1].x + 45.72) < 1e-6 and abs(positions[1].y - 12.0) < 1e-6
+    assert abs(positions[2].x + 45.72) < 1e-6 and abs(positions[2].y - 24.0) < 1e-6
 
 
 def test_grid_offset_and_spacing_rotate_with_garage_heading() -> None:
@@ -121,9 +123,11 @@ def test_grid_offset_and_spacing_rotate_with_garage_heading() -> None:
     MotorpoolPopulator(cast("Game", _game([cp], cap=10))).populate()
     positions = _unit_positions(tgo)
     assert len(positions) == 3
-    assert abs(positions[0].x + 45.72) < 1e-6 and abs(positions[0].y - 45.72) < 1e-6
-    assert abs(positions[1].x + 45.72) < 1e-6 and abs(positions[1].y - 57.72) < 1e-6
-    assert abs(positions[2].x + 45.72) < 1e-6 and abs(positions[2].y - 69.72) < 1e-6
+    # An east-facing garage has its parking row west of the marker, with the
+    # vehicles laid out from north to south along the garage's right-hand side.
+    assert abs(positions[0].x) < 1e-6 and abs(positions[0].y + 45.72) < 1e-6
+    assert abs(positions[1].x + 12.0) < 1e-6 and abs(positions[1].y + 45.72) < 1e-6
+    assert abs(positions[2].x + 24.0) < 1e-6 and abs(positions[2].y + 45.72) < 1e-6
 
 
 def test_multiple_motorpools_on_one_cp_share_one_reserve_pool() -> None:


### PR DESCRIPTION
Make motorpools spawn behind the orientation of the motorpool, and perpendicular. e.g. north-facing has motorpool spawn south of it, in an east-west fashion. cc @Starfire13 
