### PR TITLE
[FIX] An empty pylon no longer invalidates a whole payload

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[FIX]** A payload with an empty pylon was thrown away whole and the aircraft was planned carrying nothing at all: the Tornado IDS strike fit leaves four stations free, so a Tornado sent on a strike flew with no bombs.
 * **[Modding]** Added support for the CurrentHill Iran Military Assets pack: the Shahed-136 launcher, two IRGCN fast-attack craft, and a new `[CH] Iran 2020` faction, behind a New Game mods checkbox. (#886)
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.

--- a/game/ato/loadouts.py
+++ b/game/ato/loadouts.py
@@ -226,6 +226,12 @@ class Loadout:
     @staticmethod
     def valid_payload(pylons: Dict[int, Dict[str, str]]) -> bool:
         for p in pylons.values():
+            # An empty pylon is a pylon carrying nothing, not an unknown store.
+            # Treating it as invalid threw away whole payloads: the Tornado IDS
+            # "STRIKE" fit leaves stations 5-8 free, so the aircraft was planned
+            # with no loadout at all rather than with its GBU-16s.
+            if not p["CLSID"]:
+                continue
             if Weapon.with_clsid(p["CLSID"]) is None:
                 return False
         return True

--- a/tests/test_loadout_validation.py
+++ b/tests/test_loadout_validation.py
@@ -1,0 +1,18 @@
+from game.ato.loadouts import Loadout
+
+GBU_16 = "{0D33DDAE-524F-4A4E-B5B8-621754FE3ADE}"
+
+
+def test_empty_pylon_does_not_invalidate_a_payload() -> None:
+    """A pylon carrying nothing is not a pylon carrying something unknown.
+
+    The Tornado IDS "STRIKE" payload leaves stations 5-8 free, so rejecting it
+    left the aircraft planned with no loadout at all instead of its GBU-16s.
+    """
+    assert Loadout.valid_payload({1: {"CLSID": GBU_16}, 5: {"CLSID": ""}})
+
+
+def test_unknown_store_still_invalidates_a_payload() -> None:
+    assert not Loadout.valid_payload(
+        {1: {"CLSID": GBU_16}, 5: {"CLSID": "{NOT-A-REAL-WEAPON}"}}
+    )


### PR DESCRIPTION
`Loadout.valid_payload` asks `Weapon.with_clsid` about every pylon and rejects the payload if any answer is `None`. An empty pylon has an empty CLSID, so a perfectly good fit is discarded — and because the fallback is `Loadout.empty_loadout()` rather than another payload, the aircraft is planned **carrying nothing at all**.

The Tornado IDS `STRIKE` payload leaves stations 5-8 free:

```
pilon 4: {0D33DDAE-...}   GBU-16
pilon 5: ''               <- empty
pilon 6: ''
pilon 7: ''
pilon 8: ''
pilon 9: {0D33DDAE-...}   GBU-16
```

so a Tornado IDS sent on a Strike takes off with no GBU-16s and nothing else. Nothing surfaces this to the player: the log says `Incompatible loadout for ... skipped` and planning carries on.

Found by sweeping every aircraft/task pair in two factions for a default loadout of `Empty`.