### PR TITLE
Allow OPFOR ground unit purchases/transfers when buy/sell cheat is enabled.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[Ground Forces]** Enable OPFOR ground-unit transfers and buy/sell management behind the OPFOR cheat setting.
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.
 * **[UX]** Press Delete with a package selected in the Packages list to cancel it, making it quick to clear several packages in a row.

--- a/game/groundunitorders.py
+++ b/game/groundunitorders.py
@@ -108,7 +108,7 @@ class GroundUnitOrders:
         now: datetime,
     ) -> None:
         coalition.transfers.new_transfer(
-            TransferOrder(source, self.destination, units), now
+            TransferOrder(source, self.destination, units, player=coalition.player), now
         )
 
     def find_ground_unit_source(self, game: Game) -> Optional[ControlPoint]:

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 from datetime import timedelta
+from itertools import chain
 from typing import TYPE_CHECKING, Any
 
 from dcs.countries import countries_by_name
@@ -204,21 +205,53 @@ class Migrator:
                     try_set_attr(sdef, "radio_presets", {})
 
     def _update_transfers(self) -> None:
+        # Track transfers across all coalitions to detect the same object in
+        # more than one coalition's containers.
+        global_seen: set[int] = set()
         for coalition in self.game.coalitions:
-            transfers = coalition.transfers
-            for transfer in transfers.pending_transfers:
-                self._normalize_transfer_player(transfer)
-            for convoy in transfers.convoys:
-                for transfer in convoy.transfers:
-                    self._normalize_transfer_player(transfer)
-            for cargo_ship in transfers.cargo_ships:
-                for transfer in cargo_ship.transfers:
-                    self._normalize_transfer_player(transfer)
+            self._normalize_transfers_for_coalition(coalition, global_seen)
+
+    def _normalize_transfers_for_coalition(
+        self, coalition: Any, global_seen: set[int]
+    ) -> None:
+        """Normalize transfer player ownership for a coalition's transfers.
+
+        Traverses the pending list plus convoy/cargo aliases, deduplicating
+        transfer objects by identity. Missing and legacy-boolean owners are set
+        from the containing coalition. An existing enum owner that conflicts
+        with its sole container, or the same transfer reachable from more than
+        one coalition, fails with a diagnostic.
+        """
+        transfers = coalition.transfers
+        aliased = chain.from_iterable(c.transfers for c in transfers.convoys)
+        shipped = chain.from_iterable(c.transfers for c in transfers.cargo_ships)
+        seen: set[int] = set()
+        all_transfers: list[Any] = []
+        for transfer in chain(transfers.pending_transfers, aliased, shipped):
+            if id(transfer) not in seen:
+                seen.add(id(transfer))
+                all_transfers.append(transfer)
+
+        for transfer in all_transfers:
+            if id(transfer) in global_seen:
+                raise RuntimeError(
+                    f"Transfer {transfer} is reachable from more than one coalition"
+                )
+            global_seen.add(id(transfer))
+
+        for transfer in all_transfers:
+            self._normalize_single_transfer_player(transfer, coalition)
 
     @staticmethod
-    def _normalize_transfer_player(transfer: Any) -> None:
-        if hasattr(transfer, "player") and isinstance(transfer.player, bool):
-            transfer.player = Player.BLUE if transfer.player else Player.RED
+    def _normalize_single_transfer_player(transfer: Any, coalition: Any) -> None:
+        owner = getattr(transfer, "player", None)
+        if owner is None or isinstance(owner, bool):
+            transfer.player = coalition.player
+        elif owner != coalition.player:
+            raise RuntimeError(
+                f"Transfer {transfer} has owner {owner} but is in the "
+                f"{coalition.player} coalition"
+            )
 
     @typing.no_type_check
     def _update_factions(self) -> None:

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -249,7 +249,7 @@ class Migrator:
             transfer.player = coalition.player
             return
         if isinstance(owner, bool):
