### PR TITLE
[FIX] Super Hornet: fix the JSOW clsid on station 2 (no such id exists)

### DIFF
--- a/resources/customized_payloads/FA-18E.lua
+++ b/resources/customized_payloads/FA-18E.lua
@@ -344,7 +344,7 @@ local unitPayloads = {
 					},
 				},
 				[2] = {
-					["CLSID"] = "{SUPERHORNET_PYLON_02_MB_JS_2X_BRU_AGM-154C}",
+					["CLSID"] = "{SUPERHORNET_PYLON_02_MB_JS_2X_BRU55_AGM-154C}",
 					["num"] = 2,
 				},
 				[3] = {
@@ -401,7 +401,7 @@ local unitPayloads = {
 					},
 				},
 				[2] = {
-					["CLSID"] = "{SUPERHORNET_PYLON_02_MB_JS_2X_BRU_AGM-154C}",
+					["CLSID"] = "{SUPERHORNET_PYLON_02_MB_JS_2X_BRU55_AGM-154C}",
 					["num"] = 2,
 				},
 				[3] = {

--- a/resources/customized_payloads/FA-18F.lua
+++ b/resources/customized_payloads/FA-18F.lua
@@ -344,7 +344,7 @@ local unitPayloads = {
 					},
 				},
 				[2] = {
-					["CLSID"] = "{SUPERHORNET_PYLON_02_MB_JS_2X_BRU_AGM-154C}",
+					["CLSID"] = "{SUPERHORNET_PYLON_02_MB_JS_2X_BRU55_AGM-154C}",
 					["num"] = 2,
 				},
 				[3] = {
@@ -401,7 +401,7 @@ local unitPayloads = {
 					},
 				},
 				[2] = {
-					["CLSID"] = "{SUPERHORNET_PYLON_02_MB_JS_2X_BRU_AGM-154C}",
+					["CLSID"] = "{SUPERHORNET_PYLON_02_MB_JS_2X_BRU55_AGM-154C}",
 					["num"] = 2,
 				},
 				[3] = {


### PR DESCRIPTION
## Problem

The `Retribution DEAD` and `Retribution OCA/Aircraft` presets for the F/A-18E and F/A-18F put `{SUPERHORNET_PYLON_02_MB_JS_2X_BRU_AGM-154C}` on station 2. **The CJS mod never declares that id.** Its hardpoint table offers station 02 only the BRU-55 rack:

- `SUPERHORNET_PYLON_02_MB_JS_2X_BRU55_AGM-154A`
- `SUPERHORNET_PYLON_02_MB_JS_2X_BRU55_AGM-154C`

The plain `BRU_` variant exists solely on stations 03 and 09 (`..._PYLON_03_IB_MB_JS_2X_BRU_AGM-154C`, `..._PYLON_09_IB_MB_JS_2X_BRU_AGM-154C`), which is probably how the typo slipped through.

DCS silently drops a store whose clsid it does not know, so **that station flew empty** — the flight looks correctly loaded in Retribution but takes off with two fewer JSOWs.

It is not a mod-version issue: verified against CJS **2.4.5.260429**, which is also the exact content of the archive published as *v2.4.5.260501.RC1* (both byte-identical), in `Entry/FA-18EFG_HARDPOINTS_V2.lua`.

## Fix

Both files switched to `..._BRU55_AGM-154C`. Verified by resolving the affected loadouts against the mod's hardpoint table: FA-18E/F DEAD and OCA/Aircraft now reference zero non-existent clsids.

Worth noting the failure mode is invisible to validation: `Weapon.with_clsid()` fabricates a synthetic weapon for an unknown clsid rather than returning `None`, so `valid_payload()` passes and the loadout resolves with a proper name.