### PR TITLE
TACAN and VOR beacon conflict

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
 * **[Engine]** Bump campaign version to 10.9 for motorpool support
 
 ## Fixes
+* **[Mission Generator]** Dynamically allocated TACAN channels no longer collide with map beacons: DME/VOR-DME beacons (which share TACAN's channelization) are now blacklisted alongside TACAN/VORTAC, and beacons whose DCS data omits a channel (e.g. Syria's KALDE "KAD" VOR-DME) have their channel/band derived from the beacon's VHF frequency per the ICAO VOR/TACAN channelling plan instead of being silently skipped. The "Assign TACAN" dialog now warns in real time when the selected channel/band is already in use by a map beacon or another carrier/airfield/flight. (#36)
 * **[Map]** Right-clicking a front line under a blue flight-plan route now opens the new-package dialog instead of the browser context menu (the route's invisible hover overlay swallowed the click).
 * **[Data]** The F-14A-135-GR Early's payload file declared the wrong unitType, so the Early Tomcat flew every tasking unarmed; its loadouts now resolve (with a guard test pinning the payload to the airframe). (#889)
 * **[Mission Generator]** EWR sites now get the DCS "EWR" enroute task and come up on RED alarm, so their radars actually scan and report contacts (previously they could sit inert, especially with the "red alert state" performance option off). Works with or without the Skynet IADS plugin.

--- a/game/dcs/beacons.py
+++ b/game/dcs/beacons.py
@@ -46,17 +46,43 @@ class BeaconType(IntEnum):
     BEACON_TYPE_TACAN_RANGE = 262144
 
 
+# Standard ICAO VOR/TACAN channelling plan: every 50 kHz VHF nav frequency in the
+# civil VOR band (108.00-117.95 MHz) is paired 1:1 with a TACAN channel/band.
+# https://www.flightsim-corner.com/wp-content/uploads/VOR-Frequencies-to-TACAN-Channel-list.pdf
+_VOR_TACAN_STEP_HZ = 50_000
+_VOR_TACAN_LOW_BAND = (108_000_000, 112_250_000, 17)  # 108.00-112.25 MHz -> 17-59
+_VOR_TACAN_HIGH_BAND = (112_300_000, 117_950_000, 70)  # 112.30-117.95 MHz -> 70-126
+
+
+def _tacan_channel_from_vor_frequency(hertz: Optional[int]) -> Optional[TacanChannel]:
+    """Derives the TACAN channel/band paired with a VOR/DME frequency, if any.
+
+    DCS beacon data frequently omits the TACAN channel for VOR/DME beacons even
+    though the frequency uniquely determines it, per the ICAO channelling plan.
+    """
+    if hertz is None:
+        return None
+    for start, end, first_channel in (_VOR_TACAN_LOW_BAND, _VOR_TACAN_HIGH_BAND):
+        if start <= hertz <= end:
+            index = (hertz - start) // _VOR_TACAN_STEP_HZ
+            band = TacanBand.X if index % 2 == 0 else TacanBand.Y
+            return TacanChannel(first_channel + index // 2, band)
+    return None
+
+
 @dataclass(frozen=True)
 class Beacon:
     name: str
     callsign: str
     beacon_type: BeaconType
-    hertz: int
+    # DCS's beacons.lua omits the frequency for some beacons (e.g. TACAN-only ground
+    # stations with no VHF pairing).
+    hertz: Optional[int]
     channel: Optional[int]
 
     @property
     def frequency(self) -> RadioFrequency:
-        return RadioFrequency(self.hertz)
+        return RadioFrequency(self.hertz or 0)
 
     @property
     def is_tacan(self) -> bool:
@@ -66,10 +92,34 @@ class Beacon:
         )
 
     @property
-    def tacan_channel(self) -> TacanChannel:
-        assert self.is_tacan
-        assert self.channel is not None
-        return TacanChannel(self.channel, TacanBand.X)
+    def occupies_tacan_channel(self) -> bool:
+        """True if a dynamically allocated TACAN on the same channel/band would
+        conflict with this beacon.
+
+        DME and VOR-DME beacons share TACAN's channelization (the DME portion is
+        transmitted on the paired TACAN channel/frequency), so they must also be
+        blacklisted even though they aren't TACAN beacons themselves.
+        """
+        return self.is_tacan or self.beacon_type in (
+            BeaconType.BEACON_TYPE_DME,
+            BeaconType.BEACON_TYPE_VOR_DME,
+        )
+
+    @property
+    def tacan_channel(self) -> Optional[TacanChannel]:
+        """The TACAN channel/band that would conflict with this beacon, if any.
+
+        Prefers the channel/band derived from the VHF frequency (accurate for any
+        beacon in the civil VOR band, including ones DCS didn't tag with a channel),
+        falling back to the raw channel field (assumed X band, since DCS doesn't
+        expose the actual band for TACAN-only ground beacons outside the VOR band).
+        """
+        assert self.occupies_tacan_channel
+        if (channel := _tacan_channel_from_vor_frequency(self.hertz)) is not None:
+            return channel
+        if self.channel is not None:
+            return TacanChannel(self.channel, TacanBand.X)
+        return None
 
 
 class Beacons:

--- a/game/missiongenerator/missiongenerator.py
+++ b/game/missiongenerator/missiongenerator.py
@@ -225,11 +225,11 @@ class MissionGenerator:
         """
         for beacon in Beacons.iter_theater(self.game.theater):
             unique_map_frequencies.add(beacon.frequency)
-            if beacon.is_tacan:
-                if beacon.channel is None:
+            if beacon.occupies_tacan_channel:
+                if (channel := beacon.tacan_channel) is None:
                     logging.warning(f"TACAN beacon has no channel: {beacon.callsign}")
                 else:
-                    self.tacan_registry.mark_unavailable(beacon.tacan_channel)
+                    self.tacan_registry.mark_unavailable(channel)
         for cp in self.game.theater.controlpoints:
             if isinstance(cp, TacanContainer) and cp.tacan is not None:
                 self.tacan_registry.mark_unavailable(cp.tacan)

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -17,6 +17,7 @@ from game.ato.airtaaskingorder import AirTaskingOrder
 from game.ato.flight import Flight
 from game.ato.flighttype import FlightType
 from game.ato.package import Package
+from game.dcs.beacons import Beacons
 from game.game import Game
 from game.radio.RadioFrequencyContainer import RadioFrequencyContainer
 from game.radio.radios import RadioFrequency
@@ -620,12 +621,41 @@ class GameModel:
                 allocated_icls.add(cp.icls_channel)
             elif isinstance(cp, RadioFrequencyContainer):
                 allocated_freqs.add(cp.frequency)
+        # Map DME/VOR-DME/TACAN/VORTAC beacons share TACAN's channelization, so flag
+        # them as unavailable too, not just other player-assigned channels (#36).
+        for beacon in Beacons.iter_theater(self.game.theater):
+            if beacon.occupies_tacan_channel:
+                allocated_tacan.add(beacon.tacan_channel)
         allocated_freqs.remove(None)
         allocated_tacan.remove(None)
         allocated_icls.remove(None)
         self.allocated_freqs = list(allocated_freqs)
         self.allocated_tacan = list(allocated_tacan)
         self.allocated_icls = list(allocated_icls)
+
+    def unavailable_tacan_channels(self, exclude: object = None) -> list[TacanChannel]:
+        """Channels reserved by anything other than `exclude` itself.
+
+        Unlike allocated_tacan (a deduplicated set with no provenance), this always
+        includes map beacon channels, even if `exclude`'s own current channel
+        happens to share the same value (that's precisely the conflict to flag).
+        """
+        if self.game is None:
+            return []
+        channels: set[TacanChannel] = set()
+        for p in self.ato_model.ato.packages:
+            for f in p.flights:
+                if f is not exclude and f.tacan is not None:
+                    channels.add(f.tacan)
+        for cp in self.game.theater.control_points_for(True):
+            if cp is not exclude and isinstance(cp, NavalControlPoint):
+                if cp.tacan is not None:
+                    channels.add(cp.tacan)
+        for beacon in Beacons.iter_theater(self.game.theater):
+            if beacon.occupies_tacan_channel:
+                if (channel := beacon.tacan_channel) is not None:
+                    channels.add(channel)
+        return list(channels)
 
     def release_freq(self, freq: RadioFrequency):
         if freq:

--- a/qt_ui/widgets/QTacanWidget.py
+++ b/qt_ui/widgets/QTacanWidget.py
@@ -45,7 +45,12 @@ class QTacanWidget(QWidget):
         return f"<b>TACAN: {c}{cs}</b>"
 
     def open_tacan_dialog(self) -> None:
-        self.tacan_dialog = QTacanDialog(self, self.ct)
+        # Beacons are always considered, along with any other CP/flight's channel;
+        # only this container's own current assignment is excluded from "in use".
+        unavailable = self.gm.unavailable_tacan_channels(exclude=self.ct)
+        self.tacan_dialog = QTacanDialog(
+            self, self.ct, unavailable_channels=unavailable
+        )
         self.tacan_dialog.accepted.connect(self.assign_tacan)
         self.tacan_dialog.show()
 

--- a/qt_ui/windows/QTacanDialog.py
+++ b/qt_ui/windows/QTacanDialog.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Iterable, Optional
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
@@ -12,13 +12,20 @@ from PySide6.QtWidgets import (
 )
 
 from game.radio.TacanContainer import TacanContainer
+from game.radio.tacan import TacanBand, TacanChannel
 from qt_ui.uiconstants import EVENT_ICONS
 
 
 class QTacanDialog(QDialog):
-    def __init__(self, parent=None, container: Optional[TacanContainer] = None) -> None:
+    def __init__(
+        self,
+        parent=None,
+        container: Optional[TacanContainer] = None,
+        unavailable_channels: Iterable[TacanChannel] = (),
+    ) -> None:
         super().__init__(parent=parent)
         self.container = container
+        self.unavailable_channels = set(unavailable_channels)
         self.setMinimumWidth(400)
 
         # Make dialog modal to prevent background windows to close unexpectedly.
@@ -43,6 +50,10 @@ class QTacanDialog(QDialog):
         self.callsign_input.setMaxLength(3)
         self.callsign_input.setMaximumWidth(50)
         layout.addWidget(self.callsign_input)
+
+        self.warning_label = QLabel()
+        self.warning_label.setStyleSheet("color: orange")
+        layout.addWidget(self.warning_label)
         layout.addStretch()
 
         self.create_button = QPushButton("Save")
@@ -51,9 +62,29 @@ class QTacanDialog(QDialog):
 
         self.setLayout(layout)
 
+        self.tacan_input.valueChanged.connect(self.update_availability_warning)
+        self.band_input.currentTextChanged.connect(self.update_availability_warning)
+
         if container is not None:
             if container.tcn_name is not None:
                 self.callsign_input.setText(container.tcn_name)
             if container.tacan is not None:
                 self.tacan_input.setValue(container.tacan.number)
                 self.band_input.setCurrentText(container.tacan.band.value)
+
+        self.update_availability_warning()
+
+    def selected_channel(self) -> TacanChannel:
+        band = TacanBand.X if self.band_input.currentText() == "X" else TacanBand.Y
+        return TacanChannel(self.tacan_input.value(), band)
+
+    def update_availability_warning(self) -> None:
+        if self.selected_channel() in self.unavailable_channels:
+            self.warning_label.setText("Already in use!")
+            self.warning_label.setToolTip(
+                "This TACAN channel is already used by a map beacon, another "
+                "carrier/airfield, or a flight. Verify that this is intentional."
+            )
+        else:
+            self.warning_label.setText("")
+            self.warning_label.setToolTip(None)

--- a/tests/test_beacons.py
+++ b/tests/test_beacons.py
@@ -1,0 +1,69 @@
+from game.dcs.beacons import Beacon, BeaconType
+from game.radio.tacan import TacanBand, TacanChannel
+
+
+def make_beacon(
+    beacon_type: BeaconType, channel: int | None = 40, hertz: int | None = None
+) -> Beacon:
+    return Beacon(
+        name="Test",
+        callsign="TST",
+        beacon_type=beacon_type,
+        hertz=hertz,
+        channel=channel,
+    )
+
+
+def test_tacan_and_vortac_occupy_tacan_channel() -> None:
+    assert make_beacon(BeaconType.BEACON_TYPE_TACAN).occupies_tacan_channel
+    assert make_beacon(BeaconType.BEACON_TYPE_VORTAC).occupies_tacan_channel
+
+
+def test_dme_and_vor_dme_occupy_tacan_channel() -> None:
+    """DME/VOR-DME share TACAN's channelization, so they must be blacklisted too."""
+    assert make_beacon(BeaconType.BEACON_TYPE_DME).occupies_tacan_channel
+    assert make_beacon(BeaconType.BEACON_TYPE_VOR_DME).occupies_tacan_channel
+
+
+def test_vor_alone_does_not_occupy_tacan_channel() -> None:
+    assert not make_beacon(BeaconType.BEACON_TYPE_VOR).occupies_tacan_channel
+
+
+def test_ils_does_not_occupy_tacan_channel() -> None:
+    assert not make_beacon(BeaconType.BEACON_TYPE_ILS_LOCALIZER).occupies_tacan_channel
+
+
+def test_tacan_channel_falls_back_to_channel_field_outside_vor_band() -> None:
+    """No VHF frequency (or one outside the civil VOR band) means we can't derive
+    the channel/band from frequency, so fall back to the raw channel field."""
+    beacon = make_beacon(BeaconType.BEACON_TYPE_VOR_DME, channel=88, hertz=None)
+    assert beacon.tacan_channel == TacanChannel(88, TacanBand.X)
+
+
+def test_tacan_channel_derived_from_kalde_kad_beacon() -> None:
+    """Regression test for #36: KALDE airport's KAD VOR-DME beacon (Syria) has no
+    'channel' in the DCS data, but its 112.60 MHz frequency pairs with 73X per the
+    standard ICAO VOR/TACAN channelling plan, so it must still be blacklisted."""
+    beacon = make_beacon(
+        BeaconType.BEACON_TYPE_VOR_DME, channel=None, hertz=112_600_000
+    )
+    assert beacon.tacan_channel == TacanChannel(73, TacanBand.X)
+
+
+def test_tacan_channel_frequency_takes_priority_over_channel_field() -> None:
+    """The frequency-derived channel/band is authoritative even if DCS also supplied
+    a (potentially band-agnostic/incorrect) channel number."""
+    beacon = make_beacon(BeaconType.BEACON_TYPE_VOR_DME, channel=88, hertz=112_600_000)
+    assert beacon.tacan_channel == TacanChannel(73, TacanBand.X)
+
+
+def test_tacan_channel_derives_y_band() -> None:
+    beacon = make_beacon(
+        BeaconType.BEACON_TYPE_VOR_DME, channel=None, hertz=112_650_000
+    )
+    assert beacon.tacan_channel == TacanChannel(73, TacanBand.Y)
+
+
+def test_tacan_channel_none_when_unresolvable() -> None:
+    beacon = make_beacon(BeaconType.BEACON_TYPE_VOR_DME, channel=None, hertz=None)
+    assert beacon.tacan_channel is None


### PR DESCRIPTION
- Dynamically allocated TACAN channels no longer collide with map beacons:
-  DME/VOR-DME beacons (which share TACAN's channelization) are now blacklisted alongside TACAN/VORTAC, and beacons whose DCS data omits a channel (e.g. Syria's KALDE "KAD" VOR-DME) have their channel/band derived from the beacon's VHF frequency per the ICAO VOR/TACAN channelling plan instead of being silently skipped. 
- The "Assign TACAN" dialog now warns in real time when the selected channel/band is already in use by a map beacon or another carrier/airfield/flight.


Dynamically generated TACAN channels could conflict with map beacons:

- Beacon.is_tacan only covered TACAN/VORTAC beacon types, so DME and VOR-DME map beacons were never blacklisted in TacanRegistry even though they share TACAN's channelization (the DME ranging signal is transmitted on the paired TACAN channel/frequency). Added Beacon.occupies_tacan_channel to cover TACAN, VORTAC, DME, and VOR-DME, and use it when initializing the registry.

- Beacons whose DCS data omits a 'channel' field (e.g. Syria's KALDE 'KAD' VOR-DME at 112.60 MHz) were silently skipped entirely instead of being blacklisted. The channel/band is now derived from the beacon's VHF frequency per the standard ICAO VOR/TACAN channelling plan when possible, falling back to the raw channel field (assumed X band) only when no frequency is available. This also corrects the band for beacons that did have a channel set, since the old code always assumed X.

- The 'Assign TACAN' dialog gave no indication a channel was already in use; it now warns in real time as the channel/band is changed, checking against map beacon channels as well as other CPs/flights. GameModel.unavailable_tacan_channels() recomputes the reserved set from the actual sources each time (rather than reusing a deduplicated, provenance-less set), excluding only the edited container's own contribution by identity so a real beacon conflict isn't hidden just because it happens to share the container's current channel value.

Regression tests added for the beacon channel/band derivation, including the exact KALDE/KAD case from the issue.

