### PR TITLE
Stop generic AAA sites from auto-spawning a search radar

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 * **[Modding]** Update UH-60L mod to v2.1.5 including MH-60L DAP
 
 ## Fixes
+* **[Layouts]** Generic AAA sites no longer auto-fill a search radar from the faction's pool, which handed optically-guided gun batteries whatever radar the faction owned (a Patriot STR alongside 88 mm guns, for example). The radar slot stays available to groups that explicitly bring one. (#901)
 * **[Mission Generation]** Fix mission generation dying on "Duplicate convoy unit": convoy and cargo-ship names no longer reset each turn onto a convoy still in transit.
 * **[Mission Generator]** Dynamically allocated TACAN channels no longer collide with map beacons: DME/VOR-DME beacons (which share TACAN's channelization) are now blacklisted alongside TACAN/VORTAC, and beacons whose DCS data omits a channel (e.g. Syria's KALDE "KAD" VOR-DME) have their channel/band derived from the beacon's VHF frequency per the ICAO VOR/TACAN channelling plan instead of being silently skipped. The "Assign TACAN" dialog now warns in real time when the selected channel/band is already in use by a map beacon or another carrier/airfield/flight. (#36)
 * **[Map]** Right-clicking a front line under a blue flight-plan route now opens the new-package dialog instead of the browser context menu (the route's invisible hover overlay swallowed the click).

--- a/resources/layouts/anti_air/AAA_Site.yaml
+++ b/resources/layouts/anti_air/AAA_Site.yaml
@@ -6,7 +6,8 @@ tasks:
 groups:
   - AAA:
     - name: AAA Site Radar
-      optional: true # Optional if the AAA Site has a Radar
+      optional: true # Only spawned for groups that explicitly bring a radar (e.g. KS-19 Fire Can)
+      fill: false # Do not auto-fill a SearchRadar into generic AAA sites: keep them optically-guided guns
       unit_count:
         - 1
       unit_classes:


### PR DESCRIPTION
Fixes #901.

The generic `AAA Site` layout carries an optional Search Radar slot. Optional slots default to `fill: true`, so `start_generator` fills the slot with whatever unit the faction owns in the `SearchRadar` class. For a battery of optically-guided guns that is wrong at any range — the issue's screenshot shows a Patriot STR standing over 88 mm guns, which the guns cannot use.

Setting `fill: false` leaves the slot in place for groups that explicitly bring a radar, while a generic site stays what it is meant to be.

## Changes

- `resources/layouts/anti_air/AAA_Site.yaml` — `fill: false` on the radar slot, and the slot comment now says what the slot is for.
- `changelog.md` — entry under Fixes.

`AAA_Site_Small.yaml` has no radar slot and is untouched.

## Validation

On `dev` @ `59719b24`: Black clean, mypy clean (490 source files), pytest 452 passed / 2 skipped.

Loaded the layout directly to confirm the flags land as intended: `AAA Site Radar` reads `fill=False`, while `AAA Site` and `AAA Site Logistics` keep `fill=True`.

Resources only. The layout signature added this release reloads the binary automatically, so no regenerated pickle is needed.
