### PR TITLE
Add UH-60A to Sweden 2020

### DIFF
--- a/resources/factions/sweden_2020.json
+++ b/resources/factions/sweden_2020.json
@@ -13,6 +13,7 @@
     "[CH] JAS 39C Gripen",
     "[CH] HKP15B",
     "UH-1H Iroquois",
+    "UH-60A",
     "UH-60L",
     "C-130J-30"
   ],


### PR DESCRIPTION
Sweden 2020 has the UH-60L but doesn't have the UH-60A as a non-mod fallback. Added it in.