### PR TITLE
Skip the strike task when the objective has no targets left

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 * **[Modding]** Update UH-60L mod to v2.1.5 including MH-60L DAP
 
 ## Fixes
+* **[Mission Generation]** Fix a ZeroDivisionError when a Strike flight is planned against an objective whose units are all already destroyed: the strike waypoint has no targets, and the units/targets ratio divided by zero, killing mission generation. The task is now skipped, matching what add_bombing_tasks already does. (#948)
 * **[Mission Generation]** Fix mission generation dying on "Duplicate convoy unit": convoy and cargo-ship names no longer reset each turn onto a convoy still in transit.
 * **[Mission Generator]** Dynamically allocated TACAN channels no longer collide with map beacons: DME/VOR-DME beacons (which share TACAN's channelization) are now blacklisted alongside TACAN/VORTAC, and beacons whose DCS data omits a channel (e.g. Syria's KALDE "KAD" VOR-DME) have their channel/band derived from the beacon's VHF frequency per the ICAO VOR/TACAN channelling plan instead of being silently skipped. The "Assign TACAN" dialog now warns in real time when the selected channel/band is already in use by a map beacon or another carrier/airfield/flight. (#36)
 * **[Map]** Right-clicking a front line under a blue flight-plan route now opens the new-package dialog instead of the browser context menu (the route's invisible hover overlay swallowed the click).

--- a/game/missiongenerator/aircraft/waypoints/strikeingress.py
+++ b/game/missiongenerator/aircraft/waypoints/strikeingress.py
@@ -62,6 +62,11 @@ class StrikeIngressBuilder(PydcsWaypointBuilder):
     def add_strike_tasks(
         self, waypoint: MovingPoint, weapon_type: WeaponType = WeaponType.Auto
     ) -> None:
+        if not self.waypoint.targets:
+            # Nothing to strike (e.g. an objective whose units are all already
+            # destroyed). Skip -- as add_bombing_tasks does -- so we neither add
+            # an empty attack task nor divide by zero on the units/targets ratio.
+            return
         bomber = self.group.units[0].unit_type in [B_1B, B_52H]
         ratio = len(self.group.units) / len(self.waypoint.targets)
         for target in self.waypoint.targets:

--- a/tests/missiongenerator/aircraft/test_strikeingress.py
+++ b/tests/missiongenerator/aircraft/test_strikeingress.py
@@ -1,0 +1,27 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+from game.missiongenerator.aircraft.waypoints.strikeingress import (
+    StrikeIngressBuilder,
+)
+
+
+def test_add_strike_tasks_handles_no_targets() -> None:
+    """Regression: a Strike against an objective whose units are all destroyed
+    leaves the strike waypoint with no targets. add_strike_tasks must not divide
+    by zero (len(units) / len(targets)) and must add no bombing task.
+    """
+    # Bypass __init__ (needs a full mission/flight); only add_strike_tasks() and
+    # the attributes it reads are exercised.
+    builder: Any = object.__new__(StrikeIngressBuilder)
+    builder.waypoint = MagicMock()
+    builder.waypoint.targets = []
+    builder.group = MagicMock()
+    builder.group.units = [MagicMock()]  # would make the ratio 1 / 0 if reached
+
+    waypoint = MagicMock()
+    waypoint.tasks = []
+
+    builder.add_strike_tasks(waypoint)  # must not raise ZeroDivisionError
+
+    assert waypoint.tasks == []


### PR DESCRIPTION
Fixes #948.

`add_strike_tasks` computes `len(self.group.units) / len(self.waypoint.targets)` to decide how much ordnance each aircraft expends per target. When a Strike is planned against an objective whose units are all already destroyed, the strike waypoint carries no targets and that division raises `ZeroDivisionError`. Mission generation dies for the whole turn, and the save stays stuck because replanning hits the same objective again.

The sibling `add_bombing_tasks` already guards its target loop. The same early return is used here: no targets means no attack task, rather than an empty one.

## Changes

- `game/missiongenerator/aircraft/waypoints/strikeingress.py` — early return when the waypoint has no targets.
- `tests/missiongenerator/aircraft/test_strikeingress.py` — regression test that fails with `ZeroDivisionError` before the fix.
- `changelog.md` — entry under Fixes.

## Validation

On `dev` @ `59719b24`: Black clean (743 files), mypy clean (491 source files), pytest 453 passed / 2 skipped.

## Note for the reporter

This fixes the empty-target path at the traceback's line. The reporter states their motor pool is filled, so I cannot confirm from the issue alone that their save takes this path rather than another route to an empty target list. Worth re-testing against the attached save before closing.
