### PR TITLE
[FIX] Two single/multi clsids missing from their weapon group

### DIFF
--- a/resources/weapons/standoff/AGM-158C.yaml
+++ b/resources/weapons/standoff/AGM-158C.yaml
@@ -2,3 +2,4 @@ name: AGM-158C LRASM
 year: 2018
 clsids:
   - "{B21_AGM-158C*4}"   # 4 x AGM-158C LRASM AShM
+  - "{B21_AGM-158C}"   # AGM-158C LRASM AShM (single)

--- a/resources/weapons/standoff/Kh-65.yaml
+++ b/resources/weapons/standoff/Kh-65.yaml
@@ -3,3 +3,4 @@ year: 1992
 fallback: Kh-59M
 clsids:
   - "{BADAF2DE-68B5-472A-8AAC-35BAEFF6B4A1}"
+  - "{0290F5DE-014A-4BB1-9843-D717749B1DED}"   # 6 x Kh-65 (AS-15B Kent)


### PR DESCRIPTION
The AGM-158C and Kh-65 groups each list only one of the two clsids DCS ships for the weapon, so the other resolves to the "Unknown" group and loses the group's type, introduction year and fallback.

* `{B21_AGM-158C}` — the single LRASM, next to the 4x pack already listed. Declared by the CurrentHill USA asset pack, which declares both. Carried by the F-15EX mod.
* `{0290F5DE-014A-4BB1-9843-D717749B1DED}` — the 6x Kh-65 pack, next to the single already listed. Stock DCS.