### PR TITLE
Time strikes into the window behind their SEAD

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
-* **[Options]** New campaign setting "Strikes push behind their SEAD window" (off by default). Packages are timed independently, so a strike could arrive at a defended target long before the SEAD package tasked against the SAM covering it. With the option on, AI strike/BAI/OCA/CAS packages whose target sits inside a threat ring a SEAD/DEAD package is servicing are retimed into the window just behind it. Player packages are never rescheduled.
+* **[Options]** New campaign setting "Strikes push behind their SEAD window" (off by default). Packages are timed independently, so a strike could arrive at a defended target long before the SEAD package tasked against the SAM covering it. With the option on, AI strike, BAI, OCA, armed recon and CAS packages whose target sits inside a threat ring a SEAD/DEAD package is servicing are retimed into the window just behind it. Player packages are never rescheduled.
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[Options]** New campaign setting "Strikes push behind their SEAD window" (off by default). Packages are timed independently, so a strike could arrive at a defended target long before the SEAD package tasked against the SAM covering it. With the option on, AI strike/BAI/OCA/CAS packages whose target sits inside a threat ring a SEAD/DEAD package is servicing are retimed into the window just behind it. Player packages are never rescheduled.
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.

--- a/game/commander/missionscheduler.py
+++ b/game/commander/missionscheduler.py
@@ -58,15 +58,16 @@ class MissionScheduler:
     #: strike randomly spread far beyond this is pulled back into the window).
     SEAD_WINDOW_DURATION = timedelta(minutes=8)
 
-    #: The strike-class package types timed into a SEAD window. Armed Recon (a
-    #: loitering sweep, not a push) and AIR ASSAULT (tied to the ground war's
-    #: timing) deliberately stay on the spread schedule.
+    #: The package types timed into a SEAD window.
     #:
