### PR TITLE
[FIX] Give each flight its own orbit stop flag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Retribution v1.6.0
 
 ## Features/Improvements
+* **[FIX]** Every orbit in a package ended at the same time, whichever flight's time was generated first, so an AWACS or a tanker packaged with a shorter-lived BARCAP left station early — up to two hours in one case.
 * **[Modding]** Added support for the CurrentHill Iran Military Assets pack: the Shahed-136 launcher, two IRGCN fast-attack craft, and a new `[CH] Iran 2020` faction, behind a New Game mods checkbox. (#886)
 * **[Kneeboard]** Use a light-grey daytime kneeboard background instead of near-white, to avoid glare under HDR / Auto-HDR while staying readable in daylight.
 * **[UX]** Hovering a friendly flight's route line on the map highlights it in yellow, and clicking it selects that flight's package (and the flight) in the ATO sidebar.

--- a/game/missiongenerator/aircraft/waypoints/_helper.py
+++ b/game/missiongenerator/aircraft/waypoints/_helper.py
@@ -1,25 +1,37 @@
 from dcs import Mission
-from dcs.action import SetFlag
+from dcs.action import DoScript
 from dcs.condition import TimeAfter
 from dcs.task import ControlledTask
+from dcs.translation import String
 from dcs.triggers import TriggerOnce, Event
-
-from game.ato import Package
 
 
 def create_stop_orbit_trigger(
-    orbit: ControlledTask, package: Package, mission: Mission, elapsed: int
+    orbit: ControlledTask, group_id: int, mission: Mission, elapsed: int
 ) -> None:
-    orbit.stop_if_user_flag(id(package), True)
-    orbits = [
-        x
-        for x in mission.triggerrules.triggers
-        if x.comment == f"StopOrbit{id(package)}"
-    ]
-    if not any(orbits):
-        stop_trigger = TriggerOnce(Event.NoEvent, f"StopOrbit{id(package)}")
-        stop_condition = TimeAfter(elapsed)
-        stop_action = SetFlag(id(package))
-        stop_trigger.add_condition(stop_condition)
-        stop_trigger.add_action(stop_action)
-        mission.triggerrules.triggers.append(stop_trigger)
+    """End an orbit at `elapsed`, working around the broken "stop after time".
+
+    Keyed by the group rather than by its package. Every flight has its own
+    patrol or push time, but a flag can only fire once, so a package-wide flag
+    ended every orbit in the package at whichever time the first flight to be
+    generated happened to need: an AWACS packaged with a shorter-lived BARCAP
+    was pulled off station two hours early, and a tanker half an hour early.
+
+    The flag is named after the group id rather than a Python ``id()``, which is
+    an object address: it changes between two generations of the same turn, and
+    is reused once the object it belonged to has been collected.
+    """
+    flag = f"stop-orbit-{group_id}"
+    orbit.stop_if_user_flag(flag, True)
+    comment = f"StopOrbit{group_id}"
+    if any(t.comment == comment for t in mission.triggerrules.triggers):
+        return
+    stop_trigger = TriggerOnce(Event.NoEvent, comment)
+    stop_trigger.add_condition(TimeAfter(elapsed))
+    # setUserFlag rather than SetFlag: the stop condition names the flag as a
+    # string, and a string flag cannot collide with the numbered ones the
+    # trigger generator hands out for capture zones.
+    stop_trigger.add_action(
+        DoScript(String(f'trigger.action.setUserFlag("{flag}", true)'))
+    )
+    mission.triggerrules.triggers.append(stop_trigger)

--- a/game/missiongenerator/aircraft/waypoints/holdpoint.py
+++ b/game/missiongenerator/aircraft/waypoints/holdpoint.py
@@ -34,7 +34,7 @@ class HoldPointBuilder(PydcsWaypointBuilder):
         elapsed = int((push_time - self.now).total_seconds()) - 60
         loiter.stop_after_time(elapsed)
         # What follows is some code to cope with the broken 'stop after time' condition
-        create_stop_orbit_trigger(loiter, self.package, self.mission, elapsed)
+        create_stop_orbit_trigger(loiter, self.group.id, self.mission, elapsed)
         # end of hotfix
         waypoint.add_task(loiter)
         if self.flight.is_helo:

--- a/game/missiongenerator/aircraft/waypoints/racetrack.py
+++ b/game/missiongenerator/aircraft/waypoints/racetrack.py
@@ -82,7 +82,7 @@ class RaceTrackBuilder(PydcsWaypointBuilder):
         elapsed = int((flight_plan.patrol_end_time - self.now).total_seconds())
         racetrack.stop_after_time(elapsed)
         # What follows is some code to cope with the broken 'stop after time' condition
-        create_stop_orbit_trigger(racetrack, self.package, self.mission, elapsed)
+        create_stop_orbit_trigger(racetrack, self.group.id, self.mission, elapsed)
         # end of hotfix
         waypoint.add_task(racetrack)
 

--- a/tests/test_stop_orbit_trigger.py
+++ b/tests/test_stop_orbit_trigger.py
@@ -1,0 +1,47 @@
+from dcs import Mission
+from dcs.task import ControlledTask, OrbitAction
+
+from game.missiongenerator.aircraft.waypoints._helper import create_stop_orbit_trigger
+
+
+def _orbit() -> ControlledTask:
+    return ControlledTask(OrbitAction(pattern=OrbitAction.OrbitPattern.RaceTrack))
+
+
+def _flag_of(orbit: ControlledTask) -> str:
+    return str(orbit.params["stopCondition"]["userFlag"])
+
+
+def test_each_group_gets_its_own_stop_flag_and_trigger() -> None:
+    """Two flights of one package have their own patrol times.
+
+    Keying the flag by package meant one flag for both, and a flag fires once:
+    every orbit in the package ended at whichever time was generated first, so
+    an AWACS packaged with a shorter BARCAP left station hours early.
+    """
+    mission = Mission()
+    awacs, barcap = _orbit(), _orbit()
+    create_stop_orbit_trigger(awacs, 21, mission, 15780)
+    create_stop_orbit_trigger(barcap, 20, mission, 8520)
+
+    assert _flag_of(awacs) != _flag_of(barcap)
+    assert len(mission.triggerrules.triggers) == 2
+
+
+def test_the_same_group_is_only_given_one_trigger() -> None:
+    mission = Mission()
+    create_stop_orbit_trigger(_orbit(), 20, mission, 8520)
+    create_stop_orbit_trigger(_orbit(), 20, mission, 8520)
+    assert len(mission.triggerrules.triggers) == 1
+
+
+def test_the_flag_is_stable_across_generations() -> None:
+    """The flag was named after a Python id(), which is an object address.
+
+    Two generations of the same turn produced different flag names, and an
+    address is reused once its object has been collected.
+    """
+    first, second = _orbit(), _orbit()
+    create_stop_orbit_trigger(first, 20, Mission(), 8520)
+    create_stop_orbit_trigger(second, 20, Mission(), 8520)
+    assert _flag_of(first) == _flag_of(second)


### PR DESCRIPTION
`create_stop_orbit_trigger` names the flag that ends a racetrack or a hold after `id(package)`, so every flight in a package shares one. A flag fires once, and the trigger is created by whichever flight is generated first, so all the others inherit a time that is not theirs.

From one generated mission — this package's flag fires at t=8520:

```
flag 1918073730384        trigger fires at 8520
    Su-27 BARCAP          own patrol end  8520    correct, it created the trigger
    A-50 AEW&C            own patrol end 15780    off station 121 min early
    IL-78M tanker         own patrol end 10320    off station  30 min early
```

Escorts in a strike package have the mirror image and orbit past their own push time:

```
flag 1918020995344        trigger fires at 1404
    HADDOCK Escort        own time    21
    HADDOCK BAI           own time  1404
```

Losing the AWACS two hours into a three-hour mission is not subtle, and nothing reports it.

Keyed by group id instead, one trigger and one flag per flight. That also drops the `id()` calls: an object address changes between two generations of the same turn, so the same turn regenerated produces different flag numbers, and an address is reused once its object has been collected. The flag becomes a named string set with `setUserFlag` — the same mechanism the `split-` flags already use — so it cannot collide with the numbered flags `TriggerGenerator` hands out for capture zones from 600 up.

Three tests added.