-            transfer.player = Player.BLUE if owner else Player.RED
+            transfer.player = coalition.player
         if transfer.player != coalition.player:
             raise RuntimeError(
                 f"Transfer {transfer} has owner {transfer.player} but is in the "

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -245,11 +245,14 @@ class Migrator:
     @staticmethod
     def _normalize_single_transfer_player(transfer: Any, coalition: Any) -> None:
         owner = getattr(transfer, "player", None)
-        if owner is None or isinstance(owner, bool):
+        if owner is None:
             transfer.player = coalition.player
-        elif owner != coalition.player:
+            return
+        if isinstance(owner, bool):
+            transfer.player = Player.BLUE if owner else Player.RED
+        if transfer.player != coalition.player:
             raise RuntimeError(
-                f"Transfer {transfer} has owner {owner} but is in the "
+                f"Transfer {transfer} has owner {transfer.player} but is in the "
                 f"{coalition.player} coalition"
             )
 

--- a/game/purchaseadapter.py
+++ b/game/purchaseadapter.py
@@ -146,6 +146,27 @@ class GroundUnitPurchaseAdapter(PurchaseAdapter[GroundUnitType]):
         self.control_point = control_point
         self.game = game
 
+    @property
+    def _enemy_transaction_allowed(self) -> bool:
+        """Whether OPFOR ground unit transactions are currently permitted."""
+        return bool(getattr(self.game.settings, "enable_enemy_buy_sell", False))
+
+    @property
+    def _purchase_allowed(self) -> bool:
+        owner = self.control_point.captured
+        if owner.is_neutral or owner is not self.coalition.player:
+            return False
+        return owner.is_blue or self._enemy_transaction_allowed
+
+    @property
+    def _sale_allowed(self) -> bool:
+        owner = self.control_point.captured
+        return (
+            owner.is_red
+            and owner is self.coalition.player
+            and self._enemy_transaction_allowed
+        )
+
     def pending_delivery_quantity(self, item: GroundUnitType) -> int:
         return self.control_point.ground_unit_orders.pending_orders(item)
 
@@ -153,21 +174,29 @@ class GroundUnitPurchaseAdapter(PurchaseAdapter[GroundUnitType]):
         return self.control_point.base.total_units_of_type(item)
 
     def can_buy(self, item: GroundUnitType) -> bool:
-        return super().can_buy(item) and self.control_point.has_ground_unit_source(
-            self.game
+        return (
+            self._purchase_allowed
+            and super().can_buy(item)
+            and self.control_point.has_ground_unit_source(self.game)
         )
 
     def can_sell(self, item: GroundUnitType) -> bool:
-        return False
+        return self._sale_allowed and self.current_quantity_of(item) > 0
 
     def do_purchase(self, item: GroundUnitType) -> None:
+        if not self._purchase_allowed:
+            raise TransactionError("Purchase of ground units not allowed")
         self.control_point.ground_unit_orders.order({item: 1})
 
     def do_cancel_purchase(self, item: GroundUnitType) -> None:
+        if not self._purchase_allowed:
+            raise TransactionError("Cancellation of ground unit purchase not allowed")
         self.control_point.ground_unit_orders.sell({item: 1})
 
     def do_sale(self, item: GroundUnitType) -> None:
-        raise TransactionError("Sale of ground units not allowed")
+        if not self._sale_allowed:
+            raise TransactionError("Sale of ground units not allowed")
+        self.control_point.base.commit_losses({item: 1})
 
     def do_cancel_sale(self, item: GroundUnitType) -> None:
         raise TransactionError("Sale of ground units not allowed")

--- a/game/transfers.py
+++ b/game/transfers.py
@@ -161,6 +161,13 @@ class TransferOrder:
         return self.destination == self.position or not self.size
 
     def disband_at(self, location: ControlPoint) -> None:
+        if not location.is_friendly(self.player):
+            logging.info(
+                f"Cannot disband units at {location}: it is not friendly to "
+                f"{self.player}. Units were destroyed during transfer."
+            )
+            self.kill_all()
+            return
         logging.info(f"Units halting at {location}.")
         location.base.commission_units(self.units)
         self.units.clear()
@@ -402,9 +409,7 @@ class MultiGroupTransport(MissionTarget, Transport):
         self.transfers: List[TransferOrder] = []
 
     def is_friendly(self, to_player: Player) -> bool:
-        if self.origin.captured == to_player:
-            return True
-        return False
+        return self.player_owned == to_player
 
     def add_units(self, transfer: TransferOrder) -> None:
         self.transfers.append(transfer)
@@ -464,7 +469,7 @@ class MultiGroupTransport(MissionTarget, Transport):
 
     @property
     def coalition(self) -> Coalition:
-        return self.origin.coalition
+        return self.origin.coalition.game.coalition_for(self.player_owned)
 
 
 class Convoy(MultiGroupTransport):
@@ -630,7 +635,7 @@ class PendingTransfers:
         return self.pending_transfers.index(transfer)
 
     def network_for(self, control_point: ControlPoint) -> TransitNetwork:
-        return self.game.transit_network_for(control_point.captured)
+        return self.game.transit_network_for(self.player)
 
     def arrange_transport(self, transfer: TransferOrder, now: datetime) -> None:
         network = self.network_for(transfer.position)
@@ -651,7 +656,7 @@ class PendingTransfers:
             next_stop = transfer.destination
         AirliftPlanner(self.game, transfer, next_stop).create_package_for_airlift(now)
 
-    def new_transfer(self, transfer: TransferOrder, now: datetime) -> None:
+    def validate_transfer(self, transfer: TransferOrder) -> None:
         assert (
             transfer.player == self.player
         ), "Transfer ownership does not match the collection's player"
@@ -665,6 +670,9 @@ class PendingTransfers:
             )
         network = self.network_for(transfer.position)
         network.shortest_path_between(transfer.position, transfer.destination)
+
+    def new_transfer(self, transfer: TransferOrder, now: datetime) -> None:
+        self.validate_transfer(transfer)
         transfer.origin.base.commit_losses(transfer.units)
         self.pending_transfers.append(transfer)
         self.arrange_transport(transfer, now)
@@ -740,7 +748,7 @@ class PendingTransfers:
         if transfer.transport is not None:
             self.cancel_transport(transfer.transport, transfer)
         self.pending_transfers.remove(transfer)
-        transfer.origin.base.commission_units(transfer.units)
+        transfer.disband()
         self._send_supply_route_event_stream_update()
 
     def perform_transfers(self) -> None:

--- a/game/transfers.py
+++ b/game/transfers.py
@@ -655,6 +655,16 @@ class PendingTransfers:
         assert (
             transfer.player == self.player
         ), "Transfer ownership does not match the collection's player"
+        if transfer.player.is_neutral:
+            raise ValueError("Neutral transfers are not allowed")
+        if transfer.origin.captured != transfer.player:
+            raise ValueError("Transfer origin is not owned by the transfer coalition")
+        if transfer.destination.captured != transfer.player:
+            raise ValueError(
+                "Transfer destination is not owned by the transfer coalition"
+            )
+        network = self.network_for(transfer.position)
+        network.shortest_path_between(transfer.position, transfer.destination)
         transfer.origin.base.commit_losses(transfer.units)
         self.pending_transfers.append(transfer)
         self.arrange_transport(transfer, now)

--- a/game/transfers.py
+++ b/game/transfers.py
@@ -657,9 +657,10 @@ class PendingTransfers:
         AirliftPlanner(self.game, transfer, next_stop).create_package_for_airlift(now)
 
     def validate_transfer(self, transfer: TransferOrder) -> None:
-        assert (
-            transfer.player == self.player
-        ), "Transfer ownership does not match the collection's player"
+        if transfer.player != self.player:
+            raise ValueError(
+                "Transfer ownership does not match the collection's player"
+            )
         if transfer.player.is_neutral:
             raise ValueError("Neutral transfers are not allowed")
         if transfer.origin.captured != transfer.player:

--- a/game/transfers.py
+++ b/game/transfers.py
@@ -107,11 +107,13 @@ class TransferOrder:
     #: stops and can switch transport modes before reaching their destination.
     position: ControlPoint = field(init=False)
 
-    #: True if the transfer order belongs to the player.
-    player: Player = field(init=False)
-
     #: The units being transferred.
     units: dict[GroundUnitType, int]
+
+    #: The coalition that owns this transfer. This is the sole ownership authority;
+    #: it is set at construction time and never derived from mutable control-point
+    #: state.
+    player: Player
 
     transport: Optional[Transport] = field(default=None)
 
@@ -122,12 +124,11 @@ class TransferOrder:
         count = self.size
         origin = self.origin.name
         destination = self.destination.name
-        description = "Transfer" if self.player else "Enemy transfer"
+        description = "Transfer" if self.player.is_blue else "Enemy transfer"
         return f"{description} of {count} units from {origin} to {destination}"
 
     def __post_init__(self) -> None:
         self.position = self.origin
-        self.player = self.origin.captured
 
     @property
     def description(self) -> str:
@@ -281,7 +282,7 @@ class AirliftPlanner:
         self.game = game
         self.transfer = transfer
         self.next_stop = next_stop
-        self.for_player = transfer.destination.captured
+        self.for_player = transfer.player
         self.package = Package(next_stop, game.db.flights, auto_asap=True)
 
     def compatible_with_mission(
@@ -451,7 +452,9 @@ class MultiGroupTransport(MissionTarget, Transport):
 
     @property
     def player_owned(self) -> Player:
-        return self.origin.captured
+        if not self.transfers:
+            raise RuntimeError("Transport has no transfers")
+        return self.transfers[0].player
 
     def find_escape_route(self) -> Optional[ControlPoint]:
         raise NotImplementedError
@@ -649,6 +652,9 @@ class PendingTransfers:
         AirliftPlanner(self.game, transfer, next_stop).create_package_for_airlift(now)
 
     def new_transfer(self, transfer: TransferOrder, now: datetime) -> None:
+        assert (
+            transfer.player == self.player
+        ), "Transfer ownership does not match the collection's player"
         transfer.origin.base.commit_losses(transfer.units)
         self.pending_transfers.append(transfer)
         self.arrange_transport(transfer, now)
@@ -674,7 +680,12 @@ class PendingTransfers:
             units[unit_type] = take
         for td in to_delete:
             del transfer.units[td]
-        new_transfer = TransferOrder(transfer.origin, transfer.destination, units)
+        new_transfer = TransferOrder(
+            transfer.origin,
+            transfer.destination,
+            units,
+            player=transfer.player,
+        )
         self.pending_transfers.append(new_transfer)
         return new_transfer
 

--- a/game/transfers.py
+++ b/game/transfers.py
@@ -313,7 +313,7 @@ class AirliftPlanner:
 
         home = airfield.position
         pickup = self.transfer.position.position
-        drop_off = self.transfer.position.position
+        drop_off = self.next_stop.position
         if meters(home.distance_to_point(pickup)) > self.HELO_MAX_RANGE:
             return False
 

--- a/game/transfers.py
+++ b/game/transfers.py
@@ -412,6 +412,8 @@ class MultiGroupTransport(MissionTarget, Transport):
         return self.player_owned == to_player
 
     def add_units(self, transfer: TransferOrder) -> None:
+        if self.transfers and transfer.player is not self.player_owned:
+            raise ValueError("Transport ownership does not match transfer's player")
         self.transfers.append(transfer)
         transfer.transport = self
 

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -375,6 +375,13 @@ class TransferModel(QAbstractListModel):
     def __init__(self, game_model: GameModel) -> None:
         super().__init__()
         self.game_model = game_model
+        self._red_visible = self._compute_red_visible()
+
+    def _compute_red_visible(self) -> bool:
+        game = self.game_model.game
+        if game is None:
+            return False
+        return bool(getattr(game.settings, "enable_enemy_buy_sell", False))
 
     @staticmethod
     def owner_of(transfer: TransferOrder) -> Player:
@@ -389,15 +396,25 @@ class TransferModel(QAbstractListModel):
 
     @property
     def red_visible(self) -> bool:
-        return bool(
-            getattr(self.game_model.game.settings, "enable_enemy_buy_sell", False)
-        )
+        return self._red_visible
 
     def _all_transfers(self) -> list[TransferOrder]:
+        if self.game_model.game is None:
+            return []
         transfers = list(self._transfers_for(Player.BLUE).pending_transfers)
         if self.red_visible:
             transfers.extend(self._transfers_for(Player.RED).pending_transfers)
         return transfers
+
+    def sync_game_and_visibility(self) -> None:
+        """Refresh visible transfers and notify attached views."""
+        self.beginResetModel()
+        self._red_visible = self._compute_red_visible()
+        self.endResetModel()
+        self.layoutAboutToBeChanged.emit()
+        self.layoutChanged.emit()
+        if self.rowCount():
+            self.dataChanged.emit(self.index(0), self.index(self.rowCount() - 1))
 
     def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
         return len(self._all_transfers())
@@ -443,16 +460,21 @@ class TransferModel(QAbstractListModel):
         """Updates the game with the new unit transfer."""
         self._assert_authorized(transfer)
         transfers = self._transfers_for(self.owner_of(transfer))
+        visible = transfer.player.is_blue or (
+            transfer.player.is_red and self.red_visible
+        )
         insert_row = (
             transfers.pending_transfer_count
             if transfer.player.is_blue
             else self.rowCount()
         )
         transfers.validate_transfer(transfer)
-        self.beginInsertRows(QModelIndex(), insert_row, insert_row)
+        if visible:
+            self.beginInsertRows(QModelIndex(), insert_row, insert_row)
         # TODO: Needs to regenerate base inventory tab.
         transfers.new_transfer(transfer, now)
-        self.endInsertRows()
+        if visible:
+            self.endInsertRows()
 
     def cancel_transfer_at_index(self, index: QModelIndex) -> None:
         """Cancels the planned unit transfer at the given index."""
@@ -462,6 +484,9 @@ class TransferModel(QAbstractListModel):
         """Cancels the planned unit transfer at the given index."""
         self._assert_authorized(transfer)
         transfers = self._transfers_for(self.owner_of(transfer))
+        if not transfer.player.is_blue and not self.red_visible:
+            transfers.cancel_transfer(transfer)
+            return
         index = transfers.index_of_transfer(transfer)
         if transfer.player.is_red:
             index += self._transfers_for(Player.BLUE).pending_transfer_count
@@ -642,6 +667,7 @@ class GameModel:
         self.game = game
         self.ato_model.replace_from_game(player=True)
         self.red_ato_model.replace_from_game(player=False)
+        self.transfer_model.sync_game_and_visibility()
 
     def get(self) -> Game:
         if self.game is None:

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -387,8 +387,20 @@ class TransferModel(QAbstractListModel):
     def _transfers_for(self, player: Player) -> PendingTransfers:
         return self.game_model.game.coalition_for(player=player).transfers
 
+    @property
+    def red_visible(self) -> bool:
+        return bool(
+            getattr(self.game_model.game.settings, "enable_enemy_buy_sell", False)
+        )
+
+    def _all_transfers(self) -> list[TransferOrder]:
+        transfers = list(self._transfers_for(Player.BLUE).pending_transfers)
+        if self.red_visible:
+            transfers.extend(self._transfers_for(Player.RED).pending_transfers)
+        return transfers
+
     def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
-        return self.transfers.pending_transfer_count
+        return len(self._all_transfers())
 
     def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
         if not index.isValid():
@@ -430,9 +442,15 @@ class TransferModel(QAbstractListModel):
     def new_transfer(self, transfer: TransferOrder, now: datetime) -> None:
         """Updates the game with the new unit transfer."""
         self._assert_authorized(transfer)
-        self.beginInsertRows(QModelIndex(), self.rowCount(), self.rowCount())
+        transfers = self._transfers_for(self.owner_of(transfer))
+        insert_row = (
+            transfers.pending_transfer_count
+            if transfer.player.is_blue
+            else self.rowCount()
+        )
+        self.beginInsertRows(QModelIndex(), insert_row, insert_row)
         # TODO: Needs to regenerate base inventory tab.
-        self._transfers_for(self.owner_of(transfer)).new_transfer(transfer, now)
+        transfers.new_transfer(transfer, now)
         self.endInsertRows()
 
     def cancel_transfer_at_index(self, index: QModelIndex) -> None:
@@ -444,6 +462,8 @@ class TransferModel(QAbstractListModel):
         self._assert_authorized(transfer)
         transfers = self._transfers_for(self.owner_of(transfer))
         index = transfers.index_of_transfer(transfer)
+        if transfer.player.is_red:
+            index += self._transfers_for(Player.BLUE).pending_transfer_count
         self.beginRemoveRows(QModelIndex(), index, index)
         # TODO: Needs to regenerate base inventory tab.
         transfers.cancel_transfer(transfer)
@@ -451,7 +471,7 @@ class TransferModel(QAbstractListModel):
 
     def transfer_at_index(self, index: QModelIndex) -> TransferOrder:
         """Returns the transfer located at the given index."""
-        return self.transfers.transfer_at_index(index.row())
+        return self._all_transfers()[index.row()]
 
 
 class AirWingModel(QAbstractListModel):

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -448,6 +448,7 @@ class TransferModel(QAbstractListModel):
             if transfer.player.is_blue
             else self.rowCount()
         )
+        transfers.validate_transfer(transfer)
         self.beginInsertRows(QModelIndex(), insert_row, insert_row)
         # TODO: Needs to regenerate base inventory tab.
         transfers.new_transfer(transfer, now)

--- a/qt_ui/models.py
+++ b/qt_ui/models.py
@@ -376,9 +376,16 @@ class TransferModel(QAbstractListModel):
         super().__init__()
         self.game_model = game_model
 
+    @staticmethod
+    def owner_of(transfer: TransferOrder) -> Player:
+        return transfer.player
+
     @property
     def transfers(self) -> PendingTransfers:
-        return self.game_model.game.coalition_for(player=Player.BLUE).transfers
+        return self._transfers_for(Player.BLUE)
+
+    def _transfers_for(self, player: Player) -> PendingTransfers:
+        return self.game_model.game.coalition_for(player=player).transfers
 
     def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
         return self.transfers.pending_transfer_count
@@ -405,11 +412,27 @@ class TransferModel(QAbstractListModel):
         """Returns the icon that should be displayed for the transfer."""
         return None
 
+    @staticmethod
+    def _authorized(player: Player, settings: Any) -> bool:
+        if player.is_blue:
+            return True
+        if player.is_red:
+            return bool(getattr(settings, "enable_enemy_buy_sell", False))
+        return False
+
+    def _assert_authorized(self, transfer: TransferOrder) -> None:
+        if not self._authorized(transfer.player, self.game_model.game.settings):
+            raise PermissionError(
+                f"Cannot manage {transfer.player} transfer: "
+                "OPFOR buy/sell/transfer is disabled"
+            )
+
     def new_transfer(self, transfer: TransferOrder, now: datetime) -> None:
         """Updates the game with the new unit transfer."""
+        self._assert_authorized(transfer)
         self.beginInsertRows(QModelIndex(), self.rowCount(), self.rowCount())
         # TODO: Needs to regenerate base inventory tab.
-        self.transfers.new_transfer(transfer, now)
+        self._transfers_for(self.owner_of(transfer)).new_transfer(transfer, now)
         self.endInsertRows()
 
     def cancel_transfer_at_index(self, index: QModelIndex) -> None:
@@ -418,10 +441,12 @@ class TransferModel(QAbstractListModel):
 
     def cancel_transfer(self, transfer: TransferOrder) -> None:
         """Cancels the planned unit transfer at the given index."""
-        index = self.transfers.index_of_transfer(transfer)
+        self._assert_authorized(transfer)
+        transfers = self._transfers_for(self.owner_of(transfer))
+        index = transfers.index_of_transfer(transfer)
         self.beginRemoveRows(QModelIndex(), index, index)
         # TODO: Needs to regenerate base inventory tab.
-        self.transfers.cancel_transfer(transfer)
+        transfers.cancel_transfer(transfer)
         self.endRemoveRows()
 
     def transfer_at_index(self, index: QModelIndex) -> TransferOrder:

--- a/qt_ui/windows/PendingTransfersDialog.py
+++ b/qt_ui/windows/PendingTransfersDialog.py
@@ -58,7 +58,7 @@ class PendingTransfersList(QListView):
         index = self.indexAt(event.pos())
         if not index.isValid():
             return
-        if not self.transfer_model.transfer_at_index(index).player.is_blue:
+        if not self.can_cancel(index):
             return
 
         menu = QMenu("Menu")
@@ -114,7 +114,10 @@ class PendingTransfersDialog(QDialog):
     def can_cancel(self, index: QModelIndex) -> bool:
         if not index.isValid():
             return False
-        return self.transfer_model.transfer_at_index(index).player.is_blue
+        return self.transfer_model.transfer_at_index(index).player.is_blue or (
+            self.transfer_model.game_model.game.settings.enable_enemy_buy_sell
+            and self.transfer_model.transfer_at_index(index).player.is_red
+        )
 
     def on_selection_changed(
         self, selected: QItemSelection, _deselected: QItemSelection

--- a/qt_ui/windows/PendingTransfersDialog.py
+++ b/qt_ui/windows/PendingTransfersDialog.py
@@ -4,6 +4,8 @@ from PySide6.QtCore import (
     QModelIndex,
     Qt,
 )
+from typing import Callable
+
 from PySide6.QtGui import QContextMenuEvent, QAction
 from PySide6.QtWidgets import (
     QAbstractItemView,
@@ -40,9 +42,14 @@ class TransferDelegate(TwoColumnRowDelegate):
 class PendingTransfersList(QListView):
     """List view for displaying the pending unit transfers."""
 
-    def __init__(self, transfer_model: TransferModel) -> None:
+    def __init__(
+        self,
+        transfer_model: TransferModel,
+        can_cancel: Callable[[QModelIndex], bool],
+    ) -> None:
         super().__init__()
         self.transfer_model = transfer_model
+        self.can_cancel = can_cancel
 
         self.setItemDelegate(TransferDelegate(self.transfer_model))
         self.setModel(self.transfer_model)
@@ -88,7 +95,7 @@ class PendingTransfersDialog(QDialog):
         layout = QVBoxLayout()
         self.setLayout(layout)
 
-        self.transfer_list = PendingTransfersList(self.transfer_model)
+        self.transfer_list = PendingTransfersList(self.transfer_model, self.can_cancel)
         self.transfer_list.selectionModel().selectionChanged.connect(
             self.on_selection_changed
         )

--- a/qt_ui/windows/basemenu/NewUnitTransferDialog.py
+++ b/qt_ui/windows/basemenu/NewUnitTransferDialog.py
@@ -324,6 +324,7 @@ class NewUnitTransferDialog(QDialog):
             origin=self.origin,
             destination=destination,
             units=transfers,
+            player=self.origin.captured,
             request_airflift=self.dest_panel.request_airlift,
         )
         self.game_model.transfer_model.new_transfer(

--- a/qt_ui/windows/basemenu/NewUnitTransferDialog.py
+++ b/qt_ui/windows/basemenu/NewUnitTransferDialog.py
@@ -36,11 +36,13 @@ class TransferDestinationComboBox(QComboBox):
         super().__init__()
         self.game = game
         self.origin = origin
+        self.owner = origin.captured
 
         for cp in self.game.theater.controlpoints:
             if (
                 cp != self.origin
-                and cp.is_friendly(to_player=Player.BLUE)
+                and not self.owner.is_neutral
+                and cp.is_friendly(to_player=self.owner)
                 and cp.can_deploy_ground_units
             ):
                 self.addItem(cp.name, cp)
@@ -175,7 +177,7 @@ class ScrollingUnitTransferGrid(QFrame):
         task_box_layout = QGridLayout()
 
         unit_types = set(
-            self.game_model.game.faction_for(player=Player.BLUE).ground_units
+            self.game_model.game.faction_for(player=cp.captured).ground_units
         )
         sorted_units = sorted(
             {u for u in unit_types if self.cp.base.total_units_of_type(u)},
@@ -309,6 +311,8 @@ class NewUnitTransferDialog(QDialog):
 
     def on_submit(self) -> None:
         destination = self.dest_panel.current
+        if destination is None:
+            return
         transfers = {}
         for unit_type, count in self.transfer_panel.transfers.items():
             if not count:

--- a/qt_ui/windows/basemenu/QBaseMenu2.py
+++ b/qt_ui/windows/basemenu/QBaseMenu2.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QCloseEvent, QPixmap
 from PySide6.QtWidgets import (
@@ -167,7 +169,9 @@ class QBaseMenu2(QDialog):
             capture_button.clicked.connect(self.cheat_capture)
 
         self.budget_display = QLabel(
-            UnitTransactionFrame.BUDGET_FORMAT.format(self.game_model.game.blue.budget)
+            UnitTransactionFrame.BUDGET_FORMAT.format(
+                self._budget_coalition(self.game_model.game).budget
+            )
         )
         self.budget_display.setAlignment(
             Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignBottom
@@ -401,7 +405,14 @@ class QBaseMenu2(QDialog):
     def open_transfer_dialog(self) -> None:
         NewUnitTransferDialog(self.game_model, self.cp, parent=self.window()).show()
 
+    def _budget_coalition(self, game: Game) -> Any:
+        if self.cp.captured.is_red:
+            return game.red
+        return game.blue
+
     def update_budget(self, game: Game) -> None:
         self.budget_display.setText(
-            UnitTransactionFrame.BUDGET_FORMAT.format(game.blue.budget)
+            UnitTransactionFrame.BUDGET_FORMAT.format(
+                self._budget_coalition(game).budget
+            )
         )

--- a/qt_ui/windows/basemenu/QBaseMenu2.py
+++ b/qt_ui/windows/basemenu/QBaseMenu2.py
@@ -153,7 +153,7 @@ class QBaseMenu2(QDialog):
             runway_attack_button.setProperty("style", "btn-danger")
             runway_attack_button.clicked.connect(self.new_package)
 
-        if self.cp.captured.is_blue and self.has_transfer_destinations:
+        if self.can_transfer_units:
             transfer_button = QPushButton("Transfer Units")
             transfer_button.setProperty("style", "btn-success")
             bottom_row.addWidget(transfer_button)
@@ -206,6 +206,17 @@ class QBaseMenu2(QDialog):
         state = self.game_model.game.check_win_loss()
         GameUpdateSignal.get_instance().gameStateChanged(state)
         self.close()
+
+    @property
+    def can_transfer_units(self) -> bool:
+        owner = self.cp.captured
+        return (
+            not owner.is_neutral
+            and (owner.is_blue or self.game_model.game.settings.enable_enemy_buy_sell)
+            and self.game_model.game.transit_network_for(owner).has_destinations(
+                self.cp
+            )
+        )
 
     @property
     def has_transfer_destinations(self) -> bool:

--- a/qt_ui/windows/basemenu/QBaseMenuTabs.py
+++ b/qt_ui/windows/basemenu/QBaseMenuTabs.py
@@ -18,6 +18,12 @@ class QBaseMenuTabs(QTabWidget):
 
             self.departing_convoys = DepartingConvoysMenu(cp, game_model)
             self.addTab(self.departing_convoys, "Departing Convoys")
+            if (
+                game_model.game.settings.enable_enemy_buy_sell
+                and cp.can_deploy_ground_units
+            ):
+                self.ground_forces_hq = QGroundForcesHQ(cp, game_model)
+                self.addTab(self.ground_forces_hq, "Ground Forces HQ")
             return
 
         if isinstance(cp, Fob):

--- a/qt_ui/windows/basemenu/UnitTransactionFrame.py
+++ b/qt_ui/windows/basemenu/UnitTransactionFrame.py
@@ -138,11 +138,11 @@ class UnitTransactionFrame(QFrame, Generic[TransactionItemType]):
 
     @property
     def budget(self) -> float:
-        return self.game_model.game.blue.budget
+        return self.purchase_adapter.coalition.budget
 
     @budget.setter
     def budget(self, value: int) -> None:
-        self.game_model.game.blue.budget = value
+        self.purchase_adapter.coalition.budget = value
 
     def add_purchase_row(
         self,

--- a/qt_ui/windows/basemenu/ground_forces/QArmorRecruitmentMenu.py
+++ b/qt_ui/windows/basemenu/ground_forces/QArmorRecruitmentMenu.py
@@ -4,17 +4,17 @@ from PySide6.QtWidgets import QGridLayout, QScrollArea, QVBoxLayout, QWidget
 from game.dcs.groundunittype import GroundUnitType
 from game.purchaseadapter import GroundUnitPurchaseAdapter
 from game.theater import ControlPoint
-from game.theater.player import Player
 from qt_ui.models import GameModel
 from qt_ui.windows.basemenu.UnitTransactionFrame import UnitTransactionFrame
 
 
 class QArmorRecruitmentMenu(UnitTransactionFrame[GroundUnitType]):
     def __init__(self, cp: ControlPoint, game_model: GameModel):
+        owner = cp.captured
         super().__init__(
             game_model,
             GroundUnitPurchaseAdapter(
-                cp, game_model.game.coalition_for(cp.captured), game_model.game
+                cp, game_model.game.coalition_for(owner), game_model.game
             ),
         )
         self.cp = cp
@@ -31,7 +31,7 @@ class QArmorRecruitmentMenu(UnitTransactionFrame[GroundUnitType]):
         row = 0
 
         unit_types = list(
-            set(self.game_model.game.faction_for(player=Player.BLUE).ground_units)
+            set(self.game_model.game.faction_for(player=owner).ground_units)
         )
         unit_types.sort(key=lambda u: u.display_name)
         for row, unit_type in enumerate(unit_types):

--- a/qt_ui/windows/settings/QSettingsWindow.py
+++ b/qt_ui/windows/settings/QSettingsWindow.py
@@ -112,7 +112,7 @@ class CheatSettingsBox(QGroupBox):
         self.opfor_buysell_checkbox.setChecked(sc.settings.enable_enemy_buy_sell)
         self.opfor_buysell_checkbox.toggled.connect(apply_settings)
         self.redfor_buysell_cheat = QLabeledWidget(
-            "Enable OPFOR Buy/Sell actions Cheat:", self.opfor_buysell_checkbox
+            "Enable OPFOR Buy/Sell/Transfer Cheat", self.opfor_buysell_checkbox
         )
         self.main_layout.addLayout(self.redfor_buysell_cheat)
 

--- a/tests/test_opfor_ground_force_management.py
+++ b/tests/test_opfor_ground_force_management.py
@@ -5,14 +5,20 @@ from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QLabel
 
 from game.purchaseadapter import GroundUnitPurchaseAdapter
 from game.migrator import Migrator
 from game.theater.base import Base
 from game.theater.player import Player
 from game.transfers import MultiGroupTransport, PendingTransfers, TransferOrder
+from game.theater.transitnetwork import TransitNetwork
 from qt_ui.models import TransferModel
+from qt_ui.windows.basemenu.NewUnitTransferDialog import (
+    ScrollingUnitTransferGrid,
+    TransferDestinationComboBox,
+)
+from qt_ui.windows.basemenu.QBaseMenu2 import QBaseMenu2
 from qt_ui.windows.settings.QSettingsWindow import CheatSettingsBox
 
 
@@ -109,13 +115,196 @@ def test_transfer_owner_survives_origin_capture_and_split() -> None:
     assert pending.split_transfer(transfer, 1).player is Player.BLUE
 
 
-def test_transfer_migration_backfills_legacy_owner() -> None:
-    transfer = SimpleNamespace(player=True)
+def test_transfer_migration_backfills_missing_owner() -> None:
+    transfer = SimpleNamespace()
     coalition = SimpleNamespace(player=Player.RED)
 
     Migrator._normalize_single_transfer_player(transfer, coalition)
 
     assert transfer.player is Player.RED
+
+
+def test_red_transfer_model_maps_rows_and_cancels_red_transfer() -> None:
+    red_transfer = cast(Any, SimpleNamespace(player=Player.RED))
+    blue_transfer = cast(Any, SimpleNamespace(player=Player.BLUE))
+    red_transfers = MagicMock(
+        pending_transfer_count=1,
+        pending_transfers=[red_transfer],
+    )
+    blue_transfers = MagicMock(
+        pending_transfer_count=1,
+        pending_transfers=[blue_transfer],
+    )
+    game = SimpleNamespace(
+        settings=SimpleNamespace(enable_enemy_buy_sell=True),
+        coalition_for=lambda player: SimpleNamespace(
+            transfers=red_transfers if player is Player.RED else blue_transfers
+        ),
+    )
+    model = TransferModel(cast(Any, SimpleNamespace(game=game)))
+
+    assert model.rowCount() == 2
+    assert model.transfer_at_index(model.index(1, 0)) is red_transfer
+    model.cancel_transfer_at_index(model.index(1, 0))
+
+    red_transfers.cancel_transfer.assert_called_once_with(red_transfer)
+    blue_transfers.cancel_transfer.assert_not_called()
+
+
+def test_legacy_boolean_transfer_owner_is_preserved_and_validated() -> None:
+    transfer = SimpleNamespace(player=True)
+    blue_coalition = SimpleNamespace(player=Player.BLUE)
+    Migrator._normalize_single_transfer_player(transfer, blue_coalition)
+    assert transfer.player is Player.BLUE
+
+    transfer.player = False
+    red_coalition = SimpleNamespace(player=Player.RED)
+    Migrator._normalize_single_transfer_player(transfer, red_coalition)
+    assert transfer.player is Player.RED
+
+    with pytest.raises(RuntimeError, match="owner"):
+        Migrator._normalize_single_transfer_player(transfer, blue_coalition)
+
+
+def test_red_transfer_rejects_cross_coalition_destination() -> None:
+    unit_type = cast(Any, MagicMock())
+    origin = cast(
+        Any,
+        SimpleNamespace(name="Red origin", captured=Player.RED, base=Base()),
+    )
+    destination = cast(
+        Any,
+        SimpleNamespace(name="Blue destination", captured=Player.BLUE, base=Base()),
+    )
+    origin.base.commission_units({unit_type: 2})
+    pending = PendingTransfers(cast(Any, SimpleNamespace()), Player.RED)
+    transfer = TransferOrder(origin, destination, {unit_type: 1}, player=Player.RED)
+
+    with pytest.raises(ValueError, match="destination"):
+        pending.new_transfer(transfer, SimpleNamespace())
+
+    assert origin.base.total_units_of_type(unit_type) == 2
+    assert pending.pending_transfers == []
+
+
+def test_red_transfer_rejects_invalid_route_before_committing_origin_losses() -> None:
+    unit_type = cast(Any, MagicMock())
+    origin = cast(
+        Any,
+        SimpleNamespace(
+            name="Red origin",
+            captured=Player.RED,
+            base=Base(),
+            position=SimpleNamespace(distance_to_point=lambda _other: 1),
+        ),
+    )
+    destination = cast(
+        Any,
+        SimpleNamespace(
+            name="Red destination",
+            captured=Player.RED,
+            base=Base(),
+            position=SimpleNamespace(distance_to_point=lambda _other: 1),
+        ),
+    )
+    origin.base.commission_units({unit_type: 2})
+    pending = PendingTransfers(cast(Any, SimpleNamespace()), Player.RED)
+    pending.network_for = lambda _cp: TransitNetwork()
+    transfer = TransferOrder(origin, destination, {unit_type: 1}, player=Player.RED)
+
+    with pytest.raises(ValueError):
+        pending.new_transfer(transfer, SimpleNamespace())
+
+    assert origin.base.total_units_of_type(unit_type) == 2
+    assert pending.pending_transfers == []
+
+
+def test_red_transfer_destination_combo_uses_red_friendly_points(
+    app: QApplication,
+) -> None:
+    origin = cast(Any, SimpleNamespace(name="origin"))
+    red_destination = cast(
+        Any,
+        SimpleNamespace(
+            name="red destination",
+            captured=Player.RED,
+            can_deploy_ground_units=True,
+        ),
+    )
+    blue_destination = cast(
+        Any,
+        SimpleNamespace(
+            name="blue destination",
+            captured=Player.BLUE,
+            can_deploy_ground_units=True,
+        ),
+    )
+    neutral_destination = cast(
+        Any,
+        SimpleNamespace(
+            name="neutral destination",
+            captured=Player.NEUTRAL,
+            can_deploy_ground_units=True,
+        ),
+    )
+    game = cast(
+        Any,
+        SimpleNamespace(
+            theater=SimpleNamespace(
+                controlpoints=[
+                    origin,
+                    red_destination,
+                    blue_destination,
+                    neutral_destination,
+                ]
+            )
+        ),
+    )
+    origin.captured = Player.RED
+
+    combo = TransferDestinationComboBox(game, origin)
+
+    assert [combo.itemData(i) for i in range(combo.count())] == [red_destination]
+
+
+def test_red_transfer_grid_uses_red_faction_units(app: QApplication) -> None:
+    unit_type = cast(Any, SimpleNamespace(display_name="Red tank"))
+    origin = cast(
+        Any,
+        SimpleNamespace(
+            base=SimpleNamespace(total_units_of_type=lambda unit: 1),
+            captured=Player.RED,
+        ),
+    )
+    game_model = cast(
+        Any,
+        SimpleNamespace(
+            game=SimpleNamespace(
+                faction_for=lambda player: SimpleNamespace(
+                    ground_units={unit_type} if player is Player.RED else set()
+                )
+            )
+        ),
+    )
+
+    grid = ScrollingUnitTransferGrid(origin, game_model)
+
+    assert grid.transfers == {}
+    assert any(label.text() == "<b>Red tank</b>" for label in grid.findChildren(QLabel))
+
+
+def test_red_base_menu_budget_uses_captured_coalition() -> None:
+    menu = QBaseMenu2.__new__(QBaseMenu2)
+    menu.cp = SimpleNamespace(captured=Player.RED)
+    menu.budget_display = MagicMock()
+    menu.update_budget(
+        SimpleNamespace(
+            blue=SimpleNamespace(budget=10),
+            red=SimpleNamespace(budget=20),
+        )
+    )
+    menu.budget_display.setText.assert_called_once()
+    assert "20" in menu.budget_display.setText.call_args.args[0]
 
 
 def test_red_transfer_model_rejects_mutation_when_cheat_is_disabled() -> None:

--- a/tests/test_opfor_ground_force_management.py
+++ b/tests/test_opfor_ground_force_management.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from datetime import datetime
 from types import SimpleNamespace
+import typing
 from typing import Any, cast
 from unittest.mock import MagicMock
 
@@ -151,6 +153,7 @@ def test_red_transfer_model_maps_rows_and_cancels_red_transfer() -> None:
     blue_transfers.cancel_transfer.assert_not_called()
 
 
+@typing.no_type_check
 def test_legacy_boolean_transfer_owner_is_preserved_and_validated() -> None:
     transfer = SimpleNamespace(player=True)
     blue_coalition = SimpleNamespace(player=Player.BLUE)
@@ -166,6 +169,7 @@ def test_legacy_boolean_transfer_owner_is_preserved_and_validated() -> None:
         Migrator._normalize_single_transfer_player(transfer, blue_coalition)
 
 
+@typing.no_type_check
 def test_red_transfer_rejects_cross_coalition_destination() -> None:
     unit_type = cast(Any, MagicMock())
     origin = cast(
@@ -187,6 +191,7 @@ def test_red_transfer_rejects_cross_coalition_destination() -> None:
     assert pending.pending_transfers == []
 
 
+@typing.no_type_check
 def test_red_transfer_rejects_invalid_route_before_committing_origin_losses() -> None:
     unit_type = cast(Any, MagicMock())
     origin = cast(
@@ -209,7 +214,11 @@ def test_red_transfer_rejects_invalid_route_before_committing_origin_losses() ->
     )
     origin.base.commission_units({unit_type: 2})
     pending = PendingTransfers(cast(Any, SimpleNamespace()), Player.RED)
-    pending.network_for = lambda _cp: TransitNetwork()
+    invalid_network = TransitNetwork()
+    invalid_network.shortest_path_between = lambda _origin, _destination: (
+        _ for _ in ()
+    ).throw(ValueError())
+    pending.network_for = lambda _cp: invalid_network
     transfer = TransferOrder(origin, destination, {unit_type: 1}, player=Player.RED)
 
     with pytest.raises(ValueError):
@@ -219,6 +228,7 @@ def test_red_transfer_rejects_invalid_route_before_committing_origin_losses() ->
     assert pending.pending_transfers == []
 
 
+@typing.no_type_check
 def test_red_transfer_destination_combo_uses_red_friendly_points(
     app: QApplication,
 ) -> None:
@@ -229,6 +239,7 @@ def test_red_transfer_destination_combo_uses_red_friendly_points(
             name="red destination",
             captured=Player.RED,
             can_deploy_ground_units=True,
+            is_friendly=lambda to_player: red_destination.captured == to_player,
         ),
     )
     blue_destination = cast(
@@ -237,6 +248,7 @@ def test_red_transfer_destination_combo_uses_red_friendly_points(
             name="blue destination",
             captured=Player.BLUE,
             can_deploy_ground_units=True,
+            is_friendly=lambda to_player: blue_destination.captured == to_player,
         ),
     )
     neutral_destination = cast(
@@ -245,6 +257,7 @@ def test_red_transfer_destination_combo_uses_red_friendly_points(
             name="neutral destination",
             captured=Player.NEUTRAL,
             can_deploy_ground_units=True,
+            is_friendly=lambda to_player: neutral_destination.captured == to_player,
         ),
     )
     game = cast(
@@ -267,8 +280,9 @@ def test_red_transfer_destination_combo_uses_red_friendly_points(
     assert [combo.itemData(i) for i in range(combo.count())] == [red_destination]
 
 
+@typing.no_type_check
 def test_red_transfer_grid_uses_red_faction_units(app: QApplication) -> None:
-    unit_type = cast(Any, SimpleNamespace(display_name="Red tank"))
+    unit_type = cast(Any, MagicMock(display_name="Red tank"))
     origin = cast(
         Any,
         SimpleNamespace(
@@ -293,6 +307,7 @@ def test_red_transfer_grid_uses_red_faction_units(app: QApplication) -> None:
     assert any(label.text() == "<b>Red tank</b>" for label in grid.findChildren(QLabel))
 
 
+@typing.no_type_check
 def test_red_base_menu_budget_uses_captured_coalition() -> None:
     menu = QBaseMenu2.__new__(QBaseMenu2)
     menu.cp = SimpleNamespace(captured=Player.RED)
@@ -305,6 +320,124 @@ def test_red_base_menu_budget_uses_captured_coalition() -> None:
     )
     menu.budget_display.setText.assert_called_once()
     assert "20" in menu.budget_display.setText.call_args.args[0]
+
+
+@typing.no_type_check
+def test_capture_then_cancel_does_not_refund_units_to_enemy_owned_origin() -> None:
+    unit_type = cast(Any, object())
+    origin = cast(
+        Any,
+        SimpleNamespace(
+            name="Red origin",
+            captured=Player.RED,
+            base=Base(),
+            position=object(),
+            is_friendly=lambda player: origin.captured == player,
+        ),
+    )
+    destination = cast(
+        Any,
+        SimpleNamespace(
+            name="Red destination", captured=Player.RED, base=Base(), position=object()
+        ),
+    )
+    origin.base.commission_units({unit_type: 1})
+    pending = PendingTransfers(cast(Any, SimpleNamespace()), Player.RED)
+    transfer = TransferOrder(origin, destination, {unit_type: 1}, player=Player.RED)
+    origin.base.commit_losses(transfer.units)
+    pending.pending_transfers.append(transfer)
+    pending._send_supply_route_event_stream_update = lambda: None
+
+    origin.captured = Player.BLUE
+    pending.cancel_transfer(transfer)
+
+    assert origin.base.total_units_of_type(unit_type) == 0
+    assert transfer.units == {}
+
+
+@typing.no_type_check
+def test_transfer_routing_uses_owner_after_origin_is_captured() -> None:
+    origin = cast(
+        Any,
+        SimpleNamespace(name="Origin", captured=Player.RED, position=object()),
+    )
+    destination = cast(
+        Any,
+        SimpleNamespace(name="Destination", captured=Player.BLUE, position=object()),
+    )
+    blue_network = object()
+    red_network = object()
+    game = SimpleNamespace(
+        transit_network_for=lambda player: (
+            blue_network if player is Player.BLUE else red_network
+        )
+    )
+    pending = PendingTransfers(cast(Any, game), Player.BLUE)
+    transfer = TransferOrder(origin, destination, {}, player=Player.BLUE)
+
+    assert pending.network_for(transfer.position) is blue_network
+
+
+@typing.no_type_check
+def test_transport_identity_uses_contained_transfer_owner_after_capture() -> None:
+    blue_coalition = object()
+    game = SimpleNamespace(
+        coalition_for=lambda player: (
+            blue_coalition if player is Player.BLUE else object()
+        )
+    )
+    origin = cast(
+        Any,
+        SimpleNamespace(
+            captured=Player.BLUE,
+            position=object(),
+            coalition=SimpleNamespace(game=game),
+        ),
+    )
+    destination = cast(Any, SimpleNamespace(position=object()))
+    transfer = TransferOrder(origin, destination, {}, player=Player.BLUE)
+    convoy = MultiGroupTransport("Convoy", origin, destination)
+    convoy.add_units(transfer)
+
+    origin.captured = Player.RED
+
+    assert convoy.is_friendly(Player.BLUE)
+    assert convoy.coalition is blue_coalition
+
+
+def test_transfer_model_does_not_begin_insert_for_rejected_transfer(
+    app: QApplication,
+) -> None:
+    unit_type = cast(Any, object())
+    origin = cast(
+        Any,
+        SimpleNamespace(name="Red origin", captured=Player.RED, base=Base()),
+    )
+    destination = cast(
+        Any,
+        SimpleNamespace(name="Blue destination", captured=Player.BLUE, base=Base()),
+    )
+    red_transfers = PendingTransfers(cast(Any, SimpleNamespace()), Player.RED)
+    blue_transfers = PendingTransfers(cast(Any, SimpleNamespace()), Player.BLUE)
+    game = SimpleNamespace(
+        settings=SimpleNamespace(enable_enemy_buy_sell=True),
+        coalition_for=lambda player: SimpleNamespace(
+            transfers=red_transfers if player is Player.RED else blue_transfers
+        ),
+    )
+    model = TransferModel(cast(Any, SimpleNamespace(game=game)))
+    transfer = TransferOrder(origin, destination, {unit_type: 1}, player=Player.RED)
+    about_to_insert = []
+    inserted = []
+    model.rowsAboutToBeInserted.connect(lambda: about_to_insert.append(True))
+    model.rowsInserted.connect(lambda: inserted.append(True))
+
+    with pytest.raises(ValueError, match="destination"):
+        model.new_transfer(transfer, SimpleNamespace())
+
+    assert about_to_insert == []
+    assert inserted == []
+    assert red_transfers.pending_transfers == []
 
 
 def test_red_transfer_model_rejects_mutation_when_cheat_is_disabled() -> None:

--- a/tests/test_opfor_ground_force_management.py
+++ b/tests/test_opfor_ground_force_management.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from game.purchaseadapter import GroundUnitPurchaseAdapter
+from game.migrator import Migrator
+from game.theater.base import Base
+from game.theater.player import Player
+from game.transfers import MultiGroupTransport, PendingTransfers, TransferOrder
+from qt_ui.models import TransferModel
+from qt_ui.windows.settings.QSettingsWindow import CheatSettingsBox
+
+
+@pytest.fixture
+def app() -> QApplication:
+    return cast(Any, QApplication.instance() or QApplication([]))
+
+
+def test_cheat_menu_uses_explicit_opfor_transfer_label(app: QApplication) -> None:
+    settings = SimpleNamespace(
+        enable_frontline_cheats=False,
+        enable_base_capture_cheat=False,
+        enable_runway_state_cheat=False,
+        enable_transfer_cheat=False,
+        enable_air_wing_adjustments=False,
+        enable_enemy_buy_sell=False,
+    )
+    box = CheatSettingsBox(
+        cast(Any, SimpleNamespace(settings=settings)), cast(Any, lambda: None)
+    )
+
+    label = cast(Any, box.redfor_buysell_cheat.itemAt(0).widget())
+
+    assert label.text() == "Enable OPFOR Buy/Sell/Transfer Cheat"
+
+
+def test_red_ground_sale_is_available_only_when_cheat_is_enabled() -> None:
+    unit_type = cast(Any, MagicMock())
+    unit_type.price = 5
+    base = Base()
+    base.commission_units({unit_type: 2})
+    control_point = SimpleNamespace(base=base, captured=Player.RED)
+    coalition = SimpleNamespace(player=Player.RED, budget=10)
+    game = SimpleNamespace(settings=SimpleNamespace(enable_enemy_buy_sell=False))
+
+    disabled = cast(
+        Any,
+        GroundUnitPurchaseAdapter(
+            cast(Any, control_point), cast(Any, coalition), cast(Any, game)
+        ),
+    )
+    assert disabled.can_sell(unit_type) is False
+
+    game.settings.enable_enemy_buy_sell = True
+    enabled = cast(
+        Any,
+        GroundUnitPurchaseAdapter(
+            cast(Any, control_point), cast(Any, coalition), cast(Any, game)
+        ),
+    )
+
+    assert enabled.can_sell(unit_type) is True
+
+
+def test_red_transfer_model_routes_transfer_to_red_collection_when_enabled() -> None:
+    red_transfers = MagicMock(pending_transfer_count=0)
+    blue_transfers = MagicMock(pending_transfer_count=0)
+    game = SimpleNamespace(
+        settings=SimpleNamespace(enable_enemy_buy_sell=True),
+        coalition_for=lambda player: SimpleNamespace(
+            transfers=red_transfers if player is Player.RED else blue_transfers
+        ),
+    )
+    model = TransferModel(cast(Any, SimpleNamespace(game=game)))
+    transfer = cast(Any, SimpleNamespace(player=Player.RED))
+
+    now = cast(Any, SimpleNamespace())
+    model.new_transfer(transfer, now)
+
+    red_transfers.new_transfer.assert_called_once_with(transfer, now)
+    blue_transfers.new_transfer.assert_not_called()
+
+
+def test_transfer_owner_survives_origin_capture_and_split() -> None:
+    origin = SimpleNamespace(
+        name="Alpha", captured=Player.BLUE, base=Base(), position=object()
+    )
+    destination = SimpleNamespace(
+        name="Bravo", captured=Player.BLUE, base=Base(), position=object()
+    )
+    unit_type = cast(Any, object())
+    pending = PendingTransfers(cast(Any, SimpleNamespace()), Player.BLUE)
+    transfer = TransferOrder(
+        cast(Any, origin), cast(Any, destination), {unit_type: 2}, player=Player.BLUE
+    )
+    transport = MultiGroupTransport("Convoy", cast(Any, origin), cast(Any, destination))
+    transport.add_units(transfer)
+
+    origin.captured = Player.RED
+
+    assert transfer.player is Player.BLUE
+    assert transport.player_owned is Player.BLUE
+    pending.pending_transfers.append(transfer)
+    assert pending.split_transfer(transfer, 1).player is Player.BLUE
+
+
+def test_transfer_migration_backfills_legacy_owner() -> None:
+    transfer = SimpleNamespace(player=True)
+    coalition = SimpleNamespace(player=Player.RED)
+
+    Migrator._normalize_single_transfer_player(transfer, coalition)
+
+    assert transfer.player is Player.RED
+
+
+def test_red_transfer_model_rejects_mutation_when_cheat_is_disabled() -> None:
+    game = SimpleNamespace(
+        settings=SimpleNamespace(enable_enemy_buy_sell=False),
+        coalition_for=lambda _player: SimpleNamespace(
+            transfers=MagicMock(pending_transfer_count=0)
+        ),
+    )
+    model = TransferModel(cast(Any, SimpleNamespace(game=game)))
+    transfer = cast(Any, SimpleNamespace(player=Player.RED))
+
+    with pytest.raises(PermissionError, match="OPFOR buy/sell/transfer is disabled"):
+        model.new_transfer(transfer, SimpleNamespace())

--- a/tests/test_opfor_ground_force_management.py
+++ b/tests/test_opfor_ground_force_management.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
+from dcs.mapping import Point
 from PySide6.QtCore import QPoint
 from PySide6.QtGui import QContextMenuEvent
 from PySide6.QtWidgets import QApplication, QLabel, QMenu
@@ -15,7 +16,12 @@ from game.purchaseadapter import GroundUnitPurchaseAdapter
 from game.migrator import Migrator
 from game.theater.base import Base
 from game.theater.player import Player
-from game.transfers import MultiGroupTransport, PendingTransfers, TransferOrder
+from game.transfers import (
+    AirliftPlanner,
+    MultiGroupTransport,
+    PendingTransfers,
+    TransferOrder,
+)
 from game.theater.transitnetwork import TransitNetwork
 from qt_ui.models import TransferModel
 from qt_ui.windows.PendingTransfersDialog import PendingTransfersDialog
@@ -237,11 +243,11 @@ def test_transfer_model_refreshes_rows_when_red_visibility_changes(
     model_resets = []
     layouts = []
     data_changes = []
-    model.modelAboutToBeReset.connect(lambda: model_resets.append("about"))
-    model.modelReset.connect(lambda: model_resets.append("reset"))
-    model.layoutAboutToBeChanged.connect(lambda: layouts.append("about"))
-    model.layoutChanged.connect(lambda: layouts.append("changed"))
-    model.dataChanged.connect(lambda *_args: data_changes.append(True))
+    cast(Any, model).modelAboutToBeReset.connect(lambda: model_resets.append("about"))
+    cast(Any, model).modelReset.connect(lambda: model_resets.append("reset"))
+    cast(Any, model).layoutAboutToBeChanged.connect(lambda: layouts.append("about"))
+    cast(Any, model).layoutChanged.connect(lambda: layouts.append("changed"))
+    cast(Any, model).dataChanged.connect(lambda *_args: data_changes.append(True))
 
     assert model.rowCount() == 1
     settings.enable_enemy_buy_sell = True
@@ -534,6 +540,41 @@ def test_transport_identity_uses_contained_transfer_owner_after_capture() -> Non
     assert convoy.coalition is blue_coalition
 
 
+def test_airlift_rejects_helicopter_when_pickup_to_drop_off_exceeds_range() -> None:
+    max_range = AirliftPlanner.HELO_MAX_RANGE.meters
+    home = Point(0, 0, None)  # type: ignore[arg-type]
+    pickup = Point(-0.6 * max_range, 0, None)  # type: ignore[arg-type]
+    drop_off = Point(0.6 * max_range, 0, None)  # type: ignore[arg-type]
+    transfer = cast(
+        Any,
+        SimpleNamespace(
+            origin=SimpleNamespace(can_operate=lambda _unit_type: True),
+            player=Player.BLUE,
+            position=SimpleNamespace(position=pickup),
+        ),
+    )
+    next_stop = cast(
+        Any,
+        SimpleNamespace(
+            can_operate=lambda _unit_type: True,
+            position=drop_off,
+        ),
+    )
+    planner = object.__new__(AirliftPlanner)
+    planner.transfer = transfer
+    planner.next_stop = next_stop
+    helicopter = cast(
+        Any,
+        SimpleNamespace(
+            capable_of=lambda _task: True,
+            dcs_unit_type=SimpleNamespace(helicopter=True),
+        ),
+    )
+    airfield = cast(Any, SimpleNamespace(position=home))
+
+    assert not planner.compatible_with_mission(helicopter, airfield)
+
+
 def test_transfer_model_does_not_begin_insert_for_rejected_transfer(
     app: QApplication,
 ) -> None:
@@ -558,8 +599,8 @@ def test_transfer_model_does_not_begin_insert_for_rejected_transfer(
     transfer = TransferOrder(origin, destination, {unit_type: 1}, player=Player.RED)
     about_to_insert = []
     inserted = []
-    model.rowsAboutToBeInserted.connect(lambda: about_to_insert.append(True))
-    model.rowsInserted.connect(lambda: inserted.append(True))
+    cast(Any, model).rowsAboutToBeInserted.connect(lambda: about_to_insert.append(True))
+    cast(Any, model).rowsInserted.connect(lambda: inserted.append(True))
 
     with pytest.raises(ValueError, match="destination"):
         model.new_transfer(transfer, SimpleNamespace())

--- a/tests/test_opfor_ground_force_management.py
+++ b/tests/test_opfor_ground_force_management.py
@@ -120,6 +120,22 @@ def test_transfer_owner_survives_origin_capture_and_split() -> None:
     assert pending.split_transfer(transfer, 1).player is Player.BLUE
 
 
+def test_transport_rejects_mixed_owner_transfer_without_mutating() -> None:
+    origin = cast(Any, SimpleNamespace(position=object()))
+    destination = cast(Any, SimpleNamespace(position=object()))
+    blue_transfer = TransferOrder(origin, destination, {}, player=Player.BLUE)
+    red_transfer = TransferOrder(origin, destination, {}, player=Player.RED)
+    transport = MultiGroupTransport("Convoy", origin, destination)
+    transport.add_units(blue_transfer)
+
+    with pytest.raises(ValueError, match="ownership"):
+        transport.add_units(red_transfer)
+
+    assert transport.transfers == [blue_transfer]
+    assert blue_transfer.transport is transport
+    assert red_transfer.transport is None
+
+
 def test_transfer_rejects_collection_owner_mismatch_without_assert() -> None:
     pending = PendingTransfers(cast(Any, SimpleNamespace()), Player.BLUE)
     transfer = cast(Any, SimpleNamespace(player=Player.RED))
@@ -200,6 +216,43 @@ def test_pending_transfers_list_context_menu_delegates_cancel_predicate(
     list_widget.contextMenuEvent(event)
 
     menu_exec.assert_called_once()
+
+
+def test_transfer_model_refreshes_rows_when_red_visibility_changes(
+    app: QApplication,
+) -> None:
+    red_transfer = cast(Any, SimpleNamespace(player=Player.RED))
+    blue_transfer = cast(Any, SimpleNamespace(player=Player.BLUE))
+    red_transfers = SimpleNamespace(pending_transfers=[red_transfer])
+    blue_transfers = SimpleNamespace(pending_transfers=[blue_transfer])
+    settings = SimpleNamespace(enable_enemy_buy_sell=False)
+    game = SimpleNamespace(
+        settings=settings,
+        coalition_for=lambda player: SimpleNamespace(
+            transfers=red_transfers if player is Player.RED else blue_transfers
+        ),
+    )
+    game_model = cast(Any, SimpleNamespace(game=game))
+    model = TransferModel(game_model)
+    model_resets = []
+    layouts = []
+    data_changes = []
+    model.modelAboutToBeReset.connect(lambda: model_resets.append("about"))
+    model.modelReset.connect(lambda: model_resets.append("reset"))
+    model.layoutAboutToBeChanged.connect(lambda: layouts.append("about"))
+    model.layoutChanged.connect(lambda: layouts.append("changed"))
+    model.dataChanged.connect(lambda *_args: data_changes.append(True))
+
+    assert model.rowCount() == 1
+    settings.enable_enemy_buy_sell = True
+    model.sync_game_and_visibility()
+
+    assert model.rowCount() == 2
+    assert model.transfer_at_index(model.index(1, 0)) is red_transfer
+    assert model.red_visible is True
+    assert model_resets == ["about", "reset"]
+    assert layouts == ["about", "changed"]
+    assert data_changes
 
 
 def test_red_transfer_model_maps_rows_and_cancels_red_transfer() -> None:

--- a/tests/test_opfor_ground_force_management.py
+++ b/tests/test_opfor_ground_force_management.py
@@ -7,7 +7,9 @@ from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
-from PySide6.QtWidgets import QApplication, QLabel
+from PySide6.QtCore import QPoint
+from PySide6.QtGui import QContextMenuEvent
+from PySide6.QtWidgets import QApplication, QLabel, QMenu
 
 from game.purchaseadapter import GroundUnitPurchaseAdapter
 from game.migrator import Migrator
@@ -16,6 +18,7 @@ from game.theater.player import Player
 from game.transfers import MultiGroupTransport, PendingTransfers, TransferOrder
 from game.theater.transitnetwork import TransitNetwork
 from qt_ui.models import TransferModel
+from qt_ui.windows.PendingTransfersDialog import PendingTransfersDialog
 from qt_ui.windows.basemenu.NewUnitTransferDialog import (
     ScrollingUnitTransferGrid,
     TransferDestinationComboBox,
@@ -132,6 +135,71 @@ def test_transfer_migration_backfills_missing_owner() -> None:
     Migrator._normalize_single_transfer_player(transfer, coalition)
 
     assert transfer.player is Player.RED
+
+
+def test_transfer_migration_backfills_legacy_boolean_owner_from_each_coalition() -> (
+    None
+):
+    blue_transfer = SimpleNamespace(player=False)
+    red_transfer = SimpleNamespace(player=True)
+    blue_pending = SimpleNamespace(pending_transfers=[blue_transfer])
+    red_pending = SimpleNamespace(pending_transfers=[red_transfer])
+    blue_transfers = SimpleNamespace(
+        pending_transfers=blue_pending.pending_transfers,
+        convoys=[],
+        cargo_ships=[],
+    )
+    red_transfers = SimpleNamespace(
+        pending_transfers=red_pending.pending_transfers,
+        convoys=[],
+        cargo_ships=[],
+    )
+    migrator = Migrator.__new__(Migrator)
+    migrator.game = cast(
+        Any,
+        SimpleNamespace(
+            coalitions=[
+                SimpleNamespace(player=Player.BLUE, transfers=blue_transfers),
+                SimpleNamespace(player=Player.RED, transfers=red_transfers),
+            ]
+        ),
+    )
+
+    migrator._update_transfers()
+
+    assert blue_transfer.player is Player.BLUE
+    assert red_transfer.player is Player.RED
+
+
+def test_pending_transfers_list_context_menu_delegates_cancel_predicate(
+    app: QApplication, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    transfer = cast(
+        Any, SimpleNamespace(player=Player.BLUE, description="No transports available")
+    )
+    blue_transfers = MagicMock(pending_transfers=[transfer], pending_transfer_count=1)
+    game = SimpleNamespace(
+        settings=SimpleNamespace(enable_enemy_buy_sell=False),
+        coalition_for=lambda player: SimpleNamespace(transfers=blue_transfers),
+    )
+    game_model = cast(Any, SimpleNamespace(game=game))
+    transfer_model = TransferModel(game_model)
+    game_model.transfer_model = transfer_model
+    dialog = PendingTransfersDialog(game_model)
+    list_widget = dialog.transfer_list
+    list_widget.resize(200, 100)
+    list_widget.show()
+    app.processEvents()
+    menu_exec = MagicMock()
+    monkeypatch.setattr(QMenu, "exec_", menu_exec)
+    event = QContextMenuEvent(
+        QContextMenuEvent.Reason.Mouse,
+        list_widget.visualRect(list_widget.model().index(0, 0)).center(),
+        QPoint(10, 10),
+    )
+    list_widget.contextMenuEvent(event)
+
+    menu_exec.assert_called_once()
 
 
 def test_red_transfer_model_maps_rows_and_cancels_red_transfer() -> None:

--- a/tests/test_opfor_ground_force_management.py
+++ b/tests/test_opfor_ground_force_management.py
@@ -117,6 +117,14 @@ def test_transfer_owner_survives_origin_capture_and_split() -> None:
     assert pending.split_transfer(transfer, 1).player is Player.BLUE
 
 
+def test_transfer_rejects_collection_owner_mismatch_without_assert() -> None:
+    pending = PendingTransfers(cast(Any, SimpleNamespace()), Player.BLUE)
+    transfer = cast(Any, SimpleNamespace(player=Player.RED))
+
+    with pytest.raises(ValueError, match="ownership"):
+        pending.validate_transfer(transfer)
+
+
 def test_transfer_migration_backfills_missing_owner() -> None:
     transfer = SimpleNamespace()
     coalition = SimpleNamespace(player=Player.RED)


### PR DESCRIPTION
Part of splitting out #926. Contains only the changes related to opfor ground unit purchasing/transfers + transfer cancellation when the buy/sell cheat is enabled.