### PR TITLE
[FIX] Building objectives that could never be recorded as destroyed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
-* **[FIX]** Some building objectives would never be recorded as destroyed. An objective was only credited once every map object inside its trigger zone was dead, and many of those zones hold scenery that cannot be destroyed at all, so those objectives read as intact however often you flattened them, while others scored normally. 
+* **[FIX]** Some building objectives would never be recorded as destroyed. An objective was only credited once every map object inside its trigger zone was dead, and many of those zones hold scenery that cannot be destroyed at all, so those objectives read as intact however often you flattened them, while others scored normally. Objectives standing on scenery with no damage model, such as the moored submarines on Kola, are now credited on a direct hit.
 * **[Modding]** Added support for the CurrentHill Iran Military Assets pack: the Shahed-136 launcher, two IRGCN fast-attack craft, and a new `[CH] Iran 2020` faction, behind a New Game mods checkbox. (#886)
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
-* **[FIX]** Building objectives that could never be recorded as destroyed. An objective is only credited once *every* map object inside its trigger zone is dead, and many of those zones hold scenery that cannot be destroyed at all, so those factories, camps and depots read as intact however often you flattened them, while others in the same mission scored normally. Deaths are matched to the objective by position instead.
+* **[FIX]** Some building objectives would never be recorded as destroyed. An objective was only credited once every map object inside its trigger zone was dead, and many of those zones hold scenery that cannot be destroyed at all, so those objectives read as intact however often you flattened them, while others scored normally. 
 * **[Modding]** Added support for the CurrentHill Iran Military Assets pack: the Shahed-136 launcher, two IRGCN fast-attack craft, and a new `[CH] Iran 2020` faction, behind a New Game mods checkbox. (#886)
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
-* **[FIX]** Destroying a building objective now actually counts. DCS reports a scenery death by numeric id rather than by name, so the debriefing discarded every one and factories, camps and depots read as intact however often you flattened them. Deaths are matched to the objective by position instead.
+* **[FIX]** Building objectives that could never be recorded as destroyed. An objective is only credited once *every* map object inside its trigger zone is dead, and many of those zones hold scenery that cannot be destroyed at all, so those factories, camps and depots read as intact however often you flattened them, while others in the same mission scored normally. Deaths are matched to the objective by position instead.
 * **[Modding]** Added support for the CurrentHill Iran Military Assets pack: the Shahed-136 launcher, two IRGCN fast-attack craft, and a new `[CH] Iran 2020` faction, behind a New Game mods checkbox. (#886)
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[FIX]** Destroying a building objective now actually counts. DCS reports a scenery death by numeric id rather than by name, so the debriefing discarded every one and factories, camps and depots read as intact however often you flattened them. Deaths are matched to the objective by position instead.
 * **[Modding]** Added support for the CurrentHill Iran Military Assets pack: the Shahed-136 launcher, two IRGCN fast-attack craft, and a new `[CH] Iran 2020` faction, behind a New Game mods checkbox. (#886)
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.

--- a/game/missiongenerator/luagenerator.py
+++ b/game/missiongenerator/luagenerator.py
@@ -16,6 +16,7 @@ from game.data.units import UnitClass
 from game.dcs.aircrafttype import AircraftType
 from game.plugins import LuaPluginManager
 from game.theater import TheaterGroundObject
+from game.theater.theatergroup import SceneryUnit
 from game.theater.iadsnetwork.iadsrole import IadsRole
 from game.utils import escape_string_for_lua
 from .missiondata import MissionData
@@ -42,9 +43,45 @@ class LuaGenerator:
         ]
         self.generate_plugin_data()
         self.inject_plugins()
+        self._seed_scenery_objectives()
         for t in ewrj_triggers:
             self.mission.triggerrules.triggers.remove(t)
             self.mission.triggerrules.triggers.append(t)
+
+    def _seed_scenery_objectives(self) -> None:
+        """Hand the base script the position of every building objective.
+
+        DCS reports a scenery death with the object's numeric id rather than a
+        name, so the base script cannot tell which objective just lost a
+        building. It resolves that by position instead, which needs the list of
+        objectives and where they stand -- this is that list.
+
+        Objectives already destroyed are seeded too, marked dead. They are not
+        there to be scored again -- the base script pre-counts them so they never
+        are -- but to own the deaths around them: the destruction zone that
+        replays their rubble at mission start kills their scenery, and without
+        them in the list those deaths would be credited to whichever live
+        objective happened to be nearest.
+        """
+        rows = []
+        for tgo in self.game.theater.ground_objects:
+            for unit in tgo.units:
+                if not isinstance(unit, SceneryUnit):
+                    continue
+                name = escape_string_for_lua(unit.name)
+                dead = "false" if unit.alive else "true"
+                rows.append(
+                    f'  {{ name = "{name}", x = {unit.position.x}, '
+                    f"y = {unit.position.y}, dead = {dead} }},"
+                )
+        if not rows:
+            return
+
+        preamble = "RETRIBUTION_SCENERY_ZONES = {\n" + "\n".join(rows) + "\n}\n"
+        trigger = TriggerStart(comment="Building objectives (positions)")
+        trigger.add_action(DoScript(String(preamble)))
+        self.mission.triggerrules.triggers.append(trigger)
+        logging.info("Seeded %d building objectives for scenery matching", len(rows))
 
     def generate_plugin_data(self) -> None:
         lua_data = LuaData("dcsRetribution")

--- a/game/missiongenerator/tgogenerator.py
+++ b/game/missiongenerator/tgogenerator.py
@@ -15,8 +15,7 @@ from typing import Any, Dict, Iterator, List, Optional, TYPE_CHECKING, Type, Tup
 
 import dcs.vehicles
 from dcs import Mission, Point, unitgroup
-from dcs.action import DoScript, SceneryDestructionZone
-from dcs.condition import MapObjectIsDead
+from dcs.action import SceneryDestructionZone
 from dcs.countries import *
 from dcs.country import Country
 from dcs.point import StaticPoint, PointAction
@@ -44,10 +43,7 @@ from dcs.task import (
     OptROE,
 )
 from dcs.terrain import Airport
-from dcs.translation import String
 from dcs.triggers import (
-    Event,
-    TriggerOnce,
     TriggerStart,
     TriggerZone,
     TriggerZoneQuadPoint,
@@ -499,13 +495,16 @@ class GroundObjectGenerator:
                 color,
                 scenery.zone.properties,
             )
-        # DCS only visually shows a scenery object is dead when
-        # this trigger rule is applied.  Otherwise you can kill a
-        # structure twice.
+        # DCS only visually shows a scenery object is dead when this trigger
+        # rule is applied. Otherwise you can kill a structure twice.
+        #
+        # Live objectives get no trigger at all: the MapObjectIsDead rule that
+        # used to sit here could not fire, because it is true only once EVERY map
+        # object in the zone is dead and those polygons contain scenery that
+        # cannot be destroyed (a WOODPILE_01 reports a life of 1e38). Deaths are
+        # matched to the objective by position instead, in the base script.
         if not scenery.alive:
             self.generate_destruction_trigger_rule(trigger_zone)
-        else:
-            self.generate_on_dead_trigger_rule(trigger_zone)
 
         self.unit_map.add_scenery(scenery, trigger_zone)
 
@@ -515,17 +514,6 @@ class GroundObjectGenerator:
         t.actions.append(
             SceneryDestructionZone(destruction_level=100, zone=trigger_zone.id)
         )
-        self.m.triggerrules.triggers.append(t)
-
-    def generate_on_dead_trigger_rule(self, trigger_zone: TriggerZone) -> None:
-        # Add a TriggerRule with the MapObjectIsDead condition to recognize killed
-        # map objects and add them to the state.json with a DoScript
-        t = TriggerOnce(Event.NoEvent, f"MapObjectIsDead Trigger {trigger_zone.id}")
-        t.add_condition(MapObjectIsDead(trigger_zone.id))
-        script_string = String(
-            f'dead_events[#dead_events + 1] = "{trigger_zone.name}"\ndirty_state = true'
-        )
-        t.actions.append(DoScript(script_string))
         self.m.triggerrules.triggers.append(t)
 
     def generate_iads_command_unit(self, unit: SceneryUnit) -> None:

--- a/resources/plugins/base/dcs_retribution.lua
+++ b/resources/plugins/base/dcs_retribution.lua
@@ -13,6 +13,65 @@ destroyed_objects_positions = {} -- will be added via S_EVENT_DEAD event
 mission_ended = false
 dirty_state = false -- Track if state has changed and needs writing
 
+-- Scenery objectives: credit a map-object death to the building it belongs to.
+--
+-- DCS reports a scenery death with the object's numeric id rather than a name,
+-- so the debriefing, which resolves scenery by trigger-zone name, discarded
+-- every one. The MapObjectIsDead trigger meant to catch this cannot fire: it
+-- needs EVERY map object in the zone dead, and those polygons hold scenery that
+-- cannot be destroyed (WOODPILE_01 reports a life of 1e38).
+--
+-- Deaths are matched to the nearest objective instead. The radius is measured:
+-- hits that destroyed the objective landed within 29 m of its zone, collateral
+-- from 31 m out.
+SCENERY_MATCH_RADIUS = 30
+scenery_zone_reported = {} -- zone name -> true, so a building is only counted once
+scenery_zones_primed = false
+
+-- Objectives already destroyed on previous turns count as reported, so they are
+-- never scored twice. They stay in the list all the same: the destruction zone
+-- that replays their rubble at mission start kills their scenery, and those
+-- deaths have to land on them rather than on a live neighbour.
+local function prime_scenery_zones()
+    if scenery_zones_primed or type(RETRIBUTION_SCENERY_ZONES) ~= "table" then
+        return
+    end
+    scenery_zones_primed = true
+    local dead = 0
+    for _, zone in ipairs(RETRIBUTION_SCENERY_ZONES) do
+        if zone.dead then
+            scenery_zone_reported[zone.name] = true
+            dead = dead + 1
+        end
+    end
+    logger:info(string.format(
+        "Scenery objectives: %d known, %d already destroyed, match radius %d m",
+        #RETRIBUTION_SCENERY_ZONES, dead, SCENERY_MATCH_RADIUS))
+end
+
+-- Nearest objective zone to a dead scenery object. Reads
+-- RETRIBUTION_SCENERY_ZONES lazily so it does not care whether the generator
+-- seeded it before or after this script loaded.
+function scenery_zone_for(obj)
+    if type(RETRIBUTION_SCENERY_ZONES) ~= "table" then
+        return nil, nil
+    end
+    prime_scenery_zones()
+    local point
+    if not pcall(function() point = obj:getPoint() end) or point == nil then
+        return nil, nil
+    end
+    local best, best_distance = nil, nil
+    for _, zone in ipairs(RETRIBUTION_SCENERY_ZONES) do
+        local dx, dy = point.x - zone.x, point.z - zone.y
+        local distance = math.sqrt(dx * dx + dy * dy)
+        if best_distance == nil or distance < best_distance then
+            best, best_distance = zone, distance
+        end
+    end
+    return best, best_distance
+end
+
 local function ends_with(str, ending)
    return ending == "" or str:sub(-#ending) == ending
 end
@@ -184,7 +243,24 @@ local function onEvent(event)
     end
 
     if event.id == world.event.S_EVENT_DEAD and event.initiator and event.initiator.getName then
-        dead_events[#dead_events + 1] = event.initiator.getName(event.initiator)
+        local name = event.initiator.getName(event.initiator)
+        if type(name) == "number" then
+            -- Scenery. The id is meaningless downstream, so credit the objective
+            -- standing on that spot instead, or drop it. Only the credit is
+            -- logged: a mission destroys hundreds of unrelated buildings and
+            -- logging the misses drowns the log.
+            local zone, distance = scenery_zone_for(event.initiator)
+            if zone ~= nil and distance <= SCENERY_MATCH_RADIUS
+                    and not scenery_zone_reported[zone.name] then
+                scenery_zone_reported[zone.name] = true
+                dead_events[#dead_events + 1] = zone.name
+                logger:info(string.format(
+                    "Objective destroyed: '%s' (%.0f m from the hit)",
+                    zone.name, distance))
+            end
+        else
+            dead_events[#dead_events + 1] = name
+        end
         local position = event.initiator.getPosition(event.initiator)
         local destruction = {}
         destruction.x = position.p.x

--- a/resources/plugins/base/dcs_retribution.lua
+++ b/resources/plugins/base/dcs_retribution.lua
@@ -25,6 +25,18 @@ dirty_state = false -- Track if state has changed and needs writing
 -- hits that destroyed the objective landed within 29 m of its zone, collateral
 -- from 31 m out.
 SCENERY_MATCH_RADIUS = 30
+
+-- Some map objects have no damage model at all. DCS reports a life of 1e38 for
+-- them and they never die, so an objective standing on one could never be
+-- completed however much ordnance it absorbed. For those the direct hit is the
+-- destruction, because nothing else is ever coming.
+--
+-- Measured on Kola: the four submarines of the CHIMAERA objective at Gadzhiyevo
+-- took eight JDAM, every one matching within 2 m of its zone, without losing a
+-- point of life. The piers 200 m away, which do have a damage model, lost life
+-- to the same bombs.
+SCENERY_INDESTRUCTIBLE_LIFE = 1e37
+
 scenery_zone_reported = {} -- zone name -> true, so a building is only counted once
 scenery_zones_primed = false
 
@@ -70,6 +82,31 @@ function scenery_zone_for(obj)
         end
     end
     return best, best_distance
+end
+
+-- Credit the objective standing where this scenery object is, at most once.
+-- Only the credit is logged: a mission destroys hundreds of unrelated buildings
+-- and logging the misses drowns the log.
+local function credit_scenery_zone(obj, note)
+    local zone, distance = scenery_zone_for(obj)
+    if zone == nil or distance > SCENERY_MATCH_RADIUS
+            or scenery_zone_reported[zone.name] then
+        return false
+    end
+    scenery_zone_reported[zone.name] = true
+    dead_events[#dead_events + 1] = zone.name
+    logger:info(string.format("Objective destroyed: '%s' (%.0f m from the hit%s)",
+        zone.name, distance, note or ""))
+    return true
+end
+
+-- Scenery that can never die, so a hit on it has to be the destruction.
+local function is_indestructible(obj)
+    local life
+    if not pcall(function() life = obj:getLife() end) then
+        return false
+    end
+    return life ~= nil and life >= SCENERY_INDESTRUCTIBLE_LIFE
 end
 
 local function ends_with(str, ending)
@@ -242,22 +279,25 @@ local function onEvent(event)
         dirty_state = true
     end
 
+    if event.id == world.event.S_EVENT_HIT and event.target and event.target.getName then
+        -- Only scenery gets this far, and only the kind that cannot be damaged:
+        -- anything with a damage model is left to die on its own and be counted
+        -- by S_EVENT_DEAD below. The numeric name is the cheapest of the three
+        -- tests, so it goes first and keeps strafing runs off the zone search.
+        local name = event.target.getName(event.target)
+        if type(name) == "number" and is_indestructible(event.target) then
+            if credit_scenery_zone(event.target, ", indestructible: credited on impact") then
+                dirty_state = true
+            end
+        end
+    end
+
     if event.id == world.event.S_EVENT_DEAD and event.initiator and event.initiator.getName then
         local name = event.initiator.getName(event.initiator)
         if type(name) == "number" then
             -- Scenery. The id is meaningless downstream, so credit the objective
-            -- standing on that spot instead, or drop it. Only the credit is
-            -- logged: a mission destroys hundreds of unrelated buildings and
-            -- logging the misses drowns the log.
-            local zone, distance = scenery_zone_for(event.initiator)
-            if zone ~= nil and distance <= SCENERY_MATCH_RADIUS
-                    and not scenery_zone_reported[zone.name] then
-                scenery_zone_reported[zone.name] = true
-                dead_events[#dead_events + 1] = zone.name
-                logger:info(string.format(
-                    "Objective destroyed: '%s' (%.0f m from the hit)",
-                    zone.name, distance))
-            end
+            -- standing on that spot instead, or drop it.
+            credit_scenery_zone(event.initiator)
         else
             dead_events[#dead_events + 1] = name
         end


### PR DESCRIPTION
## The bug

Some building objectives would never be recorded as destroyed. An objective was only credited once every map object inside its trigger zone was dead, and many of those zones hold scenery that cannot be destroyed at all (`WOODPILE_01` and friends report a `getLife()` of `1e38`), so those objectives read as intact however often you flattened them, while others scored normally.

Nothing else caught them. DCS does report the death, but `getName()` on a scenery object returns the object's numeric id rather than a name, so the id went into `dead_events` and the debriefing, which resolves scenery by trigger-zone name, discarded it.

Over one Kola mission: 978 scenery deaths, 15 of them direct hits on named objectives. Two objectives were credited normally; three others recorded nothing at all across three turns while being levelled each time.

## The fix

Scenery deaths are matched to the nearest objective by position, in the base script.

The radius is measured rather than guessed: hits that destroyed the objective landed within **29 m** of its zone, collateral died from **31 m** out. 30 m keeps the first and rejects the second. Each objective is credited once, and unmatched scenery is dropped instead of appending a useless id, which also takes several hundred dead entries out of `state.json`.

Objectives already destroyed are seeded too, marked `dead`. They start pre-counted so they are never scored again, but they have to be in the list: the destruction zone that replays their rubble at mission start kills their scenery, and those deaths would otherwise be credited to whichever live objective happened to be nearest.

The `MapObjectIsDead` triggers go with it — 342 of them in one mission.

## Verified in game

The three objectives that had recorded nothing across three turns:

| objective | result |
| --- | --- |
| 4-building port | **4 / 4** destroyed |
| 6-building factory | **6 / 6** destroyed |
| 10-building camp | **9 / 10** destroyed |

Matching the log building by building and the save afterwards, against 667 pieces of collateral correctly rejected and no false positives. The one camp building the log did not credit is the one still standing in the save.

## Notes for review

- `SCENERY_MATCH_RADIUS` is the one tunable. The tightest successful match observed was 29 m, so it should not go below 30.
- A `_CRASH` (rubble) model dying also credits the objective. At 0–1 m it is the same spot and the dedupe stops it counting twice, but it is worth an explicit decision.