-    #: CAS is here for the front-line sandwich: it descends to acquire and eats
-    #: MANPADS low, climbs to escape into the area-SAM ring high, so a front
-    #: under a live SAM umbrella wants that umbrella down first, exactly as a
-    #: strike does. Its organic SEAD_SWEEP escort flies the package's own TOT
-    #: and so accompanies rather than pre-suppresses.
+    #: CAS is the only PatrollingFlightPlan in the set. It is here because the
+    #: front it patrols sits under the ring, and it climbs into that ring to
+    #: escape MANPADS low. Its organic SEAD_SWEEP escort flies the package's
+    #: own TOT, so it accompanies rather than pre-suppresses.
+    #:
+    #: ARMED_RECON and AIR_ASSAULT stay on the spread schedule as scope, not
+    #: mechanism: both are FormationAttackFlightPlans against a ControlPoint,
+    #: structurally the same tasking as OCA, and nothing here prevents them.
     COORDINATED_STRIKE_TYPES = frozenset(
         {
             FlightType.STRIKE,

--- a/game/commander/missionscheduler.py
+++ b/game/commander/missionscheduler.py
@@ -4,7 +4,7 @@ import logging
 import random
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Iterator, TYPE_CHECKING
+from typing import Iterator, Optional, TYPE_CHECKING
 
 from game.ato.flighttype import FlightType
 from game.ato.traveltime import TotEstimator
@@ -15,7 +15,68 @@ if TYPE_CHECKING:
     from game.ato import Package
 
 
+def coordinated_strike_tot(
+    strike_tot: datetime,
+    earliest_tot: datetime,
+    provider_tots: list[datetime],
+    lead: timedelta,
+    duration: timedelta,
+) -> Optional[datetime]:
+    """The TOT placing a strike inside its SEAD window, or None to keep it.
+
+    The window opens ``lead`` after the LATEST covering SEAD/DEAD package's TOT
+    (every suppressor on station first) and lasts ``duration`` (push while the
+    suppression holds). A strike already inside the window keeps its TOT; one
+    outside is moved to the window opening -- delayed if it would have arrived
+    before its SEAD (the naked-strike case), pulled forward if the random
+    spread had left it long after the window closed. Never earlier than the
+    package can physically fly (``earliest_tot``); if even that is past the
+    window the TOT is kept unless keeping it would still put the strike ahead
+    of its SEAD.
+    """
+    if not provider_tots:
+        return None
+    window_start = max(provider_tots) + lead
+    window_end = window_start + duration
+    if window_start <= strike_tot <= window_end:
+        return None
+    desired = max(window_start, earliest_tot)
+    if desired > window_end and strike_tot >= window_start:
+        # Can't make the window, but at least the strike isn't ahead of its
+        # SEAD. Leave the spread schedule alone.
+        return None
+    if desired == strike_tot:
+        return None
+    return desired
+
+
 class MissionScheduler:
+    #: How long after the covering SEAD/DEAD package's TOT the strike window
+    #: opens (suppressors on station first) ...
+    SEAD_WINDOW_LEAD = timedelta(minutes=2)
+    #: ... and how long it stays open (push while the suppression holds; a
+    #: strike randomly spread far beyond this is pulled back into the window).
+    SEAD_WINDOW_DURATION = timedelta(minutes=8)
+
+    #: The strike-class package types timed into a SEAD window. Armed Recon (a
+    #: loitering sweep, not a push) and AIR ASSAULT (tied to the ground war's
+    #: timing) deliberately stay on the spread schedule.
+    #:
+    #: CAS is here for the front-line sandwich: it descends to acquire and eats
+    #: MANPADS low, climbs to escape into the area-SAM ring high, so a front
+    #: under a live SAM umbrella wants that umbrella down first, exactly as a
+    #: strike does. Its organic SEAD_SWEEP escort flies the package's own TOT
+    #: and so accompanies rather than pre-suppresses.
+    COORDINATED_STRIKE_TYPES = frozenset(
+        {
+            FlightType.STRIKE,
+            FlightType.BAI,
+            FlightType.OCA_RUNWAY,
+            FlightType.OCA_AIRCRAFT,
+            FlightType.CAS,
+        }
+    )
+
     def __init__(self, coalition: Coalition, desired_mission_length: timedelta) -> None:
         self.coalition = coalition
         self.desired_mission_length = desired_mission_length
@@ -97,6 +158,16 @@ class MissionScheduler:
                 # to be present. Runway and air started aircraft will be
                 # delayed until their takeoff time by AirConflictGenerator.
                 package.time_over_target = next(start_time) + tot
+
+        # Time strikes into their SEAD windows BEFORE collecting the recovery
+        # ETAs below: landing_time is derived from the package TOT, so a
+        # retimed package collected earlier would book its tanker against a
+        # landing it no longer flies.
+        self._coordinate_sead_windows(now)
+
+        for package in self.coalition.ato.packages:
+            if package.primary_task is FlightType.RECOVERY:
+                continue
             for f in package.flights:
                 if f.departure.is_fleet and not f.is_helo:
                     carrier_etas[f.departure].append(
@@ -120,6 +191,68 @@ class MissionScheduler:
         ]:
             if carrier_etas[package.target]:
                 package.time_over_target = carrier_etas[package.target].pop(0)
+
+    def _coordinate_sead_windows(self, now: datetime) -> None:
+        """Cross-package SEAD-before-strike sequencing.
+
+        Packages are timed independently, so nothing stops the random spread
+        from sending a strike into a defended target half an hour BEFORE the
+        SEAD package tasked against the SAM covering it. This pass finds, for
+        every movable strike-class package, the SEAD/DEAD packages whose target
+        ground object's threat ring covers the strike's target, and retimes the
+        strike into the window just behind the latest of them. Several strikes
+        behind one SEAD mass into the same window, which is the point -- it
+        reads as a push.
+
+        Only AI, non-ASAP packages move: a package with a player flight is
+        never rescheduled, but a player-flown SEAD still opens a window the AI
+        strikes push behind, because providers are only read.
+        """
+        if not self.coalition.game.settings.sead_strike_coordination:
+            return
+        providers: list[tuple[Package, float]] = []
+        for package in self.coalition.ato.packages:
+            if package.primary_task not in (FlightType.SEAD, FlightType.DEAD):
+                continue
+            # SEAD/DEAD is planned against a SAM ground object; duck-typed so
+            # any non-TGO tasking degrades to "no window" rather than crashing.
+            threat_range = getattr(package.target, "max_threat_range", None)
+            if threat_range is None:
+                continue
+            ring_meters = threat_range().meters
+            if ring_meters <= 0:
+                continue
+            providers.append((package, ring_meters))
+        if not providers:
+            return
+        for package in self.coalition.ato.packages:
+            if package.primary_task not in self.COORDINATED_STRIKE_TYPES:
+                continue
+            if package.auto_asap or package.has_players:
+                continue
+            provider_tots = [
+                p.time_over_target
+                for p, ring in providers
+                if p.target.position.distance_to_point(package.target.position) <= ring
+            ]
+            if not provider_tots:
+                continue
+            new_tot = coordinated_strike_tot(
+                package.time_over_target,
+                TotEstimator(package).earliest_tot(now),
+                provider_tots,
+                self.SEAD_WINDOW_LEAD,
+                self.SEAD_WINDOW_DURATION,
+            )
+            if new_tot is not None:
+                logging.debug(
+                    "SEAD window: retimed %s vs %s from %s to %s",
+                    package.primary_task,
+                    getattr(package.target, "name", "target"),
+                    package.time_over_target,
+                    new_tot,
+                )
+                package.time_over_target = new_tot
 
     @staticmethod
     def _get_departure_time(package: Package) -> datetime | None:

--- a/game/commander/missionscheduler.py
+++ b/game/commander/missionscheduler.py
@@ -58,22 +58,26 @@ class MissionScheduler:
     #: strike randomly spread far beyond this is pulled back into the window).
     SEAD_WINDOW_DURATION = timedelta(minutes=8)
 
-    #: The package types timed into a SEAD window.
+    #: The package types timed into a SEAD window: every FormationAttack
+    #: tasking that makes one timed arrival on a point inside a threat ring,
+    #: plus CAS.
     #:
-    #: CAS is the only PatrollingFlightPlan in the set. It is here because the
+    #: CAS is the only PatrollingFlightPlan here. It is included because the
     #: front it patrols sits under the ring, and it climbs into that ring to
     #: escape MANPADS low. Its organic SEAD_SWEEP escort flies the package's
     #: own TOT, so it accompanies rather than pre-suppresses.
     #:
-    #: ARMED_RECON and AIR_ASSAULT stay on the spread schedule as scope, not
-    #: mechanism: both are FormationAttackFlightPlans against a ControlPoint,
-    #: structurally the same tasking as OCA, and nothing here prevents them.
+    #: AIR_ASSAULT is the one FormationAttack tasking left out, and not for
+    #: want of a covering ring: it is ROTARY_WING, so massing a slow helo into
+    #: an eight-minute window with fast movers converging on the same point
+    #: trades a suppression gain for a deconfliction risk.
     COORDINATED_STRIKE_TYPES = frozenset(
         {
             FlightType.STRIKE,
             FlightType.BAI,
             FlightType.OCA_RUNWAY,
             FlightType.OCA_AIRCRAFT,
+            FlightType.ARMED_RECON,
             FlightType.CAS,
         }
     )

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -230,6 +230,22 @@ class Settings:
         detail="Implicitly determines the number of Tanker flights planned by taking the mission duration"
         " and dividing it by the desired on-station time.",
     )
+    sead_strike_coordination: bool = boolean_option(
+        "Strikes push behind their SEAD window",
+        page=CAMPAIGN_DOCTRINE_PAGE,
+        section=GENERAL_SECTION,
+        default=False,
+        detail=(
+            "Packages are timed independently, so a strike can arrive at a "
+            "defended target half an hour before the SEAD package tasked "
+            "against the SAM covering it. With this on, each side's AI "
+            "strike, BAI, OCA and CAS packages whose target sits inside a SAM "
+            "threat ring that a SEAD/DEAD package is servicing are retimed "
+            "into the window just behind it, several packages massing behind "
+            "one suppressor. Player packages are never rescheduled, but a "
+            "player-flown SEAD still opens a window the AI pushes behind."
+        ),
+    )
     autoplan_tankers_for_strike: bool = boolean_option(
         "Auto-planner plans refueling flights for Strike packages",
         page=CAMPAIGN_DOCTRINE_PAGE,

--- a/tests/test_sead_strike_coordination.py
+++ b/tests/test_sead_strike_coordination.py
@@ -212,16 +212,22 @@ def test_cas_on_an_uncovered_front_keeps_the_spread_schedule() -> None:
     assert cas.time_over_target == _tot(10)
 
 
-def test_armed_recon_and_air_assault_stay_out_of_the_window() -> None:
-    # The two exclusions, pinned at the same front line the CAS above is
-    # retimed at, so sweeping them in fails here first and has to be a
-    # deliberate edit. Both are FormationAttackFlightPlans like the included
-    # types; they are out for scope, not because anything prevents them.
+def test_armed_recon_pushes_behind_the_sead() -> None:
+    # Armed Recon is a FormationAttackFlightPlan against a control point, the
+    # same shape as OCA, so a covering ring reaches it the same way.
     sead = _package(FlightType.SEAD, _tot(30), _sam_target())
-    recon = _package(FlightType.ARMED_RECON, _tot(10), _front_line(IN_RING))
-    assault = _package(FlightType.AIR_ASSAULT, _tot(10), _front_line(IN_RING))
-    _coordinate([sead, recon, assault])
-    assert recon.time_over_target == _tot(10)
+    recon = _package(FlightType.ARMED_RECON, _tot(10), _ground_target(IN_RING))
+    _coordinate([sead, recon])
+    assert recon.time_over_target == _tot(32)
+
+
+def test_air_assault_stays_out_of_the_window() -> None:
+    # The one exclusion, pinned inside a ring that would otherwise cover it so
+    # sweeping it in has to be a deliberate edit. Held out because it is
+    # rotary-wing, not because nothing reaches it.
+    sead = _package(FlightType.SEAD, _tot(30), _sam_target())
+    assault = _package(FlightType.AIR_ASSAULT, _tot(10), _ground_target(IN_RING))
+    _coordinate([sead, assault])
     assert assault.time_over_target == _tot(10)
 
 

--- a/tests/test_sead_strike_coordination.py
+++ b/tests/test_sead_strike_coordination.py
@@ -213,9 +213,10 @@ def test_cas_on_an_uncovered_front_keeps_the_spread_schedule() -> None:
 
 
 def test_armed_recon_and_air_assault_stay_out_of_the_window() -> None:
-    # The two deliberate exclusions, pinned at the same front line the CAS above
-    # is retimed at: a loitering sweep is not a push, and an assault is timed by
-    # the ground war. Sweeping them in later should fail here first.
+    # The two exclusions, pinned at the same front line the CAS above is
+    # retimed at, so sweeping them in fails here first and has to be a
+    # deliberate edit. Both are FormationAttackFlightPlans like the included
+    # types; they are out for scope, not because anything prevents them.
     sead = _package(FlightType.SEAD, _tot(30), _sam_target())
     recon = _package(FlightType.ARMED_RECON, _tot(10), _front_line(IN_RING))
     assault = _package(FlightType.AIR_ASSAULT, _tot(10), _front_line(IN_RING))

--- a/tests/test_sead_strike_coordination.py
+++ b/tests/test_sead_strike_coordination.py
@@ -1,0 +1,233 @@
+"""Cross-package SEAD-before-strike coordination.
+
+Locks the pure window math (delay the naked strike, keep an in-window TOT,
+pull a far-late TOT back, clamp to physics, degrade to no-op) and the
+scheduler wiring (threat-ring matching, the latest covering provider, player/
+ASAP immunity, provider read-only, the setting gate).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+from dcs.mapping import Point
+from dcs.terrain import Caucasus
+
+from game.ato.flighttype import FlightType
+from game.commander.missionscheduler import (
+    MissionScheduler,
+    coordinated_strike_tot,
+)
+from game.utils import meters
+
+T0 = datetime(2005, 4, 26, 23, 0)
+LEAD = timedelta(minutes=2)
+DURATION = timedelta(minutes=8)
+_TERRAIN = Caucasus()
+
+
+def _tot(minutes: float) -> datetime:
+    return T0 + timedelta(minutes=minutes)
+
+
+# --- the pure window math ---
+
+
+def test_naked_strike_is_delayed_behind_its_sead() -> None:
+    assert coordinated_strike_tot(
+        _tot(10), _tot(5), [_tot(30)], LEAD, DURATION
+    ) == _tot(32)
+
+
+def test_in_window_strike_keeps_its_tot() -> None:
+    assert coordinated_strike_tot(_tot(35), _tot(5), [_tot(30)], LEAD, DURATION) is None
+
+
+def test_far_late_strike_is_pulled_back_into_the_window() -> None:
+    assert coordinated_strike_tot(
+        _tot(120), _tot(5), [_tot(30)], LEAD, DURATION
+    ) == _tot(32)
+
+
+def test_pull_back_is_clamped_to_the_earliest_physical_tot() -> None:
+    assert coordinated_strike_tot(
+        _tot(120), _tot(36), [_tot(30)], LEAD, DURATION
+    ) == _tot(36)
+
+
+def test_unreachable_window_keeps_a_late_tot() -> None:
+    # Earliest possible arrival is past the window; the strike is already not
+    # ahead of its SEAD, so the spread schedule stands.
+    assert (
+        coordinated_strike_tot(_tot(120), _tot(50), [_tot(30)], LEAD, DURATION) is None
+    )
+
+
+def test_unreachable_window_still_never_leaves_a_strike_ahead_of_sead() -> None:
+    # Can't make the window either, but arriving BEFORE the SEAD is worse:
+    # delayed to the earliest physical arrival.
+    assert coordinated_strike_tot(
+        _tot(20), _tot(50), [_tot(30)], LEAD, DURATION
+    ) == _tot(50)
+
+
+def test_latest_covering_provider_opens_the_window() -> None:
+    assert coordinated_strike_tot(
+        _tot(10), _tot(5), [_tot(30), _tot(45)], LEAD, DURATION
+    ) == _tot(47)
+
+
+def test_no_providers_is_a_noop() -> None:
+    assert coordinated_strike_tot(_tot(10), _tot(5), [], LEAD, DURATION) is None
+
+
+# --- the scheduler wiring ---
+
+SAM_POS = Point(0, 0, _TERRAIN)
+IN_RING = Point(10_000, 0, _TERRAIN)
+OUT_OF_RING = Point(100_000, 0, _TERRAIN)
+RING = meters(46_300)  # ~25 NM
+
+
+def _sam_target() -> Any:
+    return SimpleNamespace(name="SAM", position=SAM_POS, max_threat_range=lambda: RING)
+
+
+def _ground_target(position: Point) -> Any:
+    # A strike target has no threat ring of its own to worry about here.
+    return SimpleNamespace(name="Factory", position=position)
+
+
+def _package(
+    task: FlightType,
+    tot: datetime,
+    target: Any,
+    players: bool = False,
+    asap: bool = False,
+) -> Any:
+    return SimpleNamespace(
+        primary_task=task,
+        time_over_target=tot,
+        target=target,
+        has_players=players,
+        auto_asap=asap,
+    )
+
+
+def _coordinate(packages: list[Any], on: bool = True) -> None:
+    coalition = SimpleNamespace(
+        ato=SimpleNamespace(packages=packages),
+        game=SimpleNamespace(settings=SimpleNamespace(sead_strike_coordination=on)),
+    )
+    scheduler = MissionScheduler(cast(Any, coalition), timedelta(hours=1))
+    with patch("game.commander.missionscheduler.TotEstimator") as estimator:
+        estimator.return_value.earliest_tot.return_value = _tot(5)
+        scheduler._coordinate_sead_windows(T0)
+
+
+def test_strike_in_the_sams_ring_pushes_behind_the_sead() -> None:
+    sead = _package(FlightType.SEAD, _tot(30), _sam_target())
+    strike = _package(FlightType.STRIKE, _tot(10), _ground_target(IN_RING))
+    _coordinate([sead, strike])
+    assert strike.time_over_target == _tot(32)
+    assert sead.time_over_target == _tot(30)  # provider is read-only
+
+
+def test_strike_outside_every_ring_keeps_the_spread_schedule() -> None:
+    sead = _package(FlightType.SEAD, _tot(30), _sam_target())
+    strike = _package(FlightType.STRIKE, _tot(10), _ground_target(OUT_OF_RING))
+    _coordinate([sead, strike])
+    assert strike.time_over_target == _tot(10)
+
+
+def test_player_and_asap_strikes_are_never_rescheduled() -> None:
+    sead = _package(FlightType.DEAD, _tot(30), _sam_target())
+    player = _package(
+        FlightType.STRIKE, _tot(10), _ground_target(IN_RING), players=True
+    )
+    asap = _package(FlightType.BAI, _tot(10), _ground_target(IN_RING), asap=True)
+    _coordinate([sead, player, asap])
+    assert player.time_over_target == _tot(10)
+    assert asap.time_over_target == _tot(10)
+
+
+def test_player_sead_still_opens_a_window_for_ai_strikes() -> None:
+    sead = _package(FlightType.SEAD, _tot(30), _sam_target(), players=True)
+    strike = _package(FlightType.OCA_RUNWAY, _tot(10), _ground_target(IN_RING))
+    _coordinate([sead, strike])
+    assert strike.time_over_target == _tot(32)
+    assert sead.time_over_target == _tot(30)
+
+
+def test_several_strikes_mass_behind_one_sead() -> None:
+    sead = _package(FlightType.SEAD, _tot(30), _sam_target())
+    early = _package(FlightType.STRIKE, _tot(10), _ground_target(IN_RING))
+    late = _package(FlightType.BAI, _tot(110), _ground_target(IN_RING))
+    _coordinate([sead, early, late])
+    assert early.time_over_target == _tot(32)
+    assert late.time_over_target == _tot(32)
+
+
+def test_setting_off_moves_nothing() -> None:
+    sead = _package(FlightType.SEAD, _tot(30), _sam_target())
+    strike = _package(FlightType.STRIKE, _tot(10), _ground_target(IN_RING))
+    _coordinate([sead, strike], on=False)
+    assert strike.time_over_target == _tot(10)
+
+
+def test_a_dead_sams_zero_ring_opens_no_window() -> None:
+    dead_sam = SimpleNamespace(
+        name="SAM", position=SAM_POS, max_threat_range=lambda: meters(0)
+    )
+    sead = _package(FlightType.DEAD, _tot(30), dead_sam)
+    strike = _package(FlightType.STRIKE, _tot(10), _ground_target(IN_RING))
+    _coordinate([sead, strike])
+    assert strike.time_over_target == _tot(10)
+
+
+# --- CAS and the front-line sandwich ---
+#
+# A FrontLine is a MissionTarget like any other here: a name and a position, no
+# threat ring of its own, so it duck-types as _ground_target does.
+
+
+def _front_line(position: Point) -> Any:
+    return SimpleNamespace(name="Front line Foo/Bar", position=position)
+
+
+def test_cas_under_a_live_sam_umbrella_pushes_behind_the_dead() -> None:
+    dead = _package(FlightType.DEAD, _tot(30), _sam_target())
+    cas = _package(FlightType.CAS, _tot(10), _front_line(IN_RING))
+    _coordinate([dead, cas])
+    assert cas.time_over_target == _tot(32)
+
+
+def test_cas_on_an_uncovered_front_keeps_the_spread_schedule() -> None:
+    dead = _package(FlightType.DEAD, _tot(30), _sam_target())
+    cas = _package(FlightType.CAS, _tot(10), _front_line(OUT_OF_RING))
+    _coordinate([dead, cas])
+    assert cas.time_over_target == _tot(10)
+
+
+def test_armed_recon_and_air_assault_stay_out_of_the_window() -> None:
+    # The two deliberate exclusions, pinned at the same front line the CAS above
+    # is retimed at: a loitering sweep is not a push, and an assault is timed by
+    # the ground war. Sweeping them in later should fail here first.
+    sead = _package(FlightType.SEAD, _tot(30), _sam_target())
+    recon = _package(FlightType.ARMED_RECON, _tot(10), _front_line(IN_RING))
+    assault = _package(FlightType.AIR_ASSAULT, _tot(10), _front_line(IN_RING))
+    _coordinate([sead, recon, assault])
+    assert recon.time_over_target == _tot(10)
+    assert assault.time_over_target == _tot(10)
+
+
+def test_cas_and_a_strike_mass_into_one_window() -> None:
+    sead = _package(FlightType.SEAD, _tot(30), _sam_target())
+    cas = _package(FlightType.CAS, _tot(10), _front_line(IN_RING))
+    strike = _package(FlightType.STRIKE, _tot(75), _ground_target(IN_RING))
+    _coordinate([sead, cas, strike])
+    assert cas.time_over_target == _tot(32)
+    assert strike.time_over_target == _tot(32)


### PR DESCRIPTION
Packages are scheduled independently. The generic branch in `MissionScheduler` spreads each package's TOT randomly across the mission window, and nothing connects a strike to the SEAD or DEAD package tasked against the SAM covering its target. A strike can arrive at a defended objective half an hour before its suppression.

This adds one pass that sequences them, behind a new option, off by default.

## What it does

`_coordinate_sead_windows` runs after the main scheduling loop, so it sees final TOTs.

- Providers are packages whose `primary_task` is `SEAD` or `DEAD`, read via `getattr(package.target, "max_threat_range", None)` so a non-TGO tasking degrades to "no window" instead of raising. A zero ring (a dead site) opens no window.
- Consumers are `STRIKE`, `BAI`, `OCA_RUNWAY`, `OCA_AIRCRAFT`, `ARMED_RECON` and `CAS` packages that are not `auto_asap` and have no player flight.
- A consumer matches a provider when the provider's target position is within the ring of the consumer's target position.
- The window opens `SEAD_WINDOW_LEAD` (2 min) after the **latest** matching provider's TOT and lasts `SEAD_WINDOW_DURATION` (8 min). `max`, not `min`: every suppressor on station before the strike pushes.
- A strike already inside the window keeps its TOT. One outside moves to the window opening, delayed if it was naked, pulled forward if the spread left it long after the window closed.
- Never earlier than `TotEstimator.earliest_tot`. If even that is past the window the TOT is kept, unless keeping it would still leave the strike ahead of its SEAD.
- Several strikes behind one suppressor mass into the same window.

The set is every `FormationAttackFlightPlan` tasking that makes one timed arrival on a point inside a ring, plus CAS.

`AIR_ASSAULT` is the one such tasking left out, and not for want of a covering ring: it is `ROTARY_WING`, so massing a slow helo into an eight-minute window with fast movers converging on the same point trades a suppression gain for a deconfliction risk. A test pins it excluded inside a ring that would otherwise cover it, so sweeping it in has to be deliberate.

CAS is included for the front-line sandwich: it descends to acquire and takes MANPADS low, then climbs to escape into the area-SAM ring high, so a front under a live umbrella wants that umbrella down first for the same reason a strike does. CAS already proposes an organic `SEAD_SWEEP` escort, but that flies the package's own TOT, so it accompanies rather than pre-suppresses.

## Players are immune, providers are read-only

A package with a player flight is never rescheduled. A player-flown SEAD still opens a window the AI strikes push behind, because providers are only read.

## One refactor, and why it is behaviour-identical

The recovery-tanker ETA collection moves out of the scheduling loop into its own loop below the new pass.

It has to move: `flight_plan.landing_time` derives from the package TOT, so a package retimed by this pass would otherwise have booked its recovery tanker against a landing it no longer flies.

With the option off the two are equivalent. The branches that previously skipped the collection did so by `continue`ing when `_get_departure_time` returned `None`, and `Package.mission_departure_time` returns `None` only when the package has no flights, where the inner `for f in package.flights` loop iterated nothing anyway. The `RECOVERY` skip is carried over explicitly.

## Option

`sead_strike_coordination`, Campaign Doctrine, General, default off. With it off the pass returns on the first line and no TOT changes.

## Tests

`tests/test_sead_strike_coordination.py`, 20 tests, self-contained: pydcs plus `SimpleNamespace` fakes, no campaign fixtures.

The window math is a free function, `coordinated_strike_tot(strike_tot, earliest_tot, provider_tots, lead, duration)`, which takes no `self` and touches no engine types, so the interesting half is testable without building a `Coalition`. Eight tests cover it directly: delay the naked strike, keep an in-window TOT, pull a far-late TOT back, clamp to physics, both unreachable-window cases, latest-provider, and the no-provider no-op.

Twelve cover the scheduler wiring: ring matching in and out, player and ASAP immunity, provider read-only, massing, the setting gate, a dead SAM's zero ring, CAS covered and uncovered, CAS and a strike massing together, Armed Recon retimed, and a guard pinning Air Assault as excluded inside a ring that would otherwise cover it, so sweeping it in fails there first.

## Verification

- `black --check` clean
- `mypy game tests` no issues in 491 source files
- `pytest tests` 472 passed, 2 skipped
- Red/green: removing `FlightType.CAS` fails exactly the two CAS behaviour tests; removing `FlightType.ARMED_RECON` fails exactly its own. The exclusion guard passes throughout.

Flown in the fork this is carved from, with one caveat stated plainly: the mechanism is verified in-game for the strike case, and the CAS extension has not yet had its own in-game pass. Worth watching for if it is flown: whether massing CAS behind a DEAD thins the front-line coverage window relative to today's spread.

## Correction to an earlier version of this description

An earlier version of this text justified excluding Armed Recon and Air Assault as "Armed Recon is a loitering sweep rather than a push, and Air Assault is timed by the ground war." Both halves were wrong. Armed Recon is now in the set, and Air Assault is excluded on a reason that holds.

`ArmedReconFlightPlan` extends `FormationAttackFlightPlan` — ingress, target, egress, no patrol. It is a search-and-engage-in-zone task. `CasFlightPlan` is the `PatrollingFlightPlan` with a `patrol_duration`, so the type I excluded for loitering does not loiter and the type I added is the actual patroller. Thanks to the reviewer who caught it.

Nothing times an Air Assault by the ground war either. `auto_asap` is set only for the first AEWC package and for player packages under `player_missions_asap`, so an Air Assault takes the same random spread as a strike. Its only ground-war coupling is planning eligibility — `PlanAirAssault.preconditions_met` requires the target in `vulnerable_control_points` — which governs whether it is planned, not when it arrives.

## Related

Closed PR #674's thread is the nearest discussion. The asks there were about which SAMs SEAD picks; this is the timing half of the same complaint, and does not touch target selection.
