### PR TITLE
Fix motorpool rehoming

### DIFF
--- a/game/migrator.py
+++ b/game/migrator.py
@@ -14,7 +14,7 @@ from game.ato.packagewaypoints import PackageWaypoints
 from game.data.doctrine import MODERN_DOCTRINE, COLDWAR_DOCTRINE, WWII_DOCTRINE
 from game.theater import ParkingType, SeasonalConditions, Airfield
 from game.theater.player import Player
-from game.theater.theatergroundobject import ShipGroundObject
+from game.theater.theatergroundobject import ShipGroundObject, TheaterGroundObject
 
 if TYPE_CHECKING:
     from game import Game
@@ -316,16 +316,18 @@ class Migrator:
 
         # Remove stale and duplicate persisted references before ensuring every
         # current authored marker has exactly one surviving TGO.
+        seen: set[MotorpoolGroundObject] = set()
         for cp in control_points:
-            cp.connected_objectives[:] = [
-                tgo
-                for tgo in cp.connected_objectives
-                if not isinstance(tgo, MotorpoolGroundObject)
-                or existing.get(
-                    motorpool_identity(tgo.original_name, tgo.position)
-                )
-                is tgo
-            ]
+            retained: list[TheaterGroundObject] = []
+            for tgo in cp.connected_objectives:
+                if not isinstance(tgo, MotorpoolGroundObject):
+                    retained.append(tgo)
+                    continue
+                identity = motorpool_identity(tgo.original_name, tgo.position)
+                if existing.get(identity) is tgo and tgo not in seen:
+                    retained.append(tgo)
+                    seen.add(tgo)
+            cp.connected_objectives[:] = retained
 
         for cp in control_points:
             for location in getattr(cp.preset_locations, "motorpools", []):

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -54,6 +54,12 @@ class Migrator:
         # TODO: remove in due time as this is supposedly fixed
         self.game.settings.nevatim_parking_fix = False
 
+        from game.missiongenerator.motorpoolpopulator import MotorpoolPopulator
+
+        populator = MotorpoolPopulator(self.game)
+        populator._rehome_motorpools()
+        populator.populate()
+
     def _update_doctrine(self) -> None:
         doctrines = [
             MODERN_DOCTRINE,

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -306,11 +306,17 @@ class Migrator:
             for location in getattr(cp.preset_locations, "motorpools", [])
         }
         existing: dict[tuple[str, float, float, float], MotorpoolGroundObject] = {}
+        identity: tuple[str, float, float, float]
         for cp in control_points:
             for tgo in cp.ground_objects:
                 if not isinstance(tgo, MotorpoolGroundObject):
                     continue
-                identity = motorpool_identity(tgo.original_name, tgo.position)
+                identity = (
+                    tgo.original_name,
+                    tgo.position.x,
+                    tgo.position.y,
+                    tgo.heading.degrees,
+                )
                 if identity in authored:
                     existing.setdefault(identity, tgo)
 
@@ -323,7 +329,12 @@ class Migrator:
                 if not isinstance(tgo, MotorpoolGroundObject):
                     retained.append(tgo)
                     continue
-                identity = motorpool_identity(tgo.original_name, tgo.position)
+                identity = (
+                    tgo.original_name,
+                    tgo.position.x,
+                    tgo.position.y,
+                    tgo.heading.degrees,
+                )
                 if existing.get(identity) is tgo and tgo not in seen:
                     retained.append(tgo)
                     seen.add(tgo)

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -297,37 +297,41 @@ class Migrator:
 
         if not self.game.settings.motorpool_enabled:
             return
-        for cp in self.game.theater.controlpoints:
-            locations = getattr(cp.preset_locations, "motorpools", [])
-            if not locations:
-                continue
-            existing_locations = {
-                (go.original_name, go.position.x, go.position.y, go.heading.degrees)
-                for go in cp.ground_objects
-                if isinstance(go, MotorpoolGroundObject)
-            }
-            for location in locations:
-                location_identity = (
+        control_points = self.game.theater.controlpoints
+        existing: dict[tuple[str, float, float, float], MotorpoolGroundObject] = {}
+        for cp in control_points:
+            for tgo in cp.ground_objects:
+                if not isinstance(tgo, MotorpoolGroundObject):
+                    continue
+                identity = (
+                    tgo.original_name,
+                    tgo.position.x,
+                    tgo.position.y,
+                    tgo.heading.degrees,
+                )
+                existing.setdefault(identity, tgo)
+        for cp in control_points:
+            for location in getattr(cp.preset_locations, "motorpools", []):
+                identity = (
                     location.original_name,
                     location.x,
                     location.y,
                     location.heading.degrees,
                 )
-                if location_identity in existing_locations:
+                if identity in existing:
                     continue
                 name = namegen.random_objective_name()
                 warn_if_motorpool_inside_capture_zone(name, location, cp)
-                cp.connected_objectives.append(
-                    MotorpoolGroundObject(
-                        # Codename like every other TGO; the "motorpool" category
-                        # label already says what it is.
-                        name,
-                        location,
-                        cp,
-                        GroupTask.MOTORPOOL,
-                    )
+                tgo = MotorpoolGroundObject(
+                    # Codename like every other TGO; the "motorpool" category
+                    # label already says what it is.
+                    name,
+                    location,
+                    cp,
+                    GroupTask.MOTORPOOL,
                 )
-                existing_locations.add(location_identity)
+                cp.connected_objectives.append(tgo)
+                existing[identity] = tgo
 
     def _reload_terrain(self) -> None:
         t = self.game.theater.terrain

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -58,7 +58,6 @@ class Migrator:
 
         populator = MotorpoolPopulator(self.game)
         populator._rehome_motorpools()
-        populator.populate()
 
     def _update_doctrine(self) -> None:
         doctrines = [

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -301,9 +301,20 @@ class Migrator:
             locations = getattr(cp.preset_locations, "motorpools", [])
             if not locations:
                 continue
-            if any(isinstance(go, MotorpoolGroundObject) for go in cp.ground_objects):
-                continue
+            existing_locations = {
+                (go.original_name, go.position.x, go.position.y, go.heading.degrees)
+                for go in cp.ground_objects
+                if isinstance(go, MotorpoolGroundObject)
+            }
             for location in locations:
+                location_identity = (
+                    location.original_name,
+                    location.x,
+                    location.y,
+                    location.heading.degrees,
+                )
+                if location_identity in existing_locations:
+                    continue
                 name = namegen.random_objective_name()
                 warn_if_motorpool_inside_capture_zone(name, location, cp)
                 cp.connected_objectives.append(
@@ -316,6 +327,7 @@ class Migrator:
                         GroupTask.MOTORPOOL,
                     )
                 )
+                existing_locations.add(location_identity)
 
     def _reload_terrain(self) -> None:
         t = self.game.theater.terrain

--- a/game/migrator.py
+++ b/game/migrator.py
@@ -298,26 +298,38 @@ class Migrator:
         if not self.game.settings.motorpool_enabled:
             return
         control_points = self.game.theater.controlpoints
+        from game.missiongenerator.motorpoolpopulator import motorpool_identity
+
+        authored = {
+            motorpool_identity(location.original_name, location)
+            for cp in control_points
+            for location in getattr(cp.preset_locations, "motorpools", [])
+        }
         existing: dict[tuple[str, float, float, float], MotorpoolGroundObject] = {}
         for cp in control_points:
             for tgo in cp.ground_objects:
                 if not isinstance(tgo, MotorpoolGroundObject):
                     continue
-                identity = (
-                    tgo.original_name,
-                    tgo.position.x,
-                    tgo.position.y,
-                    tgo.heading.degrees,
+                identity = motorpool_identity(tgo.original_name, tgo.position)
+                if identity in authored:
+                    existing.setdefault(identity, tgo)
+
+        # Remove stale and duplicate persisted references before ensuring every
+        # current authored marker has exactly one surviving TGO.
+        for cp in control_points:
+            cp.connected_objectives[:] = [
+                tgo
+                for tgo in cp.connected_objectives
+                if not isinstance(tgo, MotorpoolGroundObject)
+                or existing.get(
+                    motorpool_identity(tgo.original_name, tgo.position)
                 )
-                existing.setdefault(identity, tgo)
+                is tgo
+            ]
+
         for cp in control_points:
             for location in getattr(cp.preset_locations, "motorpools", []):
-                identity = (
-                    location.original_name,
-                    location.x,
-                    location.y,
-                    location.heading.degrees,
-                )
+                identity = motorpool_identity(location.original_name, location)
                 if identity in existing:
                     continue
                 name = namegen.random_objective_name()

--- a/game/missiongenerator/motorpoolpopulator.py
+++ b/game/missiongenerator/motorpoolpopulator.py
@@ -87,6 +87,9 @@ class MotorpoolPopulator:
             if getattr(cp, "position", None) is None:
                 continue
             eligible.append(cp)
+        if not eligible:
+            return
+
         # Gather the complete current authored marker set first.  Persisted TGOs
         # are projections of these markers; an identity absent from the set was
         # removed from the campaign and must not survive migration.
@@ -119,9 +122,6 @@ class MotorpoolPopulator:
                 for tgo in owner.connected_objectives
                 if not isinstance(tgo, MotorpoolGroundObject)
             ]
-
-        if not eligible:
-            return
 
         for tgo in motorpools.values():
             previous_owner = tgo.control_point

--- a/game/missiongenerator/motorpoolpopulator.py
+++ b/game/missiongenerator/motorpoolpopulator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING
 
 from game.dcs.groundunittype import GroundUnitType
@@ -80,34 +79,37 @@ class MotorpoolPopulator:
             eligible.append(cp)
         if not eligible:
             return
+
+        # Gather each TGO once, even if a malformed save references it from more
+        # than one control point.  The first instance for a marker identity wins;
+        # all duplicate references/objects are discarded below.
+        motorpools: dict[tuple[str, float, float, float], MotorpoolGroundObject] = {}
         for owner in control_points:
-            objectives = getattr(owner, "connected_objectives", None)
-            if objectives is None:
-                continue
-            for tgo in list(objectives):
+            for tgo in getattr(owner, "connected_objectives", []):
                 if not isinstance(tgo, MotorpoolGroundObject):
                     continue
-                closest = min(
-                    eligible,
-                    key=lambda cp: cp.position.distance_to_point(tgo.position),
+                identity = (
+                    tgo.original_name,
+                    tgo.position.x,
+                    tgo.position.y,
+                    tgo.heading.degrees,
                 )
-                if closest is owner:
-                    continue
-                source_locations = getattr(
-                    getattr(owner, "preset_locations", None), "motorpools", []
-                )
-                for index, location in enumerate(source_locations):
-                    if (
-                        location.original_name == tgo.original_name
-                        and math.isclose(location.x, tgo.position.x)
-                        and math.isclose(location.y, tgo.position.y)
-                        and location.heading.degrees == tgo.heading.degrees
-                    ):
-                        del source_locations[index]
-                        break
-                owner.connected_objectives.remove(tgo)
-                closest.connected_objectives.append(tgo)
-                tgo.control_point = closest
+                motorpools.setdefault(identity, tgo)
+
+        for owner in control_points:
+            owner.connected_objectives[:] = [
+                tgo
+                for tgo in owner.connected_objectives
+                if not isinstance(tgo, MotorpoolGroundObject)
+            ]
+
+        for tgo in motorpools.values():
+            closest = min(
+                eligible,
+                key=lambda cp: cp.position.distance_to_point(tgo.position),
+            )
+            closest.connected_objectives.append(tgo)
+            tgo.control_point = closest
 
     def populate(self) -> None:
         cap: int = self.game.settings.motorpool_spawn_cap

--- a/game/missiongenerator/motorpoolpopulator.py
+++ b/game/missiongenerator/motorpoolpopulator.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from game.dcs.groundunittype import GroundUnitType
 from game.ground_forces.ai_ground_planner import reserve_armor_for
+from game.theater.controlpoint import ControlPoint, ControlPointType
 from game.theater.theatergroup import TheaterGroup, TheaterUnit
 from game.theater.theatergroundobject import MotorpoolGroundObject
 from game.point_with_heading import PointWithHeading
@@ -49,6 +50,51 @@ class MotorpoolPopulator:
 
     def __init__(self, game: Game) -> None:
         self.game = game
+
+    def _rehome_motorpools(self) -> None:
+        """Attach each motorpool to its nearest eligible land control point.
+
+        Motorpool ownership is persisted as which control point's
+        ``connected_objectives`` the TGO lives in, so an existing save can park a
+        motorpool under the wrong (possibly enemy) base and nothing re-decides it.
+        FARPs/FOBs are themselves land control points with their own separate
+        ground inventory, so a motorpool parked at a FARP belongs to that FARP --
+        not to a far-away base whose influence zone happens to contain the point.
+
+        This pass runs during migration before ordinary population, converting
+        existing saves on load without changing mission-generation behavior.
+        Naval and off-map control points never own motorpools.
+        """
+        control_points = self.game.theater.controlpoints
+        eligible: list[ControlPoint] = []
+        for cp in control_points:
+            if getattr(cp, "cptype", None) in (
+                ControlPointType.AIRCRAFT_CARRIER_GROUP,
+                ControlPointType.LHA_GROUP,
+                ControlPointType.OFF_MAP,
+            ):
+                continue
+            if getattr(cp, "position", None) is None:
+                continue
+            eligible.append(cp)
+        if not eligible:
+            return
+        for owner in control_points:
+            objectives = getattr(owner, "connected_objectives", None)
+            if objectives is None:
+                continue
+            for tgo in list(objectives):
+                if not isinstance(tgo, MotorpoolGroundObject):
+                    continue
+                closest = min(
+                    eligible,
+                    key=lambda cp: cp.position.distance_to_point(tgo.position),
+                )
+                if closest is owner:
+                    continue
+                owner.connected_objectives.remove(tgo)
+                closest.connected_objectives.append(tgo)
+                tgo.control_point = closest
 
     def populate(self) -> None:
         cap: int = self.game.settings.motorpool_spawn_cap

--- a/game/missiongenerator/motorpoolpopulator.py
+++ b/game/missiongenerator/motorpoolpopulator.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from game.point_with_heading import PointWithHeading
+
 from game.dcs.groundunittype import GroundUnitType
 from game.ground_forces.ai_ground_planner import reserve_armor_for
 from game.theater.controlpoint import ControlPoint, ControlPointType
 from game.theater.theatergroup import TheaterGroup, TheaterUnit
 from game.theater.theatergroundobject import MotorpoolGroundObject
-from game.point_with_heading import PointWithHeading
 
 if TYPE_CHECKING:
     from game.game import Game
@@ -19,6 +20,14 @@ _COLUMNS = 5
 # Keep the Garage_A building at the authored marker; start vehicles clear of it
 # behind the building. 150 ft is the authoring-friendly value.
 _GRID_OFFSET_M = 45.72
+
+MotorpoolIdentity = tuple[str, float, float, float]
+
+
+def motorpool_identity(
+    original_name: str, location: PointWithHeading
+) -> MotorpoolIdentity:
+    return (original_name, location.x, location.y, location.heading.degrees)
 
 
 def _select_capped(
@@ -78,13 +87,19 @@ class MotorpoolPopulator:
             if getattr(cp, "position", None) is None:
                 continue
             eligible.append(cp)
-        if not eligible:
-            return
+        # Gather the complete current authored marker set first.  Persisted TGOs
+        # are projections of these markers; an identity absent from the set was
+        # removed from the campaign and must not survive migration.
+        authored: set[MotorpoolIdentity] = {
+            motorpool_identity(location.original_name, location)
+            for owner in control_points
+            for location in getattr(owner.preset_locations, "motorpools", [])
+        }
 
-        # Gather each TGO once, even if a malformed save references it from more
-        # than one control point.  The first instance for a marker identity wins;
-        # all duplicate references/objects are discarded below.
-        motorpools: dict[tuple[str, float, float, float], MotorpoolGroundObject] = {}
+        # Gather each authored TGO once, even if a malformed save references it
+        # from more than one control point.  The first instance for a marker
+        # identity wins; all duplicate references/objects are discarded below.
+        motorpools: dict[MotorpoolIdentity, MotorpoolGroundObject] = {}
         for owner in control_points:
             for tgo in getattr(owner, "connected_objectives", []):
                 if not isinstance(tgo, MotorpoolGroundObject):
@@ -95,7 +110,8 @@ class MotorpoolPopulator:
                     tgo.position.y,
                     tgo.heading.degrees,
                 )
-                motorpools.setdefault(identity, tgo)
+                if identity in authored:
+                    motorpools.setdefault(identity, tgo)
 
         for owner in control_points:
             owner.connected_objectives[:] = [
@@ -103,6 +119,9 @@ class MotorpoolPopulator:
                 for tgo in owner.connected_objectives
                 if not isinstance(tgo, MotorpoolGroundObject)
             ]
+
+        if not eligible:
+            return
 
         for tgo in motorpools.values():
             previous_owner = tgo.control_point

--- a/game/missiongenerator/motorpoolpopulator.py
+++ b/game/missiongenerator/motorpoolpopulator.py
@@ -11,6 +11,7 @@ from game.point_with_heading import PointWithHeading
 
 if TYPE_CHECKING:
     from game.game import Game
+    from game.sim.gameupdateevents import GameUpdateEvents
 
 # Parked vehicles laid in a grid so DCS does not reject overlapping spawns.
 _SPACING_M = 12.0
@@ -51,7 +52,7 @@ class MotorpoolPopulator:
     def __init__(self, game: Game) -> None:
         self.game = game
 
-    def _rehome_motorpools(self) -> None:
+    def _rehome_motorpools(self, events: GameUpdateEvents | None = None) -> None:
         """Attach each motorpool to its nearest eligible land control point.
 
         Motorpool ownership is persisted as which control point's
@@ -104,12 +105,15 @@ class MotorpoolPopulator:
             ]
 
         for tgo in motorpools.values():
+            previous_owner = tgo.control_point
             closest = min(
                 eligible,
                 key=lambda cp: cp.position.distance_to_point(tgo.position),
             )
             closest.connected_objectives.append(tgo)
             tgo.control_point = closest
+            if events is not None and closest is not previous_owner:
+                events.update_tgo(tgo)
 
     def populate(self) -> None:
         cap: int = self.game.settings.motorpool_spawn_cap

--- a/game/missiongenerator/motorpoolpopulator.py
+++ b/game/missiongenerator/motorpoolpopulator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 from game.dcs.groundunittype import GroundUnitType
@@ -92,6 +93,18 @@ class MotorpoolPopulator:
                 )
                 if closest is owner:
                     continue
+                source_locations = getattr(
+                    getattr(owner, "preset_locations", None), "motorpools", []
+                )
+                for index, location in enumerate(source_locations):
+                    if (
+                        location.original_name == tgo.original_name
+                        and math.isclose(location.x, tgo.position.x)
+                        and math.isclose(location.y, tgo.position.y)
+                        and location.heading.degrees == tgo.heading.degrees
+                    ):
+                        del source_locations[index]
+                        break
                 owner.connected_objectives.remove(tgo)
                 closest.connected_objectives.append(tgo)
                 tgo.control_point = closest

--- a/game/missiongenerator/motorpoolpopulator.py
+++ b/game/missiongenerator/motorpoolpopulator.py
@@ -87,9 +87,6 @@ class MotorpoolPopulator:
             if getattr(cp, "position", None) is None:
                 continue
             eligible.append(cp)
-        if not eligible:
-            return
-
         # Gather the complete current authored marker set first.  Persisted TGOs
         # are projections of these markers; an identity absent from the set was
         # removed from the campaign and must not survive migration.
@@ -122,6 +119,11 @@ class MotorpoolPopulator:
                 for tgo in owner.connected_objectives
                 if not isinstance(tgo, MotorpoolGroundObject)
             ]
+
+        if not eligible:
+            for tgo in motorpools.values():
+                tgo.control_point.connected_objectives.append(tgo)
+            return
 
         for tgo in motorpools.values():
             previous_owner = tgo.control_point

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1041,7 +1041,7 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
         self._coalition = new_coalition
         from game.missiongenerator.motorpoolpopulator import MotorpoolPopulator
 
-        MotorpoolPopulator(game)._rehome_motorpools()
+        MotorpoolPopulator(game)._rehome_motorpools(events)
         self.base.set_strength_to_minimum()
         self._clear_front_lines(events)
         self._create_missing_front_lines(game.laser_code_registry, events)

--- a/game/theater/controlpoint.py
+++ b/game/theater/controlpoint.py
@@ -1039,6 +1039,9 @@ class ControlPoint(MissionTarget, SidcDescribable, ABC):
         self.release_parking_slots()
         self.depopulate_uncapturable_tgos()
         self._coalition = new_coalition
+        from game.missiongenerator.motorpoolpopulator import MotorpoolPopulator
+
+        MotorpoolPopulator(game)._rehome_motorpools()
         self.base.set_strength_to_minimum()
         self._clear_front_lines(events)
         self._create_missing_front_lines(game.laser_code_registry, events)

--- a/game/theater/theatergroundobject.py
+++ b/game/theater/theatergroundobject.py
@@ -686,6 +686,19 @@ class MotorpoolGroundObject(TheaterGroundObject):
         # never persisted meaningfully (groups are rebuilt each mission).
         self.motorpool_unit_types: dict[int, GroundUnitType] = {}
 
+    def __getstate__(self) -> dict[str, Any]:
+        state = super().__getstate__()
+        # Reserve vehicles are rendered per mission from the current base reserve;
+        # never persist their generated groups or the renderer's lookup map.
+        state["groups"] = []
+        state["motorpool_unit_types"] = {}
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        state["groups"] = []
+        state["motorpool_unit_types"] = {}
+        super().__setstate__(state)
+
     @property
     def symbol_set_and_entity(self) -> tuple[SymbolSet, Entity]:
         # Maintenance-facility installation symbol: visually distinct from the

--- a/tests/missiongenerator/test_motorpool_rehome.py
+++ b/tests/missiongenerator/test_motorpool_rehome.py
@@ -91,6 +91,18 @@ def test_rehome_excludes_naval_control_points() -> None:
     assert tgo.control_point is base
 
 
+def test_rehome_preserves_motorpool_when_no_eligible_control_point_exists() -> None:
+    carrier = _land_cp("CVN", 0.0, 0.0, ControlPointType.AIRCRAFT_CARRIER_GROUP)
+    off_map = _land_cp("Off-map", 5000.0, 0.0, ControlPointType.OFF_MAP)
+    tgo = _motorpool_owned_by(carrier, 0.0, 0.0)
+
+    _rehome([carrier, off_map])
+
+    assert carrier.connected_objectives == [tgo]
+    assert off_map.connected_objectives == []
+    assert tgo.control_point is carrier
+
+
 def test_populate_does_not_rehome_existing_motorpools() -> None:
     owner = _land_cp("Owner", 5000.0, 0.0, ControlPointType.AIRBASE)
     nearest = _land_cp("Nearest", 0.0, 0.0, ControlPointType.FARP)
@@ -110,7 +122,9 @@ def test_rehome_discards_persisted_motorpool_without_current_marker() -> None:
     loc = PresetLocation(
         "Removed", Point(0.0, 0.0, Caucasus()), Heading.from_degrees(0.0)
     )
-    tgo = MotorpoolGroundObject("Persisted depot", loc, stale, GroupTask.MOTORPOOL)
+    tgo = MotorpoolGroundObject(
+        "Persisted depot", loc, cast(Any, stale), GroupTask.MOTORPOOL
+    )
     stale.connected_objectives.append(tgo)
 
     _rehome([owner, stale])
@@ -126,8 +140,12 @@ def test_rehome_deduplicates_current_marker_and_preserves_metadata_and_event() -
         "Authored", Point(0.0, 0.0, Caucasus()), Heading.from_degrees(0.0)
     )
     owner.preset_locations.motorpools = [loc]
-    first = MotorpoolGroundObject("First codename", loc, owner, GroupTask.MOTORPOOL)
-    duplicate = MotorpoolGroundObject("Duplicate codename", loc, owner, GroupTask.MOTORPOOL)
+    first = MotorpoolGroundObject(
+        "First codename", loc, cast(Any, owner), GroupTask.MOTORPOOL
+    )
+    duplicate = MotorpoolGroundObject(
+        "Duplicate codename", loc, cast(Any, owner), GroupTask.MOTORPOOL
+    )
     owner.connected_objectives = [first, duplicate]
     events = GameUpdateEvents()
 

--- a/tests/missiongenerator/test_motorpool_rehome.py
+++ b/tests/missiongenerator/test_motorpool_rehome.py
@@ -6,6 +6,7 @@ from dcs.terrain import Caucasus
 
 from game.data.groups import GroupTask
 from game.missiongenerator.motorpoolpopulator import MotorpoolPopulator
+from game.sim.gameupdateevents import GameUpdateEvents
 from game.theater.controlpoint import ControlPointType
 from game.theater.presetlocation import PresetLocation
 from game.theater.theatergroundobject import MotorpoolGroundObject
@@ -21,6 +22,7 @@ def _land_cp(
         position=Point(x, y, Caucasus()),
         connected_objectives=[],
         ground_objects=[],
+        preset_locations=SimpleNamespace(motorpools=[]),
     )
 
 
@@ -33,6 +35,7 @@ def _game(cps: list[Any]) -> Any:
 
 def _motorpool_owned_by(owner: Any, x: float, y: float) -> MotorpoolGroundObject:
     loc = PresetLocation("G", Point(x, y, Caucasus()), Heading.from_degrees(0.0))
+    owner.preset_locations.motorpools.append(loc)
     tgo = MotorpoolGroundObject("Motorpool 0", loc, owner, GroupTask.MOTORPOOL)
     owner.connected_objectives.append(tgo)
     return tgo
@@ -99,3 +102,40 @@ def test_populate_does_not_rehome_existing_motorpools() -> None:
     assert tgo.control_point is owner
     assert owner.connected_objectives == [tgo]
     assert nearest.connected_objectives == []
+
+
+def test_rehome_discards_persisted_motorpool_without_current_marker() -> None:
+    owner = _land_cp("Owner", 0.0, 0.0, ControlPointType.AIRBASE)
+    stale = _land_cp("Stale", 5000.0, 0.0, ControlPointType.AIRBASE)
+    loc = PresetLocation(
+        "Removed", Point(0.0, 0.0, Caucasus()), Heading.from_degrees(0.0)
+    )
+    tgo = MotorpoolGroundObject("Persisted depot", loc, stale, GroupTask.MOTORPOOL)
+    stale.connected_objectives.append(tgo)
+
+    _rehome([owner, stale])
+
+    assert owner.connected_objectives == []
+    assert stale.connected_objectives == []
+
+
+def test_rehome_deduplicates_current_marker_and_preserves_metadata_and_event() -> None:
+    owner = _land_cp("Owner", 5000.0, 0.0, ControlPointType.AIRBASE)
+    nearest = _land_cp("Nearest", 0.0, 0.0, ControlPointType.FARP)
+    loc = PresetLocation(
+        "Authored", Point(0.0, 0.0, Caucasus()), Heading.from_degrees(0.0)
+    )
+    owner.preset_locations.motorpools = [loc]
+    first = MotorpoolGroundObject("First codename", loc, owner, GroupTask.MOTORPOOL)
+    duplicate = MotorpoolGroundObject("Duplicate codename", loc, owner, GroupTask.MOTORPOOL)
+    owner.connected_objectives = [first, duplicate]
+    events = GameUpdateEvents()
+
+    MotorpoolPopulator(cast(Any, _game([owner, nearest])))._rehome_motorpools(events)
+
+    assert owner.connected_objectives == []
+    assert nearest.connected_objectives == [first]
+    assert first.control_point is nearest
+    assert first.name == "First codename"
+    assert duplicate not in nearest.connected_objectives
+    assert events.updated_tgos == {first}

--- a/tests/missiongenerator/test_motorpool_rehome.py
+++ b/tests/missiongenerator/test_motorpool_rehome.py
@@ -103,6 +103,26 @@ def test_rehome_preserves_motorpool_when_no_eligible_control_point_exists() -> N
     assert tgo.control_point is carrier
 
 
+def test_rehome_without_destination_removes_stale_and_duplicate_references() -> None:
+    carrier = _land_cp("CVN", 0.0, 0.0, ControlPointType.AIRCRAFT_CARRIER_GROUP)
+    off_map = _land_cp("Off-map", 5000.0, 0.0, ControlPointType.OFF_MAP)
+    valid = _motorpool_owned_by(carrier, 0.0, 0.0)
+    carrier.connected_objectives.append(valid)
+    stale_location = PresetLocation(
+        "Removed", Point(1000.0, 0.0, Caucasus()), Heading.from_degrees(0.0)
+    )
+    stale = MotorpoolGroundObject(
+        "Stale depot", stale_location, cast(Any, off_map), GroupTask.MOTORPOOL
+    )
+    off_map.connected_objectives.append(stale)
+
+    _rehome([carrier, off_map])
+
+    assert carrier.connected_objectives == [valid]
+    assert off_map.connected_objectives == []
+    assert valid.control_point is carrier
+
+
 def test_populate_does_not_rehome_existing_motorpools() -> None:
     owner = _land_cp("Owner", 5000.0, 0.0, ControlPointType.AIRBASE)
     nearest = _land_cp("Nearest", 0.0, 0.0, ControlPointType.FARP)

--- a/tests/missiongenerator/test_motorpool_rehome.py
+++ b/tests/missiongenerator/test_motorpool_rehome.py
@@ -1,0 +1,101 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+from dcs.mapping import Point
+from dcs.terrain import Caucasus
+
+from game.data.groups import GroupTask
+from game.missiongenerator.motorpoolpopulator import MotorpoolPopulator
+from game.theater.controlpoint import ControlPointType
+from game.theater.presetlocation import PresetLocation
+from game.theater.theatergroundobject import MotorpoolGroundObject
+from game.utils import Heading
+
+
+def _land_cp(
+    name: str, x: float, y: float, cptype: ControlPointType
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        cptype=cptype,
+        position=Point(x, y, Caucasus()),
+        connected_objectives=[],
+        ground_objects=[],
+    )
+
+
+def _game(cps: list[Any]) -> Any:
+    return SimpleNamespace(
+        theater=SimpleNamespace(controlpoints=cps),
+        settings=SimpleNamespace(motorpool_enabled=False, motorpool_spawn_cap=0),
+    )
+
+
+def _motorpool_owned_by(owner: Any, x: float, y: float) -> MotorpoolGroundObject:
+    loc = PresetLocation("G", Point(x, y, Caucasus()), Heading.from_degrees(0.0))
+    tgo = MotorpoolGroundObject("Motorpool 0", loc, owner, GroupTask.MOTORPOOL)
+    owner.connected_objectives.append(tgo)
+    return tgo
+
+
+def _rehome(cps: list[Any]) -> None:
+    MotorpoolPopulator(cast(Any, _game(cps)))._rehome_motorpools()
+
+
+def test_rehome_moves_motorpool_to_nearest_farp() -> None:
+    base = _land_cp("Countryside AB", 5000.0, 0.0, ControlPointType.AIRBASE)
+    farp = _land_cp("Frontline FARP", 0.0, 0.0, ControlPointType.FARP)
+    tgo = _motorpool_owned_by(base, 0.0, 0.0)
+
+    _rehome([base, farp])
+
+    assert tgo.control_point is farp
+    assert base.connected_objectives == []
+    assert farp.connected_objectives == [tgo]
+
+
+def test_rehome_leaves_motorpool_on_nearest_base() -> None:
+    base = _land_cp("Base", 0.0, 0.0, ControlPointType.AIRBASE)
+    farp = _land_cp("Far FARP", 5000.0, 0.0, ControlPointType.FARP)
+    tgo = _motorpool_owned_by(base, 0.0, 0.0)
+
+    _rehome([base, farp])
+
+    assert tgo.control_point is base
+    assert base.connected_objectives == [tgo]
+    assert farp.connected_objectives == []
+
+
+def test_rehome_neutral_fob_claims_adjacent_motorpool() -> None:
+    base = _land_cp("Enemy AB", -300000.0, 0.0, ControlPointType.AIRBASE)
+    neutral_farp = _land_cp("Neutral FARP", 0.0, 0.0, ControlPointType.FARP)
+    tgo = _motorpool_owned_by(base, 0.0, 0.0)
+
+    _rehome([base, neutral_farp])
+
+    # The neutral FOB wins; the motorpool follows its capture state (neutral).
+    assert tgo.control_point is neutral_farp
+
+
+def test_rehome_excludes_naval_control_points() -> None:
+    base = _land_cp("AB", 5000.0, 0.0, ControlPointType.AIRBASE)
+    carrier = _land_cp("CVN", 0.0, 0.0, ControlPointType.AIRCRAFT_CARRIER_GROUP)
+    tgo = _motorpool_owned_by(base, 0.0, 0.0)
+
+    _rehome([base, carrier])
+
+    # Carrier is excluded, so the motorpool stays with the airbase.
+    assert tgo.control_point is base
+
+
+def test_populate_does_not_rehome_existing_motorpools() -> None:
+    owner = _land_cp("Owner", 5000.0, 0.0, ControlPointType.AIRBASE)
+    nearest = _land_cp("Nearest", 0.0, 0.0, ControlPointType.FARP)
+    tgo = _motorpool_owned_by(owner, 0.0, 0.0)
+
+    populator = MotorpoolPopulator(cast(Any, _game([owner, nearest])))
+    populator.populate()
+
+    assert tgo.control_point is owner
+    assert owner.connected_objectives == [tgo]
+    assert nearest.connected_objectives == []

--- a/tests/test_motorpool_migration.py
+++ b/tests/test_motorpool_migration.py
@@ -103,7 +103,7 @@ def test_duplicate_reference_to_same_tgo_is_canonicalized_globally() -> None:
     cp.connected_objectives = [existing]
     other_cp.connected_objectives = [existing]
     migrator = _migrator_with(cp)
-    migrator.game.theater.controlpoints.append(other_cp)
+    migrator.game.theater.controlpoints.append(cast(Any, other_cp))
 
     migrator._ensure_motorpool_tgos()
 

--- a/tests/test_motorpool_migration.py
+++ b/tests/test_motorpool_migration.py
@@ -1,15 +1,47 @@
 from __future__ import annotations
 
+import pickle
+from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from dcs.mapping import Point
-from dcs.terrain import Terrain
+from dcs.terrain import Caucasus, Terrain
+from dcs.vehicles import Armor
 
+from game import persistency
+from game.dcs.groundunittype import GroundUnitType
 from game.migrator import Migrator
+from game.theater.controlpoint import ControlPointType
 from game.theater.presetlocation import PresetLocation
 from game.theater.theatergroundobject import MotorpoolGroundObject
 from game.utils import Heading
+
+
+class _IdAllocator:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> int:
+        self.calls += 1
+        return self.calls
+
+
+class _MigrationControlPoint:
+    def __init__(self, name: str, position: Point, armor: dict[object, int]) -> None:
+        self.name = name
+        self.cptype = ControlPointType.AIRBASE
+        self.position = position
+        self.connected_objectives: list[object] = []
+        self.preset_locations = SimpleNamespace(motorpools=[])
+        self.captured = object()
+        self.connected_points: list[object] = []
+        self.base = SimpleNamespace(armor=armor, total_armor=sum(armor.values()))
+
+    @property
+    def ground_objects(self) -> list[object]:
+        return list(self.connected_objectives)
 
 
 def _loc() -> PresetLocation:
@@ -97,12 +129,86 @@ def test_migrate_game_rehomes_motorpools_after_all_migrations() -> None:
         populator.return_value._rehome_motorpools.side_effect = lambda: events.append(
             "rehome"
         )
-        populator.return_value.populate.side_effect = lambda: events.append("populate")
         migrator._migrate_game()
 
     populator.assert_called_once_with(game)
     populator.return_value._rehome_motorpools.assert_called_once_with()
-    populator.return_value.populate.assert_called_once_with()
-    assert events[-2:] == ["rehome", "populate"]
+    populator.return_value.populate.assert_not_called()
+    assert events[-1] == "rehome"
     assert events.index("rehome") > events.index("_ensure_motorpool_tgos")
     assert events.index("rehome") > events.index("_update_theater")
+
+
+def test_loaded_migration_rehomes_without_persisting_ephemeral_groups(
+    tmp_path: Path,
+) -> None:
+    unit_type = next(GroundUnitType.for_dcs_type(Armor.M_1_Abrams))
+    owner = _MigrationControlPoint(
+        "Rear Base", Point(5000.0, 0.0, Caucasus()), {unit_type: 3}
+    )
+    farp = _MigrationControlPoint(
+        "Frontline FARP", Point(0.0, 0.0, Caucasus()), {unit_type: 3}
+    )
+    farp.cptype = ControlPointType.FARP
+    tgo = MotorpoolGroundObject(
+        "Motorpool", _loc(), cast("Any", owner), None
+    )
+    tgo.position = Point(0.0, 0.0, Caucasus())
+    owner.connected_objectives.append(tgo)
+    next_group_id = _IdAllocator()
+    next_unit_id = _IdAllocator()
+    game = SimpleNamespace(
+        theater=SimpleNamespace(controlpoints=[owner, farp]),
+        settings=SimpleNamespace(motorpool_enabled=True, motorpool_spawn_cap=10),
+        current_group_id=20,
+        current_unit_id=10,
+        next_group_id=next_group_id,
+        next_unit_id=next_unit_id,
+    )
+    save_path = tmp_path / "campaign.retribution"
+    with save_path.open("wb") as save_file:
+        pickle.dump(game, save_file)
+
+    persistency.setup(str(tmp_path), False, 0)
+    loaded = persistency.load_game(str(save_path))
+    assert loaded is not None
+
+    migrator = Migrator.__new__(Migrator)
+    migrator.game = loaded  # type: ignore[assignment]
+    for method_name in (
+        "_update_doctrine",
+        "_update_control_points",
+        "_update_packagewaypoints",
+        "_update_package_attributes",
+        "_update_factions",
+        "_update_flights",
+        "_update_squadrons",
+        "_update_transfers",
+        "_release_untasked_flights",
+        "_update_weather",
+        "_update_tgos",
+        "_reload_terrain",
+        "_update_theater",
+        "_update_campaign_name",
+    ):
+        setattr(migrator, method_name, MagicMock())
+    migrator._migrate_game()
+
+    loaded_tgo = loaded.theater.controlpoints[1].connected_objectives[0]
+    assert isinstance(loaded_tgo, MotorpoolGroundObject)
+    assert loaded_tgo.control_point is loaded.theater.controlpoints[1]
+    assert loaded.theater.controlpoints[0].connected_objectives == []
+    assert loaded_tgo.groups == []
+    assert loaded.current_group_id == 20
+    assert loaded.current_unit_id == 10
+    loaded_next_group_id = loaded.next_group_id
+    loaded_next_unit_id = loaded.next_unit_id
+    assert loaded_next_group_id.calls == 0
+    assert loaded_next_unit_id.calls == 0
+
+    migrated_save = tmp_path / "migrated.retribution"
+    with migrated_save.open("wb") as save_file:
+        pickle.dump(loaded, save_file)
+    reloaded = persistency.load_game(str(migrated_save))
+    assert reloaded is not None
+    assert reloaded.theater.controlpoints[1].connected_objectives[0].groups == []

--- a/tests/test_motorpool_migration.py
+++ b/tests/test_motorpool_migration.py
@@ -94,6 +94,39 @@ def test_no_double_injection_when_tgo_exists() -> None:
     assert len(pools) == 1
 
 
+def test_removed_authored_marker_discards_persisted_tgo() -> None:
+    cp = _MigrationControlPoint("CP", Point(0.0, 0.0, Caucasus()), {})
+    stale = MotorpoolGroundObject("Persisted depot", _loc(), cast(Any, cp), None)
+    cp.connected_objectives = [stale]
+
+    _migrator_with(cp)._ensure_motorpool_tgos()
+
+    assert cp.connected_objectives == []
+
+
+def test_moved_authored_marker_replaces_persisted_identity() -> None:
+    cp = _MigrationControlPoint("CP", Point(0.0, 0.0, Caucasus()), {})
+    current = PresetLocation(
+        "Garage A", Point(1000.0, 0.0, Caucasus()), Heading.from_degrees(90)
+    )
+    cp.preset_locations.motorpools = [current]
+    old = PresetLocation(
+        "Garage A", Point(0.0, 0.0, Caucasus()), Heading.from_degrees(0)
+    )
+    stale = MotorpoolGroundObject("Old codename", old, cast(Any, cp), None)
+    cp.connected_objectives = [stale]
+
+    _migrator_with(cp)._ensure_motorpool_tgos()
+
+    pools = [o for o in cp.connected_objectives if isinstance(o, MotorpoolGroundObject)]
+    assert len(pools) == 1
+    assert pools[0] is not stale
+    assert pools[0].original_name == "Garage A"
+    assert pools[0].position.x == 1000.0
+    assert pools[0].position.y == 0.0
+    assert pools[0].heading.degrees == 90
+
+
 def test_global_marker_reconciliation_finds_tgo_under_another_cp() -> None:
     marker_cp = _MigrationControlPoint("Marker", Point(0.0, 0.0, Caucasus()), {})
     stale_cp = _MigrationControlPoint("Stale", Point(10000.0, 0.0, Caucasus()), {})

--- a/tests/test_motorpool_migration.py
+++ b/tests/test_motorpool_migration.py
@@ -94,6 +94,23 @@ def test_no_double_injection_when_tgo_exists() -> None:
     assert len(pools) == 1
 
 
+def test_duplicate_reference_to_same_tgo_is_canonicalized_globally() -> None:
+    cp = _MigrationControlPoint("CP", Point(0.0, 0.0, Caucasus()), {})
+    other_cp = _MigrationControlPoint("Other", Point(1000.0, 0.0, Caucasus()), {})
+    location = _loc()
+    cp.preset_locations.motorpools = [location]
+    existing = MotorpoolGroundObject("Persisted depot", location, cast(Any, cp), None)
+    cp.connected_objectives = [existing]
+    other_cp.connected_objectives = [existing]
+    migrator = _migrator_with(cp)
+    migrator.game.theater.controlpoints.append(other_cp)
+
+    migrator._ensure_motorpool_tgos()
+
+    assert cp.connected_objectives == [existing]
+    assert other_cp.connected_objectives == []
+
+
 def test_removed_authored_marker_discards_persisted_tgo() -> None:
     cp = _MigrationControlPoint("CP", Point(0.0, 0.0, Caucasus()), {})
     stale = MotorpoolGroundObject("Persisted depot", _loc(), cast(Any, cp), None)

--- a/tests/test_motorpool_migration.py
+++ b/tests/test_motorpool_migration.py
@@ -94,6 +94,34 @@ def test_no_double_injection_when_tgo_exists() -> None:
     assert len(pools) == 1
 
 
+def test_global_marker_reconciliation_finds_tgo_under_another_cp() -> None:
+    marker_cp = _MigrationControlPoint("Marker", Point(0.0, 0.0, Caucasus()), {})
+    stale_cp = _MigrationControlPoint("Stale", Point(10000.0, 0.0, Caucasus()), {})
+    marker = PresetLocation(
+        "Garage A", Point(0.0, 0.0, Caucasus()), Heading.from_degrees(0)
+    )
+    marker_cp.preset_locations.motorpools = [marker]
+    stale_tgo = MotorpoolGroundObject("JAGUAR", marker, cast(Any, stale_cp), None)
+    stale_cp.connected_objectives.append(cast(Any, stale_tgo))
+    migrator = _migrator_with(marker_cp)
+    migrator.game.theater.controlpoints.append(cast(Any, stale_cp))
+
+    migrator._ensure_motorpool_tgos()
+    from game.missiongenerator.motorpoolpopulator import MotorpoolPopulator
+
+    MotorpoolPopulator(migrator.game)._rehome_motorpools()
+
+    motorpools = [
+        tgo
+        for cp in (marker_cp, stale_cp)
+        for tgo in cp.connected_objectives
+        if isinstance(tgo, MotorpoolGroundObject)
+    ]
+    assert motorpools == [stale_tgo]
+    assert stale_tgo.control_point is marker_cp
+    assert marker_cp.preset_locations.motorpools == [marker]
+
+
 def test_migrate_game_rehomes_motorpools_after_all_migrations() -> None:
     events: list[str] = []
     game = SimpleNamespace(settings=SimpleNamespace())
@@ -162,6 +190,8 @@ def test_loaded_migration_rehomes_without_persisting_ephemeral_groups(
         "Motorpool A", owner.preset_locations.motorpools[0], cast("Any", owner), None
     )
     owner.connected_objectives.append(tgo)
+    tgo.groups = [cast(Any, object())]
+    tgo.motorpool_unit_types = {1: unit_type}
     next_group_id = _IdAllocator()
     next_unit_id = _IdAllocator()
     game = SimpleNamespace(
@@ -214,8 +244,16 @@ def test_loaded_migration_rehomes_without_persisting_ephemeral_groups(
         for tgo in loaded_motorpools
     )
     assert loaded.theater.controlpoints[0].connected_objectives == []
-    assert loaded.theater.controlpoints[0].preset_locations.motorpools == []
+    assert loaded.theater.controlpoints[0].preset_locations.motorpools == [
+        PresetLocation(
+            "Garage A", Point(0.0, 0.0, Caucasus()), Heading.from_degrees(0)
+        ),
+        PresetLocation(
+            "Garage B", Point(1000.0, 0.0, Caucasus()), Heading.from_degrees(0)
+        ),
+    ]
     assert all(tgo.groups == [] for tgo in loaded_motorpools)
+    assert all(tgo.motorpool_unit_types == {} for tgo in loaded_motorpools)
     assert loaded.current_group_id == 20
     assert loaded.current_unit_id == 10
     loaded_next_group_id = cast(_IdAllocator, loaded.next_group_id)

--- a/tests/test_motorpool_migration.py
+++ b/tests/test_motorpool_migration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from dcs.mapping import Point
 from dcs.terrain import Terrain
@@ -60,3 +60,49 @@ def test_no_double_injection_when_tgo_exists() -> None:
     m._ensure_motorpool_tgos()
     pools = [o for o in cp.connected_objectives if isinstance(o, MotorpoolGroundObject)]
     assert len(pools) == 1
+
+
+def test_migrate_game_rehomes_motorpools_after_all_migrations() -> None:
+    events: list[str] = []
+    game = SimpleNamespace(settings=SimpleNamespace())
+    migrator = Migrator.__new__(Migrator)
+    migrator.game = game  # type: ignore[assignment]
+    method_names = [
+        "_update_doctrine",
+        "_update_control_points",
+        "_update_packagewaypoints",
+        "_update_package_attributes",
+        "_update_factions",
+        "_update_flights",
+        "_update_squadrons",
+        "_update_transfers",
+        "_release_untasked_flights",
+        "_update_weather",
+        "_update_tgos",
+        "_ensure_motorpool_tgos",
+        "_reload_terrain",
+        "_update_theater",
+        "_update_campaign_name",
+    ]
+    for method_name in method_names:
+        setattr(
+            migrator,
+            method_name,
+            MagicMock(side_effect=lambda n=method_name: events.append(n)),
+        )
+
+    with patch(
+        "game.missiongenerator.motorpoolpopulator.MotorpoolPopulator"
+    ) as populator:
+        populator.return_value._rehome_motorpools.side_effect = lambda: events.append(
+            "rehome"
+        )
+        populator.return_value.populate.side_effect = lambda: events.append("populate")
+        migrator._migrate_game()
+
+    populator.assert_called_once_with(game)
+    populator.return_value._rehome_motorpools.assert_called_once_with()
+    populator.return_value.populate.assert_called_once_with()
+    assert events[-2:] == ["rehome", "populate"]
+    assert events.index("rehome") > events.index("_ensure_motorpool_tgos")
+    assert events.index("rehome") > events.index("_update_theater")

--- a/tests/test_motorpool_migration.py
+++ b/tests/test_motorpool_migration.py
@@ -151,10 +151,16 @@ def test_loaded_migration_rehomes_without_persisting_ephemeral_groups(
     )
     farp.cptype = ControlPointType.FARP
     owner.preset_locations.motorpools = [
-        PresetLocation("G", Point(0.0, 0.0, Caucasus()), Heading.from_degrees(0))
+        PresetLocation(
+            "Garage A", Point(0.0, 0.0, Caucasus()), Heading.from_degrees(0)
+        ),
+        PresetLocation(
+            "Garage B", Point(1000.0, 0.0, Caucasus()), Heading.from_degrees(0)
+        ),
     ]
-    tgo = MotorpoolGroundObject("Motorpool", _loc(), cast("Any", owner), None)
-    tgo.position = Point(0.0, 0.0, Caucasus())
+    tgo = MotorpoolGroundObject(
+        "Motorpool A", owner.preset_locations.motorpools[0], cast("Any", owner), None
+    )
     owner.connected_objectives.append(tgo)
     next_group_id = _IdAllocator()
     next_unit_id = _IdAllocator()
@@ -195,12 +201,21 @@ def test_loaded_migration_rehomes_without_persisting_ephemeral_groups(
         setattr(migrator, method_name, MagicMock())
     migrator._migrate_game()
 
-    loaded_tgo = loaded.theater.controlpoints[1].connected_objectives[0]
-    assert isinstance(loaded_tgo, MotorpoolGroundObject)
-    assert loaded_tgo.control_point is loaded.theater.controlpoints[1]
+    loaded_motorpools = [
+        tgo
+        for control_point in loaded.theater.controlpoints
+        for tgo in control_point.connected_objectives
+        if isinstance(tgo, MotorpoolGroundObject)
+    ]
+    assert len(loaded_motorpools) == 2
+    assert {tgo.original_name for tgo in loaded_motorpools} == {"Garage A", "Garage B"}
+    assert all(
+        tgo.control_point is loaded.theater.controlpoints[1]
+        for tgo in loaded_motorpools
+    )
     assert loaded.theater.controlpoints[0].connected_objectives == []
     assert loaded.theater.controlpoints[0].preset_locations.motorpools == []
-    assert loaded_tgo.groups == []
+    assert all(tgo.groups == [] for tgo in loaded_motorpools)
     assert loaded.current_group_id == 20
     assert loaded.current_unit_id == 10
     loaded_next_group_id = cast(_IdAllocator, loaded.next_group_id)
@@ -216,8 +231,12 @@ def test_loaded_migration_rehomes_without_persisting_ephemeral_groups(
         for tgo in control_point.connected_objectives
         if isinstance(tgo, MotorpoolGroundObject)
     ]
-    assert len(loaded_motorpools) == 1
-    assert loaded_motorpools[0].control_point is loaded.theater.controlpoints[1]
+    assert len(loaded_motorpools) == 2
+    assert {tgo.original_name for tgo in loaded_motorpools} == {"Garage A", "Garage B"}
+    assert all(
+        tgo.control_point is loaded.theater.controlpoints[1]
+        for tgo in loaded_motorpools
+    )
     assert loaded.theater.controlpoints[0].connected_objectives == []
 
     migrated_save = tmp_path / "migrated.retribution"
@@ -225,4 +244,10 @@ def test_loaded_migration_rehomes_without_persisting_ephemeral_groups(
         pickle.dump(loaded, save_file)
     reloaded = persistency.load_game(str(migrated_save))
     assert reloaded is not None
-    assert reloaded.theater.controlpoints[1].connected_objectives[0].groups == []
+    reloaded_motorpools = [
+        tgo
+        for tgo in reloaded.theater.controlpoints[1].connected_objectives
+        if isinstance(tgo, MotorpoolGroundObject)
+    ]
+    assert len(reloaded_motorpools) == 2
+    assert all(tgo.groups == [] for tgo in reloaded_motorpools)

--- a/tests/test_motorpool_migration.py
+++ b/tests/test_motorpool_migration.py
@@ -150,9 +150,10 @@ def test_loaded_migration_rehomes_without_persisting_ephemeral_groups(
         "Frontline FARP", Point(0.0, 0.0, Caucasus()), {unit_type: 3}
     )
     farp.cptype = ControlPointType.FARP
-    tgo = MotorpoolGroundObject(
-        "Motorpool", _loc(), cast("Any", owner), None
-    )
+    owner.preset_locations.motorpools = [
+        PresetLocation("G", Point(0.0, 0.0, Caucasus()), Heading.from_degrees(0))
+    ]
+    tgo = MotorpoolGroundObject("Motorpool", _loc(), cast("Any", owner), None)
     tgo.position = Point(0.0, 0.0, Caucasus())
     owner.connected_objectives.append(tgo)
     next_group_id = _IdAllocator()
@@ -174,7 +175,7 @@ def test_loaded_migration_rehomes_without_persisting_ephemeral_groups(
     assert loaded is not None
 
     migrator = Migrator.__new__(Migrator)
-    migrator.game = loaded  # type: ignore[assignment]
+    migrator.game = loaded
     for method_name in (
         "_update_doctrine",
         "_update_control_points",
@@ -198,13 +199,26 @@ def test_loaded_migration_rehomes_without_persisting_ephemeral_groups(
     assert isinstance(loaded_tgo, MotorpoolGroundObject)
     assert loaded_tgo.control_point is loaded.theater.controlpoints[1]
     assert loaded.theater.controlpoints[0].connected_objectives == []
+    assert loaded.theater.controlpoints[0].preset_locations.motorpools == []
     assert loaded_tgo.groups == []
     assert loaded.current_group_id == 20
     assert loaded.current_unit_id == 10
-    loaded_next_group_id = loaded.next_group_id
-    loaded_next_unit_id = loaded.next_unit_id
+    loaded_next_group_id = cast(_IdAllocator, loaded.next_group_id)
+    loaded_next_unit_id = cast(_IdAllocator, loaded.next_unit_id)
     assert loaded_next_group_id.calls == 0
     assert loaded_next_unit_id.calls == 0
+
+    migrator._migrate_game()
+
+    loaded_motorpools = [
+        tgo
+        for control_point in loaded.theater.controlpoints
+        for tgo in control_point.connected_objectives
+        if isinstance(tgo, MotorpoolGroundObject)
+    ]
+    assert len(loaded_motorpools) == 1
+    assert loaded_motorpools[0].control_point is loaded.theater.controlpoints[1]
+    assert loaded.theater.controlpoints[0].connected_objectives == []
 
     migrated_save = tmp_path / "migrated.retribution"
     with migrated_save.open("wb") as save_file:

--- a/tests/theater/test_controlpoint.py
+++ b/tests/theater/test_controlpoint.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 from typing import Any, cast
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from dcs import Point
@@ -15,10 +16,12 @@ from game.data.groups import GroupTask
 from game.point_with_heading import PointWithHeading
 from game.squadrons import Squadron
 from game.squadrons.operatingbases import OperatingBases
+from game.sim.gameupdateevents import GameUpdateEvents
 from game.theater.controlpoint import (
     Airfield,
     Carrier,
     ControlPoint,
+    ControlPointType,
     Lha,
     OffMapSpawn,
     Fob,
@@ -322,7 +325,47 @@ def test_capture_rehomes_motorpools_immediately() -> None:
         cp.capture(game, events, Player.BLUE)
 
     assert cp._coalition is new_coalition
-    rehome.assert_called_once_with()
+    rehome.assert_called_once_with(events)
+
+
+def test_capture_publishes_rehomed_motorpool_tgo_update() -> None:
+    terrain = MagicMock(spec=Terrain)
+    captured_cp = cast(Any, ControlPoint.__new__(Airfield))
+    captured_cp._coalition = MagicMock()
+    captured_cp.connected_objectives = []
+    captured_cp.front_lines = {}
+    captured_cp.ground_unit_orders = MagicMock()
+    captured_cp.base = MagicMock()
+    captured_cp.retreat_ground_units = MagicMock()
+    captured_cp.retreat_air_units = MagicMock()
+    captured_cp.release_parking_slots = MagicMock()
+    captured_cp.depopulate_uncapturable_tgos = MagicMock()
+    captured_cp._clear_front_lines = MagicMock()
+    captured_cp._create_missing_front_lines = MagicMock()
+    captured_cp.cptype = ControlPointType.AIRBASE
+    captured_cp.position = Point(5000.0, 0.0, terrain)
+
+    destination_cp = SimpleNamespace(
+        cptype=ControlPointType.FARP,
+        position=Point(0.0, 0.0, terrain),
+        connected_objectives=[],
+    )
+    tgo = MotorpoolGroundObject(
+        "JAGUAR",
+        _preset("Garage A", Point(0.0, 0.0, terrain)),
+        captured_cp,
+        GroupTask.MOTORPOOL,
+    )
+    captured_cp.connected_objectives.append(tgo)
+    game = MagicMock()
+    game.coalition_for.return_value = MagicMock()
+    game.theater.controlpoints = [captured_cp, destination_cp]
+    events = GameUpdateEvents()
+
+    captured_cp.capture(game, events, Player.BLUE)
+
+    assert tgo.control_point is destination_cp
+    assert events.updated_tgos == {tgo}
 
 
 def test_motorpools_inside_capture_zone_reports_only_inside() -> None:

--- a/tests/theater/test_controlpoint.py
+++ b/tests/theater/test_controlpoint.py
@@ -344,15 +344,18 @@ def test_capture_publishes_rehomed_motorpool_tgo_update() -> None:
     captured_cp._create_missing_front_lines = MagicMock()
     captured_cp.cptype = ControlPointType.AIRBASE
     captured_cp.position = Point(5000.0, 0.0, terrain)
+    motorpool_location = _preset("Garage A", Point(0.0, 0.0, terrain))
+    captured_cp.preset_locations = SimpleNamespace(motorpools=[motorpool_location])
 
     destination_cp = SimpleNamespace(
         cptype=ControlPointType.FARP,
         position=Point(0.0, 0.0, terrain),
         connected_objectives=[],
+        preset_locations=SimpleNamespace(motorpools=[]),
     )
     tgo = MotorpoolGroundObject(
         "JAGUAR",
-        _preset("Garage A", Point(0.0, 0.0, terrain)),
+        motorpool_location,
         captured_cp,
         GroupTask.MOTORPOOL,
     )

--- a/tests/theater/test_controlpoint.py
+++ b/tests/theater/test_controlpoint.py
@@ -1,8 +1,8 @@
 import logging
 
 import pytest
-from typing import Any
-from unittest.mock import MagicMock
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
 
 from dcs import Point
 from dcs.planes import AJS37
@@ -11,6 +11,7 @@ from dcs.terrain.terrain import Airport
 from game.ato.flighttype import FlightType
 from game.dcs.aircrafttype import AircraftType
 from game.dcs.countries import country_with_name
+from game.data.groups import GroupTask
 from game.point_with_heading import PointWithHeading
 from game.squadrons import Squadron
 from game.squadrons.operatingbases import OperatingBases
@@ -286,6 +287,42 @@ def _cp_with_motorpool_tgos(
         for tgo_name, pos in tgo_positions
     ]
     return cp
+
+
+def test_capture_rehomes_motorpools_immediately() -> None:
+    from game.missiongenerator.motorpoolpopulator import MotorpoolPopulator
+
+    cp = cast(Any, ControlPoint.__new__(Airfield))
+    old_coalition = MagicMock()
+    new_coalition = MagicMock()
+    cp._coalition = old_coalition
+    cp.connected_objectives = []
+    cp.front_lines = {}
+    cp.ground_unit_orders = MagicMock()
+    cp.base = MagicMock()
+    cp.retreat_ground_units = MagicMock()
+    cp.retreat_air_units = MagicMock()
+    cp.release_parking_slots = MagicMock()
+    cp.depopulate_uncapturable_tgos = MagicMock()
+    cp._clear_front_lines = MagicMock()
+    cp._create_missing_front_lines = MagicMock()
+    tgo = MotorpoolGroundObject(
+        "JAGUAR",
+        _preset("Garage A", Point(4000.0, 0.0, MagicMock(spec=Terrain))),
+        cp,
+        GroupTask.MOTORPOOL,
+    )
+    cp.connected_objectives.append(tgo)
+    game = MagicMock()
+    game.coalition_for.return_value = new_coalition
+    game.theater.controlpoints = [cp]
+    events = MagicMock()
+
+    with patch.object(MotorpoolPopulator, "_rehome_motorpools") as rehome:
+        cp.capture(game, events, Player.BLUE)
+
+    assert cp._coalition is new_coalition
+    rehome.assert_called_once_with()
 
 
 def test_motorpools_inside_capture_zone_reports_only_inside() -> None:


### PR DESCRIPTION
Splits out rehoming logic from #926. Fixes issues with motorpools not changing ownership during capture events as well as not being assigned to FARPs when they're closer than base control points. 