### PR TITLE
[FIX] Laser-coded bombs are generated without a fuze

### DIFF
--- a/game/missiongenerator/aircraft/flightgroupconfigurator.py
+++ b/game/missiongenerator/aircraft/flightgroupconfigurator.py
@@ -17,7 +17,7 @@ from dcs.unitgroup import FlyingGroup
 from game.ato import Flight, FlightType
 from game.ato.flightplans.shiprecoverytanker import RecoveryTankerFlightPlan
 from game.callsigns import callsign_for_support_unit
-from game.data.weapons import Pylon, WeaponType
+from game.data.weapons import Pylon, Weapon, WeaponType
 from game.lasercodes.lasercode import LaserCode
 from game.missiongenerator.logisticsgenerator import LogisticsGenerator
 from game.missiongenerator.missiondata import MissionData, AwacsInfo, TankerInfo
@@ -439,7 +439,7 @@ class FlightGroupConfigurator:
             pylon = Pylon.for_aircraft(self.flight.unit_type, pylon_number)
             settings = self._merge_laser_code(
                 loadout.pylon_settings.get(pylon_number),
-                weapon.accepts_laser_code(),
+                weapon,
                 member.weapon_laser_code,
             )
             pylon.equip(unit, weapon, settings)
@@ -447,14 +447,22 @@ class FlightGroupConfigurator:
     @staticmethod
     def _merge_laser_code(
         base: Optional[dict[str, Any]],
-        accepts_laser_code: bool,
+        weapon: Weapon,
         laser_code: Optional[LaserCode],
     ) -> Optional[dict[str, Any]]:
-        if laser_code is None or not accepts_laser_code:
+        """Settings to write for this pylon, laser code included.
+
+        DCS reads a weapon's settings table as the whole truth: a key that is absent
+        is not fitted, and a bomb's fuze lives in that table. Start from the weapon's
+        own defaults, which is what DCS applies when no table is written at all.
+        """
+        if laser_code is None or not weapon.accepts_laser_code():
             return base
-        settings = dict(base or {})
-        settings["laser_code"] = laser_code.code
-        return settings
+        settings = weapon.create_settings()
+        defaults = settings.to_dict() if settings is not None else {}
+        merged = {**defaults, **(base or {})}
+        merged["laser_code"] = laser_code.code
+        return merged
 
     def setup_fuel(self) -> None:
         fuel = self.flight.state.estimate_fuel()

--- a/tests/missiongenerator/aircraft/test_flightgroupconfigurator.py
+++ b/tests/missiongenerator/aircraft/test_flightgroupconfigurator.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 
@@ -17,29 +17,74 @@ class _StubRegistry(ILaserCodeRegistry):
         pass
 
 
+class _StubSettings:
+    """Stands in for pydcs' WeaponSettings, which reports the weapon's defaults."""
+
+    def __init__(self, values: Dict[str, Any]) -> None:
+        self._values = values
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dict(self._values)
+
+
+class _StubWeapon:
+    """A weapon whose settings schema declares a tail fuze, like any real bomb."""
+
+    def __init__(
+        self, accepts: bool = True, defaults: Optional[Dict[str, Any]] = None
+    ) -> None:
+        self._accepts = accepts
+        self._defaults = {"NFP_fuze_type_tail": "FMU139CB_LD", "laser_code": 1688}
+        if defaults is not None:
+            self._defaults = defaults
+
+    def accepts_laser_code(self) -> bool:
+        return self._accepts
+
+    def create_settings(self) -> Optional[_StubSettings]:
+        return _StubSettings(self._defaults) if self._defaults else None
+
+
 @pytest.fixture(name="laser_code")
 def laser_code_fixture() -> LaserCode:
     return LaserCode(1511, _StubRegistry())
 
 
-def test_merge_inserts_laser_code_when_accepted_and_no_existing_settings(
+def test_merge_keeps_the_weapon_defaults_when_the_loadout_has_no_settings(
     laser_code: LaserCode,
 ) -> None:
-    result = FlightGroupConfigurator._merge_laser_code(None, True, laser_code)
-    assert result == {"laser_code": 1511}
+    """The regression this guards: a table holding only the laser code told DCS the
+    bomb had no fuze fitted, so it fell as a dud."""
+    result = FlightGroupConfigurator._merge_laser_code(
+        None, _StubWeapon(), laser_code  # type: ignore[arg-type]
+    )
+    assert result == {"NFP_fuze_type_tail": "FMU139CB_LD", "laser_code": 1511}
 
 
 def test_merge_preserves_other_settings_when_accepted(laser_code: LaserCode) -> None:
     base: Dict[str, Any] = {"fuze_setting": "instant"}
-    result = FlightGroupConfigurator._merge_laser_code(base, True, laser_code)
+    result = FlightGroupConfigurator._merge_laser_code(
+        base, _StubWeapon(defaults={}), laser_code  # type: ignore[arg-type]
+    )
     assert result == {"fuze_setting": "instant", "laser_code": 1511}
+
+
+def test_merge_lets_the_loadout_override_a_default(laser_code: LaserCode) -> None:
+    base: Dict[str, Any] = {"NFP_fuze_type_tail": "FMU152AB_LD"}
+    result = FlightGroupConfigurator._merge_laser_code(
+        base, _StubWeapon(), laser_code  # type: ignore[arg-type]
+    )
+    assert result is not None
+    assert result["NFP_fuze_type_tail"] == "FMU152AB_LD"
 
 
 def test_merge_overrides_existing_laser_code_when_accepted(
     laser_code: LaserCode,
 ) -> None:
     base: Dict[str, Any] = {"laser_code": 1688}
-    result = FlightGroupConfigurator._merge_laser_code(base, True, laser_code)
+    result = FlightGroupConfigurator._merge_laser_code(
+        base, _StubWeapon(defaults={}), laser_code  # type: ignore[arg-type]
+    )
     assert result == {"laser_code": 1511}
 
 
@@ -47,23 +92,31 @@ def test_merge_returns_base_unchanged_when_not_accepted(
     laser_code: LaserCode,
 ) -> None:
     base: Dict[str, Any] = {"fuze_setting": "instant"}
-    result = FlightGroupConfigurator._merge_laser_code(base, False, laser_code)
+    result = FlightGroupConfigurator._merge_laser_code(
+        base, _StubWeapon(accepts=False), laser_code  # type: ignore[arg-type]
+    )
     assert result is base
 
 
 def test_merge_returns_base_unchanged_when_no_laser_code() -> None:
     base: Dict[str, Any] = {"fuze_setting": "instant"}
-    result = FlightGroupConfigurator._merge_laser_code(base, True, None)
+    result = FlightGroupConfigurator._merge_laser_code(
+        base, _StubWeapon(), None  # type: ignore[arg-type]
+    )
     assert result is base
 
 
 def test_merge_returns_none_when_no_laser_code_and_no_base() -> None:
-    result = FlightGroupConfigurator._merge_laser_code(None, True, None)
+    result = FlightGroupConfigurator._merge_laser_code(
+        None, _StubWeapon(), None  # type: ignore[arg-type]
+    )
     assert result is None
 
 
 def test_merge_does_not_mutate_input_base(laser_code: LaserCode) -> None:
     base: Dict[str, Any] = {"laser_code": 1688, "fuze_setting": "instant"}
     snapshot = dict(base)
-    FlightGroupConfigurator._merge_laser_code(base, True, laser_code)
+    FlightGroupConfigurator._merge_laser_code(
+        base, _StubWeapon(), laser_code  # type: ignore[arg-type]
+    )
     assert base == snapshot


### PR DESCRIPTION
Writing a laser code onto a pylon builds the weapon's settings table from scratch, so a loadout with no settings of its own reaches the mission carrying only the code:

```lua
["CLSID"]="{BRU33_2X_GBU-12}", ["settings"]={ ["laser_code"]=1686 }
```

DCS reads that table as the whole truth — a key that is absent is **not fitted** — and a bomb's fuze lives in it (`NFP_fuze_type_tail`). The GBU therefore spawns with an empty fuze well: MFUZ/EFUZ blank and unselectable on the stores page, DUD on the HUD, and no detonation however well the bomb is guided.

It affects any weapon that accepts a laser code whenever the loadout carries no settings of its own — which is the normal case, stock DCS payloads included. Payloads authored in the Mission Editor are unaffected, since they already carry the full table.

**Fix:** start from the weapon's own defaults (what DCS applies when no table is written at all), then overlay the loadout's stored values and the laser code. A preset that specifies its own fuze still wins. A GBU-12 now generates as:

```
NFP_fuze_type_tail = FMU139CB_LD
01_prfx_arm_delay_ctrl_FMU139CB_LD = 4
01_prfx_function_delay_ctrl_FMU139CB_LD = 0
laser_code = 1686
NFP_VIS_DrawArgNo_57 = 0
```

Introduced in 9be723733 ("Assign per-weapon laser codes", #732). Found while flying, then confirmed against the generated .miz and pydcs' settings schema for the weapon. Tests updated for the new signature, with a regression test pinning that the fuze survives when the loadout has no settings of its own.