### PR TITLE
[FIX] Right-click on a front line under a flight-plan route opens the browser context menu

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,6 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
-* **[Map]** Right-clicking a front line under a blue flight-plan route now opens the new-package dialog instead of the browser context menu (the route's invisible hover overlay swallowed the click).
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.
@@ -29,6 +28,7 @@
 * **[Engine]** Bump campaign version to 10.9 for motorpool support
 
 ## Fixes
+* **[Map]** Right-clicking a front line under a blue flight-plan route now opens the new-package dialog instead of the browser context menu (the route's invisible hover overlay swallowed the click).
 * **[Data]** The F-14A-135-GR Early's payload file declared the wrong unitType, so the Early Tomcat flew every tasking unarmed; its loadouts now resolve (with a guard test pinning the payload to the airframe). (#889)
 * **[Mission Generator]** EWR sites now get the DCS "EWR" enroute task and come up on RED alarm, so their radars actually scan and report contacts (previously they could sit inert, especially with the "red alert state" performance option off). Works with or without the Skynet IADS plugin.
 * **[Plugins]** Fix the escort leash never running (DCS has no `Group.getByID`; look the group up by name via mist), so escorts are actually held to their engagement range.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[Map]** Right-clicking a front line under a blue flight-plan route now opens the new-package dialog instead of the browser context menu (the route's invisible hover overlay swallowed the click).
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.

--- a/client/src/components/frontlineslayer/FrontLinesLayer.test.tsx
+++ b/client/src/components/frontlineslayer/FrontLinesLayer.test.tsx
@@ -4,7 +4,12 @@ import { PropsWithChildren } from "react";
 
 const mockPolyline = jest.fn();
 const mockLayerGroup = jest.fn();
+const mockPane = jest.fn();
 jest.mock("react-leaflet", () => ({
+  Pane: (props: PropsWithChildren<any>) => {
+    mockPane(props);
+    return <>{props.children}</>;
+  },
   LayerGroup: (props: PropsWithChildren<any>) => {
     mockLayerGroup(props);
     return <>{props.children}</>;
@@ -22,6 +27,19 @@ describe("FrontLinesLayer", () => {
     renderWithProviders(<FrontLinesLayer />);
     expect(mockPolyline).not.toHaveBeenCalled();
     expect(mockLayerGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it("draws into a pane above the default overlay pane", () => {
+    // Front lines live in their own pane so a flight plan's wide invisible hover
+    // polyline (in the default overlayPane, z 400) cannot swallow a right-click
+    // on a front line crossing it. Below the marker pane at z 600.
+    renderWithProviders(<FrontLinesLayer />);
+    expect(mockPane).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "front-lines",
+        style: { zIndex: 450 },
+      })
+    );
   });
 
   it("draws front lines", () => {

--- a/client/src/components/frontlineslayer/FrontLinesLayer.tsx
+++ b/client/src/components/frontlineslayer/FrontLinesLayer.tsx
@@ -1,15 +1,23 @@
 import { selectFrontLines } from "../../api/frontLinesSlice";
 import { useAppSelector } from "../../app/hooks";
 import FrontLine from "../frontline";
-import { LayerGroup } from "react-leaflet";
+import { LayerGroup, Pane } from "react-leaflet";
 
 export default function FrontLinesLayer() {
   const fronts = useAppSelector(selectFrontLines).fronts;
   return (
-    <LayerGroup>
-      {Object.values(fronts).map((front, idx) => {
-        return <FrontLine key={idx} front={front} />;
-      })}
-    </LayerGroup>
+    // Dedicated pane above the default overlayPane (z 400): blue flight plans
+    // put a wide invisible hover polyline on top of everything in that pane,
+    // which swallowed right-clicks on a front line crossing it (the browser
+    // context menu appeared instead of the new-package dialog). Panes hit-test
+    // in z order, so raising the fronts keeps their contextmenu reachable.
+    // Still below the marker pane (z 600).
+    <Pane name="front-lines" style={{ zIndex: 450 }}>
+      <LayerGroup>
+        {Object.values(fronts).map((front, idx) => {
+          return <FrontLine key={idx} front={front} />;
+        })}
+      </LayerGroup>
+    </Pane>
   );
 }


### PR DESCRIPTION
Right-clicking a front line that runs under a blue flight-plan route opened the browser context menu instead of the new-package dialog. Flight-plan routes draw a wide invisible hover polyline in the default `overlayPane`, on top of the front lines, so it took the `contextmenu` event.

Front lines now render into their own pane at z 450 — above `overlayPane` (400), below the marker pane (600). Panes hit-test in z order, so the front line gets the click back.

Test updated: the suite mocked `react-leaflet` without `Pane`, and it now also asserts the pane name and z-index.