### PR TITLE
[FIX] Faction-editor papercuts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,9 @@
 * **[Modding]** Update UH-60L mod to v2.1.5 including MH-60L DAP
 
 ## Fixes
+* **[UX]** Editing a faction from the Air Wing dialog now takes effect in the running campaign; only preset-group changes did before.
+* **[UX]** The faction editor's tick boxes did nothing outside the New Game wizard; entries have a remove button there instead, which refuses a unit the campaign still has deployed.
+* **[UX]** The faction editor sorts its lists by the name shown rather than the internal DCS id.
 * **[Mission Generation]** Fix mission generation dying on "Duplicate convoy unit": convoy and cargo-ship names no longer reset each turn onto a convoy still in transit.
 * **[Mission Generator]** Dynamically allocated TACAN channels no longer collide with map beacons: DME/VOR-DME beacons (which share TACAN's channelization) are now blacklisted alongside TACAN/VORTAC, and beacons whose DCS data omits a channel (e.g. Syria's KALDE "KAD" VOR-DME) have their channel/band derived from the beacon's VHF frequency per the ICAO VOR/TACAN channelling plan instead of being silently skipped. The "Assign TACAN" dialog now warns in real time when the selected channel/band is already in use by a map beacon or another carrier/airfield/flight. (#36)
 * **[Map]** Right-clicking a front line under a blue flight-plan route now opens the new-package dialog instead of the browser context menu (the route's invisible hover overlay swallowed the click).

--- a/qt_ui/windows/AirWingDialog.py
+++ b/qt_ui/windows/AirWingDialog.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterator, Optional
+from typing import Any, Iterator, Optional
 
 from PySide6.QtCore import QItemSelectionModel, QModelIndex, QSize
 from PySide6.QtWidgets import (
@@ -290,8 +290,10 @@ class AirWingTabs(QTabWidget):
             self,
             show_jtac=True,
             show_doctrine=True,
+            editable=True,
+            in_use=lambda unit: self._in_use_by(unit, Player.BLUE),
         )
-        qfu_ownfor.preset_groups_changed.connect(self.preset_group_updated_ownfor)
+        qfu_ownfor.faction_changed.connect(self.faction_updated_ownfor)
         self.addTab(
             qfu_ownfor,
             "Faction OWNFOR",
@@ -301,8 +303,10 @@ class AirWingTabs(QTabWidget):
             self,
             show_jtac=True,
             show_doctrine=True,
+            editable=True,
+            in_use=lambda unit: self._in_use_by(unit, Player.RED),
         )
-        qfu_opfor.preset_groups_changed.connect(self.preset_group_updated_opfor)
+        qfu_opfor.faction_changed.connect(self.faction_updated_opfor)
         self.addTab(
             qfu_opfor,
             "Faction OPFOR",
@@ -314,13 +318,48 @@ class AirWingTabs(QTabWidget):
         EventStream.put_nowait(events)
         self.game_model.ato_model.on_sim_update(events)
 
-    def preset_group_updated_ownfor(self, f: Faction) -> None:
-        self.preset_group_updated(f, player=Player.BLUE)
+    def _in_use_by(self, unit: Any, player: Player) -> Optional[str]:
+        """Why this side cannot give up ``unit`` yet, or None if it can.
 
-    def preset_group_updated_opfor(self, f: Faction) -> None:
-        self.preset_group_updated(f, player=Player.RED)
+        Deliberately counts what is ON THE MAP rather than what the faction lists:
+        the point is to keep the campaign consistent, not the paperwork.
+        """
+        coalition = self.game_model.game.coalition_for(player)
+        squadrons = [
+            s for s in coalition.air_wing.iter_squadrons() if s.aircraft == unit
+        ]
+        if squadrons:
+            names = ", ".join(sorted(str(s.name) for s in squadrons)[:3])
+            more = " and others" if len(squadrons) > 3 else ""
+            return f"{len(squadrons)} squadron(s) fly it ({names}{more})"
+        deployed = 0
+        for cp in self.game_model.game.theater.controlpoints:
+            if cp.captured != player:
+                continue
+            for tgo in cp.ground_objects:
+                for theater_unit in getattr(tgo, "units", []):
+                    if getattr(theater_unit, "unit_type", None) == unit:
+                        deployed += 1
+        if deployed:
+            return f"{deployed} of them are deployed on the map"
+        return None
 
-    def preset_group_updated(self, f: Faction, player: Player) -> None:
+    def faction_updated_ownfor(self, f: Faction) -> None:
+        self.faction_updated(f, player=Player.BLUE)
+
+    def faction_updated_opfor(self, f: Faction) -> None:
+        self.faction_updated(f, player=Player.RED)
+
+    def faction_updated(self, f: Faction, player: Player) -> None:
+        """Rebuild the coalition's forces from the faction as it now stands.
+
+        ArmedForces is built from the faction once, in Coalition.__init__, and each
+        ForceGroup freezes the unit list it could reach at that moment. So editing the
+        faction mid-campaign changed nothing that the buy menus could see: adding an
+        early-warning radar left the EWR site still offering the SAM search radars it
+        had fallen back to, and adding a second one after a rebuild never appeared at
+        all. Rebuilding here costs a moment on a dialog the player already stopped at.
+        """
         self.game_model.game.coalition_for(player).armed_forces = ArmedForces(f)
 
 

--- a/qt_ui/windows/newgame/WizardPages/QFactionSelection.py
+++ b/qt_ui/windows/newgame/WizardPages/QFactionSelection.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import json
 from copy import deepcopy
-from typing import Union, Callable, Set, Optional, List
+from typing import Any, Union, Callable, Set, Optional, List
 
 from PySide6 import QtWidgets, QtGui
 from PySide6.QtCore import Qt, Signal
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QLabel,
     QTextBrowser,
+    QMessageBox,
     QPushButton,
     QComboBox,
     QHBoxLayout,
@@ -37,7 +38,11 @@ from qt_ui.windows.newgame.jinja_env import jinja_env
 
 
 class QFactionUnits(QScrollArea):
-    preset_groups_changed = Signal(Faction)
+    #: Emitted whenever anything the faction fields changes -- a preset group, a
+    #: unit, an aircraft. In a running campaign the coalition's ArmedForces are built
+    #: from the faction ONCE, so a listener has to rebuild them or the change is
+    #: invisible until a new campaign.
+    faction_changed = Signal(Faction)
 
     def __init__(
         self,
@@ -45,6 +50,8 @@ class QFactionUnits(QScrollArea):
         parent=None,
         show_jtac: bool = False,
         show_doctrine: bool = False,
+        editable: bool = False,
+        in_use: Optional[Callable[[Any], Optional[str]]] = None,
     ):
         super().__init__()
         self.setWidgetResizable(True)
@@ -53,6 +60,15 @@ class QFactionUnits(QScrollArea):
         self.parent = parent
         self.faction = faction
         self.doctrine_combo: Optional[QComboBox] = None
+        # In the New Game wizard the tick boxes ARE the mechanism: unticking one drops
+        # the unit from the faction the campaign is built with, and non-destructively,
+        # since the faction here is the shared one loaded from disk. In a running
+        # campaign nothing reads them, so there the entry gets a remove button instead.
+        self.editable = editable
+        # Asked, before removing anything, whether the campaign is already using it.
+        # Returns a reason to refuse, or None to allow. The wizard passes nothing:
+        # there is no campaign yet, so nothing can be in use.
+        self.in_use = in_use
         self._create_checkboxes(show_jtac, show_doctrine)
         self.show_jtac = show_jtac
         self.show_doctrine = show_doctrine
@@ -65,11 +81,31 @@ class QFactionUnits(QScrollArea):
         combo_layout: Optional[QHBoxLayout] = None,
     ) -> int:
         counter += 1
-        for i, v in enumerate(sorted(units, key=lambda x: str(x)), counter):
+        for i, v in enumerate(sorted(units, key=lambda x: str(x).lower()), counter):
+            # A checkbox promised a removal it never performed: unticking one and
+            # closing the dialog left the entry in place, because the ticks are only
+            # read by the New Game wizard's save path. A button removes it here and
+            # now, and the entry reappears in the combo box above.
+            # Always built and registered: the wizard's save path reads every entry,
+            # and one left unshown reads as checked, i.e. kept.
             cb = QCheckBox(str(v))
             cb.setCheckState(Qt.CheckState.Checked)
             self.checkboxes[str(v)] = cb
-            grid.addWidget(cb, i, 1)
+            if not self.editable:
+                grid.addWidget(cb, i, 1)
+                counter += 1
+                continue
+            row = QHBoxLayout()
+            row.addWidget(QLabel(str(v)))
+            row.addStretch()
+            remove = QPushButton("✕")
+            remove.setToolTip(f"Remove {v}")
+            remove.setFixedWidth(28)
+            remove.clicked.connect(
+                lambda _=False, unit=v, group=units: self._on_remove_unit(unit, group)
+            )
+            row.addWidget(remove)
+            grid.addLayout(row, i, 1)
             counter += 1
         if combo_layout:
             counter += 1
@@ -261,7 +297,8 @@ class QFactionUnits(QScrollArea):
     def _create_aircraft_combobox(
         self, cb: QComboBox, callback: Callable, predicate: Callable
     ):
-        for ac_dcs in sorted(AircraftType.each_dcs_type(), key=lambda x: x.id):
+        offered = []
+        for ac_dcs in AircraftType.each_dcs_type():
             for ac in AircraftType.for_dcs_type(ac_dcs):
                 if (
                     ac in self.faction.aircraft
@@ -269,41 +306,47 @@ class QFactionUnits(QScrollArea):
                     or ac in self.faction.tankers
                 ):
                     continue
-                predicate(ac)
+                offered.append(ac)
+        for ac in sorted(offered, key=lambda a: str(a.variant_id).lower()):
+            predicate(ac)
         hbox = self._format(cb, callback)
         return hbox
 
     def _create_unit_combobox(
         self, cb: QComboBox, callback: Callable, units: Set[GroundUnitType], type: list
     ):
-        for dcs_unit in sorted(GroundUnitType.each_dcs_type(), key=lambda x: x.id):
+        # Sorted by the name the player reads, not by the internal DCS id: the two
+        # orders are unrelated, so the list looked shuffled.
+        offered = []
+        for dcs_unit in GroundUnitType.each_dcs_type():
             if dcs_unit not in self.faction.country.vehicles:
                 continue
             for unit in GroundUnitType.for_dcs_type(dcs_unit):
                 if unit in units:
                     continue
-                if "Frontline vehicles" in type:
-                    cb.addItem(unit.variant_id, unit)
-                elif unit.unit_class.value in type:
-                    cb.addItem(unit.variant_id, unit)
-                else:
-                    continue
+                if "Frontline vehicles" in type or unit.unit_class.value in type:
+                    offered.append(unit)
+        for unit in sorted(offered, key=lambda u: str(u.variant_id).lower()):
+            cb.addItem(unit.variant_id, unit)
         hbox = self._format(cb, callback)
         return hbox
 
     def _create_naval_combobox(self, cb: QComboBox, callback: Callable):
-        for ship_dcs in sorted(ShipUnitType.each_dcs_type(), key=lambda x: x.id):
+        offered = []
+        for ship_dcs in ShipUnitType.each_dcs_type():
             for ship in ShipUnitType.for_dcs_type(ship_dcs):
                 if ship in self.faction.naval_units:
                     continue
-                cb.addItem(ship.variant_id, ship)
+                offered.append(ship)
+        for ship in sorted(offered, key=lambda s: str(s.variant_id).lower()):
+            cb.addItem(ship.variant_id, ship)
         hbox = self._format(cb, callback)
         return hbox
 
     def _create_preset_group_combobox(self, cb: QComboBox, callback: Callable):
         ForceGroup._load_all()
         preset_group_names = {pg.name for pg in self.faction.preset_groups}
-        for preset_group in ForceGroup._by_name:
+        for preset_group in sorted(ForceGroup._by_name, key=str.lower):
             if preset_group in preset_group_names:
                 continue
             cb.addItem(preset_group, ForceGroup._by_name[preset_group])
@@ -316,6 +359,7 @@ class QFactionUnits(QScrollArea):
             # invalidate the cached property
             del self.faction.__dict__["accessible_units"]
         self.updateFaction(self.faction)
+        self.faction_changed.emit(self.faction)
 
     def _on_add_ac(self, aircraft: Set[AircraftType], cb: QComboBox):
         aircraft.add(cb.currentData())
@@ -323,6 +367,7 @@ class QFactionUnits(QScrollArea):
             # invalidate the cached property
             del self.faction.__dict__["all_aircrafts"]
         self.updateFaction(self.faction)
+        self.faction_changed.emit(self.faction)
 
     def _on_add_preset_group(self, groups: List[ForceGroup], cb: QComboBox):
         groups.append(cb.currentData())
@@ -330,7 +375,30 @@ class QFactionUnits(QScrollArea):
             # invalidate the cached property
             del self.faction.__dict__["accessible_units"]
         self.updateFaction(self.faction)
-        self.preset_groups_changed.emit(self.faction)
+        self.faction_changed.emit(self.faction)
+
+    def _on_remove_unit(self, unit: Any, units: Union[set, list]) -> None:
+        """Drop a unit from the faction and tell anyone who cares.
+
+        Refused while the campaign is still using it: removing a unit the map already
+        has deployed leaves the game holding materiel its own faction no longer
+        admits, and nothing downstream expects that.
+        """
+        reason = self.in_use(unit) if self.in_use else None
+        if reason:
+            QMessageBox.information(
+                self,
+                "Still in use",
+                f"{unit} cannot be removed: {reason}. Remove or replace it in "
+                f"the campaign first.",
+            )
+            return
+        if unit in units:
+            units.remove(unit)
+        for cached in ("accessible_units", "all_aircrafts"):
+            self.faction.__dict__.pop(cached, None)
+        self.updateFaction(self.faction)
+        self.faction_changed.emit(self.faction)
 
     def updateFaction(self, faction: Faction):
         self.faction = faction

--- a/tests/test_faction_edit_rebuilds_forces.py
+++ b/tests/test_faction_edit_rebuilds_forces.py
@@ -1,0 +1,123 @@
+"""Editing a faction mid-campaign has to rebuild the coalition's forces.
+
+`ArmedForces` is built from the faction once, in `Coalition.__init__`, and every
+`ForceGroup` freezes the unit list it could reach at that moment. So a faction edit that
+does not trigger a rebuild is invisible to every buy menu until the next campaign.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from game import persistency
+
+from game.armedforces.armedforces import ArmedForces
+from game.data.units import UnitClass
+from game.dcs.groundunittype import GroundUnitType
+from game.factions import FACTIONS
+
+
+@pytest.fixture(autouse=True)
+def _init_persistency(tmp_path_factory: pytest.TempPathFactory) -> None:
+    # Layout/preset loading reads the DCS saved-game folder, only configured once the
+    # app boots. An empty temp dir makes it fall back to the bundled resources.
+    persistency.setup(
+        str(tmp_path_factory.mktemp("saved_games")),
+        prefer_liberation_payloads=False,
+        port=0,
+    )
+
+
+def _ewr_options(faction: Any) -> set[str]:
+    """What the generic Early-Warning Radar site would offer for this faction."""
+    forces = ArmedForces(faction)
+    offered: set[str] = set()
+    for force_group in forces.forces:
+        for layout in force_group.layouts:
+            if layout.name != "Early-Warning Radar":
+                continue
+            for unit_group in layout.all_unit_groups:
+                for unit_type in force_group.unit_types_for_group(unit_group):
+                    offered.add(unit_type.display_name)
+    return offered
+
+
+def test_an_added_early_warning_radar_reaches_the_buy_menu() -> None:
+    """The reported case: adding an EWR to a faction left the EWR site still offering
+    the SAM search radars it had fallen back to."""
+    faction = FACTIONS["Bluefor Modern"]
+    before = _ewr_options(faction)
+    assert before, "the EWR site should offer something"
+
+    added = GroundUnitType.named("EWR 1L13")
+    assert added.unit_class is UnitClass.EARLY_WARNING_RADAR
+    if added in faction.air_defense_units:
+        return  # already fielded; nothing this test can add
+
+    faction.air_defense_units.add(added)
+    faction.__dict__.pop("accessible_units", None)
+    try:
+        after = _ewr_options(faction)
+        assert added.display_name in after, (
+            "a rebuild must pick up the unit the faction gained; without one the buy "
+            "menu keeps whatever the ForceGroup froze at campaign start"
+        )
+    finally:
+        faction.air_defense_units.discard(added)
+        faction.__dict__.pop("accessible_units", None)
+
+
+def test_every_faction_edit_announces_itself() -> None:
+    """The bug was a signal wired to preset groups alone, so adding a unit or an
+    aircraft changed the faction silently and nothing rebuilt."""
+    import inspect
+
+    from qt_ui.windows.newgame.WizardPages import QFactionSelection
+
+    source = inspect.getsource(QFactionSelection.QFactionUnits)
+    for handler in ("_on_add_unit", "_on_add_ac", "_on_add_preset_group"):
+        start = source.index(f"def {handler}(")
+        body = source[start : source.index("\n    def ", start + 1)]
+        assert "faction_changed.emit" in body, f"{handler} must announce the change"
+
+
+def test_removing_a_unit_actually_removes_it() -> None:
+    """The tick box promised a removal it never performed: it is only read by the New
+    Game wizard's save path, so unticking one in a running campaign did nothing."""
+    import inspect
+
+    from qt_ui.windows.newgame.WizardPages import QFactionSelection
+
+    source = inspect.getsource(QFactionSelection.QFactionUnits)
+    assert "_on_remove_unit" in source, "the list needs a real remove, not a tick box"
+    start = source.index("def _on_remove_unit(")
+    body = source[start : source.index(chr(10) + "    def ", start + 1)]
+    assert "units.remove(unit)" in body
+    assert "faction_changed.emit" in body, "a removal must rebuild the forces too"
+
+
+def test_a_unit_in_use_is_refused() -> None:
+    """Removing a unit the map has deployed would leave the campaign holding materiel
+    its own faction no longer admits."""
+    import inspect
+
+    from qt_ui.windows.newgame.WizardPages import QFactionSelection
+
+    source = inspect.getsource(QFactionSelection.QFactionUnits)
+    start = source.index("def _on_remove_unit(")
+    body = source[start : source.index(chr(10) + "    def ", start + 1)]
+    guard = body.index("self.in_use(unit)")
+    assert guard < body.index("units.remove(unit)"), "check before removing"
+    assert "return" in body[guard : body.index("units.remove(unit)")]
+
+
+def test_the_dialog_rebuilds_on_that_signal() -> None:
+    import inspect
+
+    from qt_ui.windows import AirWingDialog
+
+    source = inspect.getsource(AirWingDialog)
+    assert source.count("faction_changed.connect") == 2, "both sides must be wired"
+    assert "armed_forces = ArmedForces(f)" in source


### PR DESCRIPTION
Three fixes to the Air Wing dialog's faction tabs. The first two affect a running campaign only; the New Game wizard was never wrong.

1. A faction edit did not reach the buy menus: A coalition's forces are built from its faction once, at campaign start, and each force group freezes the units it could reach then. The rebuild was wired to `preset_groups_changed` alone, so adding a *unit* changed nothing you could buy — adding an early-warning radar left every EWR site still offering the SAM search radars it had fallen back to. The signal now covers every mutation.

2. Outside of the New Campaign dialog, the tick boxes never removed anything: Unticking a unit and closing the dialog when opened from the Air Wing button inside a campaign, left it in place: the ticks are only read by the wizard's save path. Entries get a remove button instead, and the dead tick box is hidden here (still built, so the wizard keeps working — an unshown one reads as kept). Removing a unit that is used in the campaign is not allowed and will show a popup indicating the problem.

3. Both lists sort by name: They were ordered by the internal DCS id, which is unrelated to the displayed name, so the combo box looked shuffled. Case-insensitive